### PR TITLE
fix(core): fixes leaking private key password to logs in mongo setup

### DIFF
--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/serverCertFromSecrets.sh
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/serverCertFromSecrets.sh
@@ -40,12 +40,14 @@ get_secret_string "${CHAIN_ID}"
 printenv RET_VALUE > ./ca.crt
 get_secret_string "${KEY_ID}" 
 printenv RET_VALUE > ./encrypted_key.pem
+
+# Note: We must get the private key passphrase **LAST**. We use the returned
+# environment variable to securely invoke openssl to decrypt the private key.
 get_secret_string "${KEY_PW_ID}"
-export KEY_PW=$(printenv RET_VALUE)
 
 # Decrypt the private key.
-openssl rsa -in ./encrypted_key.pem -passin env:KEY_PW -out ./decrypted_key.pem
-unset KEY_PW
+openssl rsa -in ./encrypted_key.pem -passin env:RET_VALUE -out ./decrypted_key.pem
+unset RET_VALUE
 
 cat key.crt decrypted_key.pem > key.pem
 


### PR DESCRIPTION
This fixes a bug in the `serverCertFromSecrets.sh` script that is used by the MongoDbInstance construct to fetch the server's TLS certificates from secrets. The bug results in the passphrase for the private key being leaked to logs.
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
