### PR TITLE
fix(deadline): fix UsageBasedLicensing stack updates

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -497,6 +497,12 @@ export class UsageBasedLicensing extends Construct implements IGrantable {
       taskDefinition,
       desiredCount: props.desiredCount,
       placementConstraints: [PlacementConstraint.distinctInstances()],
+      // This is required to right-size our host capacity and not have the ECS service block on updates. We set a memory
+      // reservation, but no memory limit on the container. This allows the container's memory usage to grow unbounded.
+      // We want 1:1 container to container instances to not over-spend, but this comes at the price of down-time during
+      // cloudformation updates.
+      minHealthyPercent: 0,
+      maxHealthyPercent: 100,
     });
 
     this.node.defaultChild = this.service;

--- a/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
@@ -110,6 +110,26 @@ beforeEach(() => {
   });
 });
 
+test('configures deployment configuration', () => {
+  // WHEN
+  new UsageBasedLicensing(stack, 'licenseForwarder', {
+    vpc,
+    images,
+    certificateSecret: certSecret,
+    memoryLimitMiB: 1024,
+    licenses: [UsageBasedLicense.forVray()],
+    renderQueue,
+  });
+
+  // THEN
+  expectCDK(stack).to(haveResourceLike('AWS::ECS::Service', {
+    DeploymentConfiguration: {
+      MaximumPercent: 100,
+      MinimumHealthyPercent: 0,
+    },
+  }));
+});
+
 test('default ECS stack for License Forwarder is created correctly', () => {
   // WHEN
   new UsageBasedLicensing(stack, 'licenseForwarder', {


### PR DESCRIPTION
## Problem

When a task definition was updated for the ECS service deployed by the `UsageBasedLicensing` construct, the update would fail because the cluster could not find a container instance with sufficient memory.

The intended design is that each EC2 container instance maps 1:1 with a Deadline License Forwarder container. We want the container to use all available memory on the host instance to not cause over-spend and under-utilize the deployed resources.

By default, an ECS service sets `minHealthyPercent` to 100% and `maxHealthyPercent` to 200% ([source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-deploymentconfiguration.html)). This is to ensure that there is no outage or decreased service throughput. For this to be feasible given we want the container to saturate the host instance, the ASG instance capacity must first be provisioned to 200% of the ECS service desired count.

This would require three consecutive deployments to successfully update the farm without over-spend:

1.  Increase ASG capacity to 200% and run a CDK deploy
1.  Update the CDK application to use the new ECS task definition (e.g. update Deadline version) and run a CDK deploy.
1.  Decrease the ASG capacity to 100% and run a CDK deploy.

## Solution

Use a `minHealthyPercent` of 0% and `maxHealthyPercent` of 100%. This reduces the update workflow to simply modifying the task definition and doing a deployment. It comes at the expense of a service outage during deployment.

## Testing

1.  Deployed a CDK application with the `UsageBasedLicensing` construct
1.  Modified the task definition by altering the docker recipe for the license forwarder with an additional `echo` command
1.  Re-deployed the CDK application and confirmed that the update succeeded and the new service output the echo command.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
