### PR TITLE
WIP: chore(core): Update default health check port in HealthMonitor

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -262,7 +262,7 @@ export class HealthMonitor extends HealthMonitorBase {
   /**
    * Default health check listening port
    */
-  public static readonly DEFAULT_HEALTH_CHECK_PORT: number = 63415;
+  public static readonly DEFAULT_HEALTH_CHECK_PORT: number = 17004;
 
   /**
    * Resource Tracker in Deadline currently publish health status every 5 min, hence keeping this same


### PR DESCRIPTION
### Notes
The default health check port in Deadline Launcher was changed in code review but the default health check port in RFDK was not changed as well.
- Changed from 63415 --> 17004

### Testing
1. Deployed a `WorkerInstanceFleet` with configured with a `HealthMonitor` using the new default port
    - AMI used was a 10.1.9.2 AWS Portal AMI (**TODO:** Insert AMI ID)
2. Ensured the worker instances have successful health checks with the new default port

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
