### PR TITLE
chore: Enable VPC Flow Logs in sample app and add documentation explaining the benefits of them

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
@@ -107,6 +107,11 @@ The Health Monitor component contains a [Network Load Balancer](https://docs.aws
 
 The Bastion Host is a `BastionHostLinux` construct that allows you to connect to the Render Queue and Worker Fleet if you would like to take a look at the state of these components. It is not an essential component to the render farm, so it can be omitted without side effects, if desired. To connect to it, please refer to [Bastion Hosts CDK documentation](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-ec2-readme.html#bastion-hosts).
 
+## Best Practices
+
+### VPC Flow Logs
+We recommend enabling VPC Flow Logs for networks containing sensitive information. For example, in this application, we have enabled flow logs on the VPC created in the Network Tier. These logs capture information about the IP traffic going in and out of your VPC, which can be useful to detect malicious activity. For more information, see [VPC Flow Logs documentation](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html).
+
 ## Prerequisites
 
 - You have an EC2 Amazon Machine Image (AMI) with the Deadline Worker application to run the worker nodes in the compute tier. Make note of the AMI ID as it will be used in this guide. You can use AWS Portal AMIs which can be found in Deadline's amis.json file (see https://awsportal.s3.amazonaws.com/10.1.9/Release/amis.json). **Note:** The link to the amis.json file contains the Deadline version (10.1.9), which you should change if you are using a different version of Deadline.

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/network-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/network-tier.ts
@@ -4,6 +4,8 @@
  */
 
 import {
+  FlowLogDestination,
+  FlowLogTrafficType,
   GatewayVpcEndpointAwsService,
   IInterfaceVpcEndpointService,
   IGatewayVpcEndpointService,
@@ -80,6 +82,15 @@ export class NetworkTier extends cdk.Stack {
           cidrMask: 18, // 16,382 IP addresses
         },
       ],
+      // VPC flow logs are a security best-practice as they allow us
+      // to capture information about the traffic going in and out of
+      // the VPC. For more information, see the README for this app.
+      flowLogs: {
+        'NetworkTierFlowLogs': {
+          trafficType: FlowLogTrafficType.ALL,
+          destination: FlowLogDestination.toCloudWatchLogs(),
+        },
+      },
     });
 
     // Add the required VPC Endpoints


### PR DESCRIPTION
### Notes
- Enable VPC Flow Logs to increase the security in the `NetworkTier`  of the sample app.
- Added documentation in the sample app README about the flow logs and why we add them.

### Testing
- Deployed the `NetworkTier` and ensured the flow logs were created successfully

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
