### PR TITLE
fix: adding deletion protection for load balancer

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -175,7 +175,7 @@ export interface HealthMonitorProps {
 
   /**
    * Describes the current Elastic Load Balancing resource limits for your AWS account.
-   * This object should be the output of 'describeAccountLimits' API
+   * This object should be the output of 'describeAccountLimits' API.
    *
    * @default default account limits for ALB is used
    *
@@ -189,6 +189,17 @@ export interface HealthMonitorProps {
    * @default A new Key will be created and used.
    */
   readonly encryptionKey?: IKey;
+
+  /**
+   * Indicates whether deletion protection is enabled for the LoadBalancer.
+   *
+   * @default true
+   *
+   * Note: This value is true by default which means that the deletion protection is enabled for the
+   * load balancer. Hence, user needs to disable it using AWS Console or CLI before deleting the stack.
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection
+   */
+  readonly deletionProtection?: boolean;
 }
 
 /**
@@ -389,7 +400,7 @@ export class HealthMonitor extends HealthMonitorBase {
     const {loadBalancer, targetGroup} = this.lbFactory.registerWorkerFleet(
       monitorableFleet,
       healthCheckConfig,
-      this.props.elbAccountLimits);
+      this.props);
 
     this.createFleetAlarms(monitorableFleet, healthCheckConfig, loadBalancer, targetGroup);
   }

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -262,6 +262,17 @@ export interface RenderQueueProps {
    * @default - LogGroup will be created with all properties' default values and a prefix of "/renderfarm/".
    */
   readonly logGroupProps?: LogGroupFactoryProps;
+
+  /**
+   * Indicates whether deletion protection is enabled for the LoadBalancer.
+   *
+   * @default true
+   *
+   * Note: This value is true by default which means that the deletion protection is enabled for the
+   * load balancer. Hence, user needs to disable it using AWS Console or CLI before deleting the stack.
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection
+   */
+  readonly deletionProtection?: boolean;
 }
 
 /**

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -318,6 +318,12 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       loadBalancerFQDN = `${label}.${props.hostname.zone.zoneName}`;
     }
 
+    const loadBalancer = new ApplicationLoadBalancer(this, 'LB', {
+      vpc: this.cluster.vpc,
+      internetFacing: false,
+      deletionProtection: props.deletionProtection ?? true,
+    });
+
     this.pattern = new ApplicationLoadBalancedEc2Service(this, 'AlbEc2ServicePattern', {
       certificate: this.clientCert,
       cluster: this.cluster,
@@ -325,7 +331,7 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       domainZone: props.hostname?.zone,
       domainName: loadBalancerFQDN,
       listenerPort: externalPortNumber,
-      publicLoadBalancer: false,
+      loadBalancer,
       protocol: externalProtocol,
       taskDefinition,
       // This is required to right-size our host capacity and not have the ECS service block on updates. We set a memory

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -98,7 +98,7 @@ test('default worker fleet is created correctly', () => {
       ],
     },
     GroupId: {
-      'Fn::ImportValue': 'infraStack:ExportsOutputFnGetAttRQAlbEc2ServicePatternLBSecurityGroupCA2B91D3GroupId1AAC6AC8',
+      'Fn::ImportValue': 'infraStack:ExportsOutputFnGetAttRQLBSecurityGroupAC643AEDGroupId8F9F7830',
     },
   }));
   expectCDK(wfstack).to(haveResource('Custom::LogRetention', {
@@ -486,7 +486,7 @@ test('default worker fleet is created correctly custom subnet values', () => {
         '" --render-queue "http://',
         {
           'Fn::GetAtt': [
-            'RQAlbEc2ServicePatternLB29395F99',
+            'RQLB3B7B1CBC',
             'DNSName',
           ],
         },
@@ -886,7 +886,7 @@ test('default worker fleet is created correctly with groups, pools and region', 
       '" --render-queue "http://',
       {
         'Fn::GetAtt': [
-          'RQAlbEc2ServicePatternLB29395F99',
+          'RQLB3B7B1CBC',
           'DNSName',
         ],
       },


### PR DESCRIPTION
This commit enables customers to create the load-balancers created
in HealthMonitor and RenderQueue with delete protection.

* Updated the unit tests to validate the change.
* Deployed the kitchen-sink app and verified its functionality.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
