### PR TITLE
fix(core): enhance security of MongoDbInstance setup scripts

### DIFF
--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/serverCertFromSecrets.sh
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/serverCertFromSecrets.sh
@@ -54,7 +54,11 @@ cat key.crt decrypted_key.pem > key.pem
 # Validate the certificate and key are valid.
 echo "Validating server key"
 
+set +x # Do not print out key modulus; it's a secret
 KEY_MODULUS=$(openssl rsa -modulus -noout -in ./decrypted_key.pem | openssl md5)
 CA_MODULUS=$(openssl x509 -modulus -noout -in ./key.crt | openssl md5)
 
-test "${KEY_MODULUS}" == "${CA_MODULUS}"
+test "${KEY_MODULUS}" == "${CA_MODULUS}" || exit 1
+set -x
+
+echo "Success - valid key"

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setAdminCredentials.sh
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setAdminCredentials.sh
@@ -24,7 +24,7 @@ function cleanup() {
   exit ${RC}
 }
 
-trap cleanup EXIT
+trap cleanup EXIT ERR SIGQUIT SIGKILL SIGTERM SIGPIPE
 
 SCRIPT_DIR=$(dirname $0)
 source "${SCRIPT_DIR}/secretsFunction.sh"
@@ -39,3 +39,4 @@ cat temp.js | tr -d '\n' > ./adminCredentials.js
 rm -f ./temp.js
 
 mongo --port 27017 --host localhost ./createAdminUser.js --quiet
+rm -f ./adminCredentials.js


### PR DESCRIPTION
A few issues were discovered during a security audit of the MongoDbInstance's logs. This PR fixes both of these issues:

1. Leaking the modulus of an x.509 certificate and private key into the logs -- fixed by adding a `set +x` to suppress command echo.
2. Theoretical risk of MongoDB admin credentials living on the disk long enough to be intercepted by an attacker -- fixed by ensuring that the `adminCredentials.js` file that's created is actively deleted in more cases. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
