### PR TITLE
fix(core): fixing security group for health monitor

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/load-balancer-manager.ts
+++ b/packages/aws-rfdk/lib/core/lib/load-balancer-manager.ts
@@ -332,6 +332,7 @@ class LoadBalancerManager {
       port: HealthMonitor.LOAD_BALANCER_LISTENING_PORT + this.listenerMap.size, // dummy port for load balancing
       protocol: ApplicationProtocol.HTTP,
       loadBalancer,
+      open: false,
     });
   }
 }

--- a/packages/aws-rfdk/lib/core/test/health-monitor.test.ts
+++ b/packages/aws-rfdk/lib/core/test/health-monitor.test.ts
@@ -4,8 +4,10 @@
  */
 
 import {
+  arrayWith,
   countResources,
   countResourcesLike,
+  deepObjectLike,
   expect as expectCDK,
   haveResource,
   haveResourceLike,
@@ -255,6 +257,14 @@ test('validating the target with default health config', () => {
 
   // THEN
   expectCDK(wfStack).to(haveResource('AWS::ElasticLoadBalancingV2::Listener'));
+  expectCDK(hmStack).notTo((haveResourceLike('AWS::EC2::SecurityGroup', {
+    SecurityGroupIngress: arrayWith(deepObjectLike({
+      CidrIp: '0.0.0.0/0',
+      FromPort: 8081,
+      IpProtocol: 'tcp',
+      ToPort: 8081,
+    })),
+  })));
   expectCDK(wfStack).to(haveResourceLike('AWS::ElasticLoadBalancingV2::TargetGroup', {
     HealthCheckIntervalSeconds: 300,
     HealthCheckPort: '8081',


### PR DESCRIPTION
The bug was creating an open ingress security group rule on the load
balancer traffic port. Fixing the code to not create this rule.

Verified by deploying health monitor that the open security group rule
is not being created anymore.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
