### PR TITLE
fix(integ): update existing repository tests to use docker recipes

### DIFF
--- a/integ/README.md
+++ b/integ/README.md
@@ -7,11 +7,11 @@ To run all test suites:
 2. Configure AWS credentials (tests will use the default AWS profile, so either set up a default profile in .aws/credentials or use temporary credentials).
 
 3. Configure test-config.sh. This script sets environment variables which are necessary for the tests. Currently this includes:
-  * DEADLINE_VERSION - version of the Deadline repository installer used for the test
-  * DEADLINE_REPOSITORY_INSTALLER_PATH - To use a local Deadline installer, set this variable to the local path to your file, relative to the `integ` directory. If this variable is set, it will supercede any S3 bucket provided by the following two variables.
-  * DEADLINE_INSTALLER_BUCKET - An S3 bucket containing the Deadline installer to use for the installation. This will be ignored if DEADLINE_REPOSITORY_INSTALLER_PATH is set.
-  * DEADLINE_INSTALLER_BUCKET_KEY - The key at which to find the installer to use in the bucket provided above. This will be ignored if DEADLINE_REPOSITORY_INSTALLER_PATH is set.
-  * USER_ACCEPTS_SSPL_FOR_RFDK_TESTS - should be set to true. Setting this variable is considered acceptance of the terms of the SSPL license. Follow [this link](https://www.mongodb.com/licensing/server-side-public-license) to read the terms of the SSPL license.  
+  * Options required for all Deadline test components:
+    * DEADLINE_VERSION - version of the Deadline repository installer used for the test
+    * DEADLINE_STAGING_PATH - Complete path to local staging folder for Deadline assets (see `packages/aws-rfdk/docs/DockerImageRecipes.md` for more information)
+  * Options required for the Deadline repository test component:
+    * USER_ACCEPTS_SSPL_FOR_RFDK_TESTS - should be set to true. Setting this variable is considered acceptance of the terms of the SSPL license. Follow [this link](https://www.mongodb.com/licensing/server-side-public-license) to read the terms of the SSPL license.  
 
 4. Execute `yarn run e2e` from the `integ` directory. This will handle deploying the necessary stacks, run the appropriate tests on them, and then tear them down.
 
@@ -20,17 +20,6 @@ To run all test suites:
 # Example Output:
 
 ```bash
-Starting RFDK-integ end-to-end tests
-Deploying RFDK-integ infrastructure...
-RFDK-integ infrastructure deployed.
-Running Deadline Repository end-to-end test...
-Deploying test app for Deadline Repository test suite
-Test app deployed. Running test suite...
-
-> integ@0.12.0 test /local/home/painec/workspace/rfdk/src/AWS-RFDK/integ
-> jest "/home/painec/workspace/rfdk/src/AWS-RFDK/integ/components/deadline/repository/test"
-
-(node:13341) ExperimentalWarning: The fs.promises API is experimental
 PASS components/deadline/repository/test/deadline-repository.test.ts (13.218 s)
   DocDB tests
     ✓ DL-1-1: Deadline DB is initialized (3 ms)
@@ -52,11 +41,4 @@ Test Suites: 1 passed, 1 total
 Tests:       12 passed, 12 total
 Snapshots:   0 total
 Time:        13.803 s, estimated 19 s
-Ran all test suites matching /\/home\/painec\/workspace\/rfdk\/src\/AWS-RFDK\/integ\/components\/deadline\/repository\/test/i.
-Test suite complete. Destroying test app...
-Test app destroyed.
-Deadline Repository tests complete.
-Test suites completed. Destroying infrastructure stack...
-Infrastructure stack destroyed.
-Complete!
 ```

--- a/integ/components/deadline/common/preflight.test.ts
+++ b/integ/components/deadline/common/preflight.test.ts
@@ -3,35 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const DEADLINE_REPOSITORY_INSTALLER_PATH = process.env.DEADLINE_REPOSITORY_INSTALLER_PATH?.toString();
-const DEADLINE_INSTALLER_BUCKET = process.env.DEADLINE_INSTALLER_BUCKET?.toString();
-const DEADLINE_INSTALLER_BUCKET_PROFILE = process.env.DEADLINE_INSTALLER_BUCKET_PROFILE?.toString();
 const DEADLINE_VERSION = process.env.DEADLINE_VERSION?.toString();
+const DEADLINE_STAGING_PATH = process.env.DEADLINE_STAGING_PATH?.toString();
 
 const runRepositoryTests = process.env.EXECUTE_DEADLINE_REPOSITORY_TEST_SUITE?.toString();
 
 if (runRepositoryTests === 'true') {
 
-  test('DEADLINE_REPOSITORY_INSTALLER_PATH is set if DEADLINE_INSTALLER_BUCKET is not set', () => {
-    if(!DEADLINE_INSTALLER_BUCKET){
-      expect(DEADLINE_REPOSITORY_INSTALLER_PATH).toBeTruthy();
-    }
-    else {
-      expect(DEADLINE_INSTALLER_BUCKET).toBeTruthy();
-    }
-  });
-
-  test('DEADLINE_REPOSITORY_INSTALLER_PATH is set if DEADLINE_INSTALLER_BUCKET_PROFILE is not set', () => {
-    if(!DEADLINE_INSTALLER_BUCKET_PROFILE){
-      expect(DEADLINE_REPOSITORY_INSTALLER_PATH).toBeTruthy();
-    }
-    else {
-      expect(DEADLINE_INSTALLER_BUCKET_PROFILE).toBeTruthy();
-    }
-  });
-
   test('DEADLINE_VERSION is set', () => {
     expect(DEADLINE_VERSION).toBeTruthy();
+  });
+
+  test('DEADLINE_STAGING_PATH is set', () => {
+    expect(DEADLINE_STAGING_PATH).toBeTruthy();
   });
 }
 else {

--- a/integ/components/deadline/repository/bin/deadline-repository.ts
+++ b/integ/components/deadline/repository/bin/deadline-repository.ts
@@ -15,28 +15,14 @@ const env = {
 
 const integStackTag = process.env.INTEG_STACK_TAG!.toString();
 
-const deadlineVersion = process.env.DEADLINE_VERSION!.toString();
-const deadlineRepositoryInstallerPath = process.env.DEADLINE_REPOSITORY_INSTALLER_PATH?.toString();
-const deadlineRepositoryInstallerBucketName = process.env.DEADLINE_REPOSITORY_INSTALLER_BUCKET_NAME?.toString();
-const deadlineRepositoryInstallerObjectKey = process.env.DEADLINE_REPOSITORY_INSTALLER_OBJECT_KEY?.toString();
-
-const deadlineRepositoryInstallationConfig = {
-  deadlineVersion,
-  deadlineRepositoryInstallerPath,
-  deadlineRepositoryInstallerBucketName,
-  deadlineRepositoryInstallerObjectKey,
-};
-
 const componentTier = new Stack(app, 'RFDKInteg-DL-ComponentTier' + integStackTag, {env});
 const storage1 = new StorageStruct(componentTier, 'StorageStruct1', {
   integStackTag,
   provideDocdbEfs: 'false',
-  deadlineRepositoryInstallationConfig,
 });
 const storage2 = new StorageStruct(componentTier, 'StorageStruct2', {
   integStackTag,
   provideDocdbEfs: 'true',
-  deadlineRepositoryInstallationConfig,
 });
 
 new TestingTier(app, 'RFDKInteg-DL-TestingTier' + integStackTag, { env, integStackTag, structs: [storage1, storage2] });

--- a/integ/scripts/bash/deploy-all.sh
+++ b/integ/scripts/bash/deploy-all.sh
@@ -17,10 +17,6 @@ if [ -z ${INTEG_STACK_TAG+x} ]; then
     export INTEG_STACK_TAG="$(date +%s%N)"
 fi
 
-if [ -n ${DEADLINE_REPOSITORY_INSTALLER_PATH+x} ]; then
-    export DEADLINE_REPOSITORY_INSTALLER_PATH="${root}/${DEADLINE_REPOSITORY_INSTALLER_PATH}"
-fi
-
 # Run preflight checks to make sure necessary variables, etc. are set
 jest --passWithNoTests --silent "preflight"
 

--- a/integ/scripts/bash/rfdk-integ-e2e.sh
+++ b/integ/scripts/bash/rfdk-integ-e2e.sh
@@ -23,10 +23,6 @@ if [ -z ${INTEG_STACK_TAG+x} ]; then
     export INTEG_STACK_TAG="$(date +%s%N)"
 fi
 
-if [ -n ${DEADLINE_REPOSITORY_INSTALLER_PATH+x} ]; then
-    export DEADLINE_REPOSITORY_INSTALLER_PATH="${root}/${DEADLINE_REPOSITORY_INSTALLER_PATH}"
-fi
-
 # Set location of output file
 mkdir -p "test-output"
 export OUTPUT_FILE="${root}/test-output/output-${INTEG_STACK_TAG}.txt"

--- a/integ/scripts/bash/tear-down.sh
+++ b/integ/scripts/bash/tear-down.sh
@@ -19,10 +19,6 @@ if [ -z ${INTEG_STACK_TAG+x} ]; then
     exit 1
 fi
 
-if [ -n ${DEADLINE_REPOSITORY_INSTALLER_PATH+x} ]; then
-    export DEADLINE_REPOSITORY_INSTALLER_PATH="${root}/${DEADLINE_REPOSITORY_INSTALLER_PATH}"
-fi
-
 for component in **/cdk.json; do
     component_root="$(dirname "$component")"
     # Use a pattern match to exclude the infrastructure app from the results

--- a/integ/test-config.sh
+++ b/integ/test-config.sh
@@ -5,11 +5,8 @@
 
 # Options for Deadline test suite
 export EXECUTE_DEADLINE_REPOSITORY_TEST_SUITE=true
+export DEADLINE_STAGING_PATH
 export DEADLINE_VERSION
-export DEADLINE_REPOSITORY_INSTALLER_PATH
-export DEADLINE_INSTALLER_BUCKET
-export DEADLINE_INSTALLER_BUCKET_KEY
 
 # Options for Deadline Repository test component
 export USER_ACCEPTS_SSPL_FOR_RFDK_TESTS=false
-


### PR DESCRIPTION
### Notes
Removes requirement to provide Deadline installer to repository tests, now relies on existing staging folder for Deadline assets to use the docker recipes
### Testing
Ran repository test suite without issue

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
