### PR TITLE
chore: Fixup doc display of resources deployed and residual risk

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/cloudwatch-agent.ts
+++ b/packages/aws-rfdk/lib/core/lib/cloudwatch-agent.ts
@@ -45,12 +45,17 @@ export interface CloudWatchAgentProps {
  * WARNING: Only use this if your deployments are failing due to a validation failure,
  * but you have verified that the failure is benign.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) String SSM Parameter in Systems Manager Parameter Store to store the cloudwatch agent configuration;
  * 2) A script Asset which is uploaded to S3 bucket.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - Grants read permission to the host instance/ASG/fleet on the assets bucket and parameter store.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class CloudWatchAgent extends Construct {
 

--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -58,17 +58,22 @@ export interface ExportingLogGroupProps {
  * Note, that it isn't economical to export logs to S3 if you plan on storing them for less than
  * 7 days total (CloudWatch and S3 combined).
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) The Lambda SingletonFunction that checks for the existence of the LogGroup;
  * 2) The CloudWatch LogGroup (if it didn't exist already);
  * 3) The CloudWatch Alarm watching log exportation failures;
  * 4) The CloudWatch Event Rule to schedule log exportation;
  * 5) The Lambda SingletonFunction, with role, to export log groups to S3 by schedule.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - The Lambda's Role grants the Lambda permission:
  *    1) To export the log group that this construct is exporting
  *       to ***any*** S3 bucket that your account has write-access to.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class ExportingLogGroup extends Construct {
   /**

--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -243,7 +243,8 @@ abstract class HealthMonitorBase extends Construct implements IHealthMonitor {
  * being sufficiently unhealthy to warrant termination.
  * This lambda is triggered by CloudWatch alarms via SNS (Simple Notification Service).
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) Application Load Balancer(s) doing frequent pings to the workers;
  * 2) KMS Key to encrypt SNS messages - If no encryption key is provided;
  * 3) SNS topic for all unhealthy fleet notifications;
@@ -251,11 +252,15 @@ abstract class HealthMonitorBase extends Construct implements IHealthMonitor {
  * 5) The Alarm if the healthy host percentage if lower than allowed;
  * 4) A single Lambda function that sets fleet size to 0 when triggered.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - CloudWatch has permissions to send encrypted messages
  * - CloudWatch has topic publishing permissions
  * - Lambda has permissions to change min, max and desired size
  *   of all ASGs in the account with the specified tag key and value
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class HealthMonitor extends HealthMonitorBase {
 

--- a/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
@@ -72,17 +72,22 @@ export interface ImportedAcmCertificateProps {
  * Function to extract the certificate from Secrets and then import it into ACM. It is intended to be used with the
  * X509CertificatePem Construct.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) DynamoDB Table - Used for tracking resources created by the CustomResource.
  * 2) Lambda Function, with Role - Used to create/update/delete the CustomResource.
  * 3) ACM Certificate - Created by the CustomResource.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - The Lambda role's policy gives it full access to the DynamoDB Table and access to get the X.509 certificate,
  *   private key, certificate chain, and passphrase Secrets that are taken as input.
  * - The Lambda also has permission to add tags to and import certificates to ACM that have the unique tag generated
  *   in this Construct. The permissions to delete and get certificates are open to all resources as ACM has not
  *   implemented policy conditions to restrict those operations to the unique tag.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class ImportedAcmCertificate extends Construct implements ICertificate {
   private static IMPORTER_UUID = '2d20d8f2-7b84-444e-b738-c75b499a9eaa';

--- a/packages/aws-rfdk/lib/core/lib/mongodb-installer.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-installer.ts
@@ -82,16 +82,21 @@ export interface MongoDbInstallerProps {
  * 2) The instance on which the installation is being performed is in a subnet that can access
  * the official MongoDB sites: https://repo.mongodb.org/ and https://www.mongodb.org
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * - A CDK Asset package containing the installation scripts is deployed to your CDK staging bucket.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - Since this class installs MongoDB from official sources dynamically during instance start-up, it is succeptable to an attacker compromising
  * the official MongoDB Inc. distribution channel for MongoDB. Such a compromise may result in the installation of unauthorized MongoDB binaries.
  * Executing this attack would require an attacker compromise both the official installation packages and the MongoDB Inc. gpg key with which they are
  * signed.
  * - This installer uses scripts that are deployed to your CDK staging bucket. An attacker that modifies those scripts can cause an instance that
  * uses this installer to perform any actions when it is first launched.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class MongoDbInstaller {
 

--- a/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
@@ -298,16 +298,21 @@ export interface IMongoDb extends IConnectable, IConstruct {
  * The instance's launch logs and MongoDB logs will be automatically stored in Amazon CloudWatch logs; the
  * default log group name is: /renderfarm/<this construct ID>
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * - {@link StaticPrivateIpServer} that hosts MongoDB.
  * - An A Record in the provided PrivateHostedZone to create a DNS entry for this server's static private IP.
  * - A Secret containing the administrator credentials for MongoDB.
  * - An encrypted EBS Volume on which the MongoDB data is stored.
  * - Amazon CloudWatch log group that contains instance-launch and MongoDB application logs.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - The administrator credentials for MongoDB are stored in a Secret within AWS SecretsManager; you must limit access to this secret.
  * - Any risk present in {@link StaticPrivateIpServer} and {@link MongoDbInstaller}.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class MongoDbInstance extends Construct implements IMongoDb, IGrantable {
   // How often Cloudwatch logs will be flushed.

--- a/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
@@ -139,15 +139,20 @@ export interface MongoDbPostInstallSetupProps {
  * 1. Password-authenticated users -- these users will be created within the 'admin' database.
  * 2. X.509-authenticated users -- these users will be created within the '$external' database.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * - An AWS Lambda that is used to connect to the MongoDB application, and perform post-installation tasks.
  * - A CloudFormation Custom Resource that triggers execution of the Lambda on stack deployment, update, and deletion.
  * - An Amazon CloudWatch log group that records history of the AWS Lambda's execution.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - The AWS Lambda function that is created by this resource has access to both the MongoDB administrator credentials,
  * and the MongoDB application port. An attacker that can find a way to execute this lambda could use it to modify or read
  * any data in the database.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class MongoDbPostInstallSetup extends Construct {
   constructor(scope: Construct, id: string, props: MongoDbPostInstallSetupProps) {

--- a/packages/aws-rfdk/lib/core/lib/script-assets.ts
+++ b/packages/aws-rfdk/lib/core/lib/script-assets.ts
@@ -123,12 +123,17 @@ export interface ScriptAssetProps extends AssetProps {}
  *
  * The script asset is placed into and fetched from the CDK bootstrap S3 bucket.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) An Asset which is uploaded to the bootstrap S3 bucket.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - Every principal that has permissions to read this script asset,
  *   also has permissions to read ***everything*** in the bootstrap bucket.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class ScriptAsset extends Asset {
   /**

--- a/packages/aws-rfdk/lib/core/lib/staticip-server.ts
+++ b/packages/aws-rfdk/lib/core/lib/staticip-server.ts
@@ -157,7 +157,8 @@ export interface StaticPrivateIpServerProps {
  * automatically recover from termination. This instance is suitable for use as an application server,
  * such as a license server, that must always be reachable by the same IP address.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) Auto Scaling Group (ASG) with min & max capacity of 1 instance;
  * 2) Elastic Network Interface (ENI);
  * 3) Security Group for the ASG;
@@ -165,12 +166,16 @@ export interface StaticPrivateIpServerProps {
  * 5) SNS Topic & Role for instance-launch lifecycle events -- max one of each per stack; and
  * 6) Lambda function, with role, to attach the ENI in response to instace-launch lifecycle events -- max one per stack.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - The Lambda's Role grants the Lambda permission:
  *    1) The ability to attach **any** Elastic Network Interface to **any** instance.
  *    2) To invoke autoscaling:CompleteLifecycleAction on **any** Auto Scaling Group that is tagged with the
  *       key 'RfdkStaticPrivateIpServerGrantConditionKey' and a unique value derived from this construct's
  *       scope.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class StaticPrivateIpServer extends Construct implements IConnectable, IGrantable {
 

--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -234,15 +234,20 @@ abstract class X509CertificateBase extends Construct {
  * The cost of four AWS SecretsManager Secrets in the deployed region.
  * The other resources created by this construct have negligible ongoing costs.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) DynamoDB Table - Used for tracking resources created by the Custom Resource.
  * 2) Secrets - 4 in total, for the certificate, it's private key, the passphrase to the key, and the cert chain.
  * 3) Lambda Function, with role - Used to create/update/delete the Custom Resource
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - The Lambda role's policy gives it full access to the DynamoDB Table and access to get the passphrase Secret.
  *   It also has permission to create/delete/put Secrets with a resource tag that is generated uniquely for each
  *   instance of this Construct.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class X509CertificatePem extends X509CertificateBase implements IX509CertificatePem {
   public readonly cert: ISecret;
@@ -379,15 +384,20 @@ export interface IX509CertificatePkcs12 extends IConstruct {
  * the result is stored in a Secret. The PKCS #12 file is password protected with a passphrase that is randomly
  * generated and stored in a Secret.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) DynamoDB Table - Used for tracking resources created by the CustomResource.
  * 2) Secrets - 2 in total, The binary of the PKCS #12 certificate and its passphrase.
  * 3) Lambda Function, with role - Used to create/update/delete the CustomResource.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - The Lambda role's policy gives it full access to the DynamoDB Table and access to get the passphrase secret.
  *   It also has permission to create/delete/put Secrets with a resource tag that is uniquely generated for each
  *   instance of this Construct.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class X509CertificatePkcs12 extends X509CertificateBase implements IX509CertificatePkcs12 {
 

--- a/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
@@ -83,15 +83,20 @@ export abstract class DatabaseConnection {
   /**
    * Creates a DatabaseConnection which allows Deadline to connect to Amazon DocumentDB.
    *
-   * @ResourcesDeployed
+   * Resources Deployed
+   * ------------------------
    * This construct does not deploy any resources
    *
-   * @ResidualRisk
+   * Residual Risk
+   * ------------------------
    * This construct is used to grant the following IAM permissions:
    * - Read permissions to the DocumentDB's Login Secret
    *
    * The following security group changes are made by this construct
    *  - TCP access to the DocumentDB Cluster over it's default port
+   *
+   * @ResourcesDeployed
+   * @ResidualRisk
    */
   public static forDocDB(options: DocDBConnectionOptions): DatabaseConnection {
     return new DocDBDatabaseConnection(options);
@@ -100,16 +105,21 @@ export abstract class DatabaseConnection {
   /**
    * Creates a DatabaseConnection which allows Deadline to connect to MongoDB.
    *
-   * @ResourcesDeployed
+   * Resources Deployed
+   * ------------------------
    * This construct does not deploy any resources
    *
-   * @ResidualRisk
+   * Residual Risk
+   * ------------------------
    * This construct is used to grant the following IAM permissions:
    * - Read permissions to the MongoDB's Login Secret
    * - Read permissions to the client PKCS#12 certificate and its password.
    *
    * The following security group changes are made by this construct
    *  - TCP access to the MongoDB over it's default port
+   *
+   * @ResourcesDeployed
+   * @ResidualRisk
    */
   public static forMongoDbInstance(options: MongoDbInstanceConnectionOptions): DatabaseConnection {
     return new MongoDbInstanceDatabaseConnection(options);

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -123,19 +123,24 @@ abstract class RenderQueueBase extends Construct implements IRenderQueue {
  * Most Deadline clients will connect to a Deadline render farm via the the RenderQueue. The API provides Deadline
  * clients access to Deadline's database and repository file-system in a way that is secure, performant, and scalable.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) An ECS cluster
  * 2) An EC2 auto-scaling group that provides the EC2 container instances that host the ECS service
  * 3) An ECS service with a task definition that deploys the RCS container
  * 4) A CloudWatch bucket for streaming logs from the RCS container
  * 5) An application load balancer, listener and target group that balance incoming traffic among the RCS containers
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - Grants full read permission to the ASG to CDK's assets bucket.
  * - Care must be taken to secure what can connect to the RenderQueue. The RenderQueue does not authenticate API
  *   requests made against it. Users must take responsibility for limiting access to the RenderQueue endpoint to only
  *   trusted hosts. Those hosts should be governed carefully, as malicious software could use the API to
  *   remotely execute code across the entire render farm.
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class RenderQueue extends RenderQueueBase implements IGrantable {
   /**

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -270,7 +270,8 @@ export interface RepositoryProps {
  * and the deployment will continue, otherwise the the deployment will be cancelled.
  * In either case the instance will be cleaned up.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) Encrypted EFS File System - If no IFileSystem is provided;
  * 2) DocumentDB and DatabaseConnection - If no database connection is provided;
  * 3) Auto Scaling Group (ASG) with min & max capacity of 1 instance;
@@ -278,13 +279,17 @@ export interface RepositoryProps {
  * 5) A Script Asset which is uploaded to your deployment bucket to run the installer
  * 6) An aws-rfdk.CloudWatchAgent to configure sending logs to cloudwatch.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * The instance in the AutoScaling group is given a role with the following permissions:
  * - Read permissions to the bucket containing the S3 Assets
  *
  * The Following Security Group changes are made by this construct:
  * - TCP access to the DocumentDB Cluster over it's default port
  * - TCP access to the Provided File system over it's default port
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class Repository extends Construct implements IRepository {
   /**

--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -377,17 +377,22 @@ export interface UsageBasedLicensingProps {
  * Note: This construct does not currently implement the Deadline License Forwarder's Web Forwarding functionality.
  * This construct is not usable in any China region.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) The Auto Scaling Group (ASG) added to the Amazon ECS cluster that is hosting the Deadline License Forwarder for UBL.
  *    By default, creates one instance. The default instance type is C5 Large.
  * 2) Elastic Block Store device(s) associated with the EC2 instance(s) in the ASG. The default volume size is 30 GiB.
  * 3) The LogGroup if it doesn't exist already.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * - Any machine that has ingress network access to the License Forwarder is able to receive the licenses.
  *   Make sure the security group of the license forwarder is tightly restricted
  *   to allow only ingress from the machines that require it
  * - Docker container has permissions to read a secret with 3rd Party Licensing Certificates
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class UsageBasedLicensing extends Construct implements IGrantable {
   /**

--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -274,18 +274,23 @@ abstract class WorkerInstanceFleetBase extends Construct implements IWorkerFleet
  * When the worker fleet is deployed if it has been provided a HealthMonitor the Worker fleet will register itself against the Monitor
  * to ensure that the fleet remains healthy.
  *
- * @ResourcesDeployed
+ * Resources Deployed
+ * ------------------------
  * 1) An AutoScalingGroup to maintain the number of instances;
  * 2) An Instance Role and corresponding IAM Policy;
  * 3) A script asset which is uploaded to your deployment bucket used to configure the worker so it can connect to the Render Queue
  * 4) An aws-rfdk.CloudWatchAgent to configure sending logs to cloudwatch.
  *
- * @ResidualRisk
+ * Residual Risk
+ * ------------------------
  * The instance in the AutoScaling group is given a role with the following permissions:
  * - Read permissions to the bucket containing the S3 Assets
  *
  * The Following Security Group changes are made by this construct:
  * - TCP access to the Render Queue's Load Balancer
+ *
+ * @ResourcesDeployed
+ * @ResidualRisk
  */
 export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
 


### PR DESCRIPTION
Our API docs do not display custom tag sections. This implements an
interim fix to display these sections to buy some time to sort out how
to do this for real.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
