### PR TITLE
feature(deadline): exposing documentDB backup retention period

### DIFF
--- a/examples/kitchen-sink/lib/index.ts
+++ b/examples/kitchen-sink/lib/index.ts
@@ -138,7 +138,10 @@ export class KitchenSinkApp extends App {
         vpcSubnets: {
           onePerAz: true,
           subnetType: SubnetType.PRIVATE
-        }
+        },
+      },
+      backup: {
+        retention: Duration.days(15),
       },
       /**
        * Default is to retain the DocDB cluster when deleting the stack. Since this is an example app, we will mark

--- a/integ/lib/storage-struct.ts
+++ b/integ/lib/storage-struct.ts
@@ -53,6 +53,9 @@ export class StorageStruct extends Construct {
         masterUser: {
           username: 'DocDBUser',
         },
+        backup: {
+          retention: Duration.days(15),
+        },
         removalPolicy: RemovalPolicy.DESTROY,
       });
       deadlineDatabaseConnection = DatabaseConnection.forDocDB({

--- a/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
@@ -32,6 +32,7 @@ import {
   PrivateHostedZone,
 } from '@aws-cdk/aws-route53';
 import {
+  Duration,
   Stack,
 } from '@aws-cdk/core';
 
@@ -72,6 +73,9 @@ describe('DocumentDB', () => {
           onePerAz: true,
           subnetType: SubnetType.PRIVATE,
         },
+      },
+      backup: {
+        retention: Duration.days(15),
       },
     });
 


### PR DESCRIPTION
A few issues were discovered during a security audit related to DocumentDB.
This PR fixes the short backup retention period by exposing the ` readonly databaseRetentionPeriod?: Duration` property on `Repository` construct.

### Notes
DocumentDB supports automatic backups which should be enabled in the event that something happens to the main database.
Backup retention periods should be set as long as possible for the event that they are needed.  Currently, the retention time for documentDB clusters is 1 day. It is recommended to have a retention period of 15 days.

I also updated all the usages in RFDK codebase, to bring more attention to the new exposed property.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
