### PR TITLE
feat(deadline): RenderQueue support ELB access logs

### DIFF
--- a/examples/kitchen-sink/lib/index.ts
+++ b/examples/kitchen-sink/lib/index.ts
@@ -214,6 +214,8 @@ export class KitchenSinkApp extends App {
       signingCertificate: caCert,
     });
 
+    const rqLogBucket = new Bucket(rqStack, 'RQAccessBucket');
+
     /**
      * Create a render queue. This is the service that backs the REST API for clients connecting to the render farm.
      */
@@ -231,7 +233,10 @@ export class KitchenSinkApp extends App {
           rfdkCertificate: rqCertPem,
         },
         internalProtocol: ApplicationProtocol.HTTP,
-      }
+      },
+      accessLogs: {
+        destinationBucket: rqLogBucket,
+      },
     });
 
     // Add the AWS Managed SSM role to the ASG container instances.

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -24,6 +24,9 @@ import {
   IPrivateHostedZone,
 } from '@aws-cdk/aws-route53';
 import {
+  IBucket,
+} from '@aws-cdk/aws-s3';
+import {
   ISecret,
 } from '@aws-cdk/aws-secretsmanager';
 import { Duration } from '@aws-cdk/core';
@@ -189,6 +192,26 @@ export interface RenderQueueImages {
 }
 
 /**
+ * Properties for enabling access logs for the Render Queue's load balancer. See
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+ * for more information on what gets logged and how to access them.
+ */
+export interface RenderQueueAccessLogProps {
+  /**
+   * The S3 Bucket that the access logs should be stored in. It is recommended to set a lifecycle rule on
+   * this Bucket to avoid having it grow indefinitely. Costs will be incurred for
+   * requests made to put logs in the Bucket as well as storage.
+   */
+  readonly destinationBucket: IBucket;
+  /**
+   * The prefix to be used for the access logs when they are stored in S3.
+   *
+   * @default None
+   */
+  readonly prefix?: string;
+}
+
+/**
  * Properties for the Render Queue
  */
 export interface RenderQueueProps {
@@ -256,6 +279,15 @@ export interface RenderQueueProps {
    * @default The values outlined in {@link RenderQueueHealthCheckConfiguration}
    */
   readonly healthCheckConfig?: RenderQueueHealthCheckConfiguration;
+
+  /**
+   * Properties for configuring access logging for the load balancer used by the Render
+   * Queue. This is disabled by default, but it is highly recommended to enable it to
+   * allow engineers to identify and root cause incidents such as unauthorized access.
+   *
+   * @default - Access logging is disabled
+   */
+  readonly accessLogs?: RenderQueueAccessLogProps;
 
   /**
    * Properties for setting up the Render Queue's LogGroup


### PR DESCRIPTION
Added the ability to send all ELB access logs to a provided bucket for the render queue

This allows users to audit who is connecting to the Renderqueue.

## Testing

This was tested by creating a render farm that has ELB access logging enabled then ensuring that the initial test file and access logs are added to the provided s3 bucket.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
