### PR TITLE
fix(deadline): Support multiple Block Devices

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import {
   AutoScalingGroup,
-  BlockDeviceVolume,
+  BlockDevice,
   CfnAutoScalingGroup,
   HealthCheck,
 } from '@aws-cdk/aws-autoscaling';
@@ -36,8 +36,6 @@ import {
   Construct,
   Duration,
   IResource,
-  Size,
-  SizeRoundingBehavior,
   Stack,
 } from '@aws-cdk/core';
 import {
@@ -197,11 +195,11 @@ export interface WorkerInstanceFleetProps {
   readonly spotPrice?: number;
 
   /*
-   * The block device volume size, in Gibibytes (GiB)
+   * The Block devices that will be attached to your workers.
    *
-   * @default 50 GiB
+   * @default The default devices of the provided ami will be used.
    */
-  readonly blockDeviceVolumeSize?: Size
+  readonly blockDevices?: BlockDevice[];
 }
 
 /**
@@ -397,10 +395,7 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
       }),
       role: props.role,
       spotPrice: props.spotPrice?.toString(),
-      blockDevices: [ {
-        deviceName: '/dev/xvda',
-        volume: BlockDeviceVolume.ebs( props.blockDeviceVolumeSize?.toGibibytes({ rounding: SizeRoundingBehavior.FAIL }) ?? 50, {encrypted: true}),
-      }],
+      blockDevices: props.blockDevices,
     });
 
     this.targetCapacity = parseInt((this.fleet.node.defaultChild as CfnAutoScalingGroup).maxSize, 10);
@@ -534,6 +529,7 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
     this.validateArrayGroupsPoolsSyntax(props.groups, /^(?!none$)[a-zA-Z0-9-_]+$/i, 'groups');
     this.validateArrayGroupsPoolsSyntax(props.pools, /^(?!none$)[a-zA-Z0-9-_]+$/i, 'pools');
     this.validateRegion(props.region, /^(?!none$|all$|unrecognized$)[a-zA-Z0-9-_]+$/i);
+    this.validateBlockDevices(props.blockDevices);
   }
 
   private validateSpotPrice(spotPrice: number | undefined) {
@@ -553,6 +549,27 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
       array.forEach(value => {
         if (!regex.test(value)) {
           throw new Error(`Invalid value: ${value} for property '${property}'. Valid characters are A-Z, a-z, 0-9, - and _. Also, group 'none' is reserved as the default group.`);
+        }
+      });
+    }
+  }
+
+  private validateBlockDevices(blockDevices: BlockDevice[] | undefined) {
+    if (blockDevices === undefined) {
+      this.node.addWarning(`The worker-fleet ${this.node.id} is being created without being provided any block devices so the Source AMI's devices will be used. ` +
+        'Workers can have access to sensitive data so it is recommended to either explicitly encrypt the devices on the worker fleet or to ensure the source AMI\'s Drives are encrypted.');
+    } else {
+      blockDevices.forEach(device => {
+        if (device.volume.ebsDevice === undefined) {
+          // Suppressed or Ephemeral Block Device
+          return;
+        }
+
+        // encrypted is not exposed as part of ebsDeviceProps so we need to confirm it exists then access it via [].
+        // eslint-disable-next-line dot-notation
+        if ( ('encrypted' in device.volume.ebsDevice === false) || ('encrypted' in device.volume.ebsDevice && !device.volume.ebsDevice['encrypted'] ) ) {
+          this.node.addWarning(`The BlockDevice "${device.deviceName}" on the worker-fleet ${this.node.id} is not encrypted. ` +
+              'Workers can have access to sensitive data so it is recommended to encrypt the devices on the worker fleet.');
         }
       });
     }

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -3,7 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ABSENT, expect as expectCDK, haveResource, haveResourceLike} from '@aws-cdk/assert';
+import {
+  ABSENT,
+  expect as expectCDK,
+  haveResource,
+  haveResourceLike,
+} from '@aws-cdk/assert';
+import {
+  BlockDeviceVolume,
+} from '@aws-cdk/aws-autoscaling';
 import {
   GenericLinuxImage,
   GenericWindowsImage,
@@ -20,7 +28,14 @@ import {
   ContainerImage,
 } from '@aws-cdk/aws-ecs';
 import {ArtifactMetadataEntryType} from '@aws-cdk/cloud-assembly-schema';
-import {App, CfnElement, Size, Stack} from '@aws-cdk/core';
+import {
+  App,
+  CfnElement,
+  Stack,
+} from '@aws-cdk/core';
+import {
+  HealthMonitor,
+} from '../../core/lib';
 import {
   IRenderQueue,
   RenderQueue,
@@ -106,7 +121,9 @@ test('default worker fleet is created correctly', () => {
     LogGroupName: '/renderfarm/workerFleet',
   }));
   expect(fleet.node.metadata[0].type).toMatch(ArtifactMetadataEntryType.WARN);
-  expect(fleet.node.metadata[0].data).toContain('being created without a health monitor attached to it. This means that the fleet will not automatically scale-in to 0 if the workers are unhealthy');
+  expect(fleet.node.metadata[0].data).toMatch('being created without being provided any block devices so the Source AMI\'s devices will be used. Workers can have access to sensitive data so it is recommended to either explicitly encrypt the devices on the worker fleet or to ensure the source AMI\'s Drives are encrypted.');
+  expect(fleet.node.metadata[1].type).toMatch(ArtifactMetadataEntryType.WARN);
+  expect(fleet.node.metadata[1].data).toContain('being created without a health monitor attached to it. This means that the fleet will not automatically scale-in to 0 if the workers are unhealthy');
 });
 
 test('security group is added to fleet after its creation', () => {
@@ -1165,49 +1182,184 @@ test('worker fleet does validation correctly with groups, pools and region', () 
     });
   }).toThrowError(/Invalid value: None for property 'region'/);
 });
+describe('Block Device Tests', () => {
+  let healthMonitor: HealthMonitor;
 
-test('worker fleet is created correctly with the specified encrypted EBS block device size', () => {
-  vpc = new Vpc(stack, 'VPC1Az', {
-    maxAzs: 1,
-  });
-
-  // WHEN
-  const gibibytes = 123;
-  new WorkerInstanceFleet(stack, 'workerFleet', {
-    vpc,
-    workerMachineImage: new GenericLinuxImage({
-      'us-east-1': '123',
-    }),
-    renderQueue,
-    blockDeviceVolumeSize: Size.gibibytes(gibibytes),
-  });
-
-  // THEN
-  expectCDK(stack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
-    BlockDeviceMappings: [
-      {
-        Ebs: {
-          Encrypted: true,
-          VolumeSize: gibibytes,
-        },
-      },
-    ],
-  }));
-});
-
-test('worker fleet creation fails when the specified EBS block device size must be rounded', () => {
-  vpc = new Vpc(stack, 'VPC1Az', {
-    maxAzs: 1,
-  });
-
-  expect(() => {
-    new WorkerInstanceFleet(stack, 'workerFleet', {
+  beforeEach(() => {
+    // create a health monitor so it does not trigger warnings
+    healthMonitor = new HealthMonitor(wfstack,'healthMonitor', {
       vpc,
-      workerMachineImage: new GenericLinuxImage({
-        'us-east-1': '123',
+    });
+  });
+
+  test('Warning if no BlockDevices provided', () => {
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericWindowsImage({
+        'us-east-1': 'ami-any',
       }),
       renderQueue,
-      blockDeviceVolumeSize: Size.kibibytes(1),
+      healthMonitor,
     });
-  }).toThrowError(/'[0-9]+ .*bytes' cannot be converted into a whole number of gibibytes./);
+    expect(fleet.node.metadata[0].type).toMatch(ArtifactMetadataEntryType.WARN);
+    expect(fleet.node.metadata[0].data).toMatch('being created without being provided any block devices so the Source AMI\'s devices will be used. Workers can have access to sensitive data so it is recommended to either explicitly encrypt the devices on the worker fleet or to ensure the source AMI\'s Drives are encrypted.');
+  });
+
+  test('No Warnings if Encrypted BlockDevices Provided', () => {
+    const VOLUME_SIZE = 50;
+
+    // WHEN
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericWindowsImage({
+        'us-east-1': 'ami-any',
+      }),
+      renderQueue,
+      healthMonitor,
+      blockDevices: [ {
+        deviceName: '/dev/xvda',
+        volume: BlockDeviceVolume.ebs( VOLUME_SIZE, {encrypted: true}),
+      }],
+    });
+
+    //THEN
+    expectCDK(wfstack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+      BlockDeviceMappings: [
+        {
+          Ebs: {
+            Encrypted: true,
+            VolumeSize: VOLUME_SIZE,
+          },
+        },
+      ],
+    }));
+
+    expect(fleet.node.metadata).toHaveLength(0);
+  });
+
+  test('Warnings if non-Encrypted BlockDevices Provided', () => {
+    const VOLUME_SIZE = 50;
+    const DEVICE_NAME = '/dev/xvda';
+
+    // WHEN
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericWindowsImage({
+        'us-east-1': 'ami-any',
+      }),
+      renderQueue,
+      healthMonitor,
+      blockDevices: [ {
+        deviceName: DEVICE_NAME,
+        volume: BlockDeviceVolume.ebs( VOLUME_SIZE, {encrypted: false}),
+      }],
+    });
+
+    //THEN
+    expectCDK(wfstack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+      BlockDeviceMappings: [
+        {
+          Ebs: {
+            Encrypted: false,
+            VolumeSize: VOLUME_SIZE,
+          },
+        },
+      ],
+    }));
+
+    expect(fleet.node.metadata[0].type).toMatch(ArtifactMetadataEntryType.WARN);
+    expect(fleet.node.metadata[0].data).toMatch(`The BlockDevice \"${DEVICE_NAME}\" on the worker-fleet workerFleet is not encrypted. Workers can have access to sensitive data so it is recommended to encrypt the devices on the worker fleet.`);
+  });
+
+  test('Warnings for BlockDevices without encryption specified', () => {
+    const VOLUME_SIZE = 50;
+    const DEVICE_NAME = '/dev/xvda';
+
+    // WHEN
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericWindowsImage({
+        'us-east-1': 'ami-any',
+      }),
+      renderQueue,
+      healthMonitor,
+      blockDevices: [ {
+        deviceName: DEVICE_NAME,
+        volume: BlockDeviceVolume.ebs( VOLUME_SIZE ),
+      }],
+    });
+
+    //THEN
+    expectCDK(wfstack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+      BlockDeviceMappings: [
+        {
+          Ebs: {
+            VolumeSize: VOLUME_SIZE,
+          },
+        },
+      ],
+    }));
+
+    expect(fleet.node.metadata[0].type).toMatch(ArtifactMetadataEntryType.WARN);
+    expect(fleet.node.metadata[0].data).toMatch(`The BlockDevice \"${DEVICE_NAME}\" on the worker-fleet workerFleet is not encrypted. Workers can have access to sensitive data so it is recommended to encrypt the devices on the worker fleet.`);
+  });
+
+  test('No warnings for Ephemeral blockDeviceVolumes', () => {
+    const DEVICE_NAME = '/dev/xvda';
+
+    // WHEN
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericWindowsImage({
+        'us-east-1': 'ami-any',
+      }),
+      renderQueue,
+      healthMonitor,
+      blockDevices: [ {
+        deviceName: DEVICE_NAME,
+        volume: BlockDeviceVolume.ephemeral( 0 ),
+      }],
+    });
+
+    //THEN
+    expectCDK(wfstack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+      BlockDeviceMappings: [
+        {
+          DeviceName: DEVICE_NAME,
+          VirtualName: 'ephemeral0',
+        },
+      ],
+    }));
+
+    expect(fleet.node.metadata).toHaveLength(0);
+  });
+
+  test('No warnings for Suppressed blockDeviceVolumes', () => {
+    const DEVICE_NAME = '/dev/xvda';
+
+    // WHEN
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericWindowsImage({
+        'us-east-1': 'ami-any',
+      }),
+      renderQueue,
+      healthMonitor,
+      blockDevices: [ {
+        deviceName: DEVICE_NAME,
+        volume: BlockDeviceVolume.noDevice(  ),
+      }],
+    });
+
+    //THEN
+    expectCDK(wfstack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+      BlockDeviceMappings: [
+        {
+          DeviceName: DEVICE_NAME,
+        },
+      ],
+    }));
+
+    expect(fleet.node.metadata).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Changed WorkerFleet to accept a list of BlockDevices instead of taking a Size
value.

Breaking Changes: Removed blockDeviceVolumeSize. Default volume is no longer
encrypted by default.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
