### PR TITLE
feature(deadline): Enable logging for DocDB

### DIFF
--- a/examples/kitchen-sink/lib/index.ts
+++ b/examples/kitchen-sink/lib/index.ts
@@ -5,6 +5,8 @@
 
 import {
   DatabaseCluster,
+  ClusterParameterGroup,
+  CfnDBCluster,
 } from '@aws-cdk/aws-docdb';
 import {
   AmazonLinuxImage,
@@ -121,6 +123,23 @@ export class KitchenSinkApp extends App {
       filesystem: fileSystem,
     });
 
+    /**
+     * This option is part of enabling audit logging for DocumentDB; the other required part is the enabling of the CloudWatch exports below.
+     *
+     * Audit logs are a security best-practice. They record connection, data definition language (DDL), user management,
+     * and authorization events within the database, and are useful for post-incident auditing. That is, they can help you
+     * figure out what an unauthorized user, who gained access to your database, has done with that access.
+     *
+     * For more information about audit logging in DocumentDB, see:  https://docs.aws.amazon.com/documentdb/latest/developerguide/event-auditing.html
+     */
+    const parameterGroup = new ClusterParameterGroup(infrastructureStack, 'ParameterGroup', {
+      description: 'DocDB cluster parameter group with enabled audit logs',
+      family: 'docdb3.6',
+      parameters: {
+        audit_logs: 'enabled',
+      },
+    });
+
     /*
      * DocumentDB database cluster for storing the render farm database.
      */
@@ -134,6 +153,7 @@ export class KitchenSinkApp extends App {
           InstanceClass.R4,
           InstanceSize.LARGE
         ),
+        parameterGroup,
         vpc,
         vpcSubnets: {
           onePerAz: true,
@@ -147,6 +167,13 @@ export class KitchenSinkApp extends App {
        */
       removalPolicy: RemovalPolicy.DESTROY
     });
+
+    /**
+     * This option enable export audit logs to Amazon CloudWatch.
+     * This is second options that required for enable audit log.
+     */
+    const cfnDB = database.node.findChild('Resource') as CfnDBCluster;
+    cfnDB.enableCloudwatchLogsExports = ['audit'];
 
     /**
      * Bastion instance.

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -14,6 +14,8 @@ import {
 } from '@aws-cdk/aws-autoscaling';
 import {
   DatabaseCluster,
+  CfnDBCluster,
+  ClusterParameterGroup,
 } from '@aws-cdk/aws-docdb';
 import {
   AmazonLinuxGeneration,
@@ -255,6 +257,17 @@ export interface RepositoryProps {
    * @default RemovalPolicy.RETAIN
    */
   readonly databaseRemovalPolicy?: RemovalPolicy;
+
+  /**
+   * If this Repository is creating its own DocumentDB database, then this specifies if audit logging will be enabled
+   *
+   * Audit logs are a security best-practice. They record connection, data definition language (DDL), user management,
+   * and authorization events within the database, and are useful for post-incident auditing. That is, they can help you
+   * figure out what an unauthorized user, who gained access to your database, has done with that access.
+   *
+   * @default true
+   */
+  readonly databaseAuditLogging?: boolean;
 }
 
 /**
@@ -355,14 +368,39 @@ export class Repository extends Construct implements IRepository {
     if (props.database) {
       this.databaseConnection = props.database;
     } else {
+      const databaseAuditLogging = props.databaseAuditLogging ?? true;
+
+      /**
+       * This option is part of enabling audit logging for DocumentDB; the other required part is the enabling of the CloudWatch exports below.
+       *
+       * For more information about audit logging in DocumentDB, see:  https://docs.aws.amazon.com/documentdb/latest/developerguide/event-auditing.html
+       */
+      const parameterGroup = databaseAuditLogging ? new ClusterParameterGroup(this, 'ParameterGroup', {
+        description: 'DocDB cluster parameter group with enabled audit logs',
+        family: 'docdb3.6',
+        parameters: {
+          audit_logs: 'enabled',
+        },
+      }) : undefined;
+
       const dbCluster = new DatabaseCluster(this, 'DocumentDatabase', {
         masterUser: {username: 'DocDBUser'},
         instanceProps: {
           instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
           vpc: props.vpc,
         },
+        parameterGroup: parameterGroup,
         removalPolicy: props.databaseRemovalPolicy ?? RemovalPolicy.RETAIN,
       });
+
+      if (databaseAuditLogging) {
+        /**
+         * This option enable export audit logs to Amazon CloudWatch.
+         * This is second options that required for enable audit log.
+         */
+        const cfnDB = dbCluster.node.findChild('Resource') as CfnDBCluster;
+        cfnDB.enableCloudwatchLogsExports = ['audit'];
+      }
       /* istanbul ignore next */
       if (!dbCluster.secret) {
         /* istanbul ignore next */


### PR DESCRIPTION
This fix DocDB part of the issue discovered during the security audit

Was added class that can be used if customer want to switch audit log.

Description of how audit log can be enabled is [here](https://docs.aws.amazon.com/documentdb/latest/developerguide/event-auditing.html)

In repository constructor was added `databaseAuditLogging` parameter and according to value of this parameter enable audit logging for DocDB cluster.

Also was added example code in kitchen sink.

Was enabled parameter `audit_logs` and added `audit` to `enableCloudwatchLogsExports` construct option.

## Testing

Was deployed kitchen sink with this changes and checked that CloudWatch logs enabled 
![image](https://user-images.githubusercontent.com/68875428/89476503-7647e480-d750-11ea-9236-e466e20d2c1e.png)
 
Checking CloudWatch that audit log group was created and messages appeared.