### PR TITLE
chore: Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: CI
+
+on:
+  push:
+    branches: [ mainline ]
+  pull_request:
+    branches: [ mainline ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container:
+      image: jsii/superchain
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn global add typescript
+    - run: yarn install --frozen-lockfile
+    - run: ./build.sh
+    - run: ./pack.sh


### PR DESCRIPTION
### Notes
- Added a CI workflow that runs under ubuntu-latest w/ the jsii/superchain docker container
- **Note**: See my fork of `aws-rfdk` for what the resulting CI looks like:
    - [`mainline`](https://github.com/jericht/aws-rfdk)
    - [On a PR](https://github.com/jericht/aws-rfdk/pull/1)

### Testing
- Pushed to `mainline` and ensured the CI ran all the required steps successfully

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
