### PR TITLE
chore: removing residual risk tags

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/cloudwatch-agent.ts
+++ b/packages/aws-rfdk/lib/core/lib/cloudwatch-agent.ts
@@ -50,12 +50,7 @@ export interface CloudWatchAgentProps {
  * 1) String SSM Parameter in Systems Manager Parameter Store to store the cloudwatch agent configuration;
  * 2) A script Asset which is uploaded to S3 bucket.
  *
- * Residual Risk
- * ------------------------
- * - Grants read permission to the host instance/ASG/fleet on the assets bucket and parameter store.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class CloudWatchAgent extends Construct {
 

--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -66,14 +66,7 @@ export interface ExportingLogGroupProps {
  * 4) The CloudWatch Event Rule to schedule log exportation;
  * 5) The Lambda SingletonFunction, with role, to export log groups to S3 by schedule.
  *
- * Residual Risk
- * ------------------------
- * - The Lambda's Role grants the Lambda permission:
- *    1) To export the log group that this construct is exporting
- *       to ***any*** S3 bucket that your account has write-access to.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class ExportingLogGroup extends Construct {
   /**

--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -263,15 +263,7 @@ abstract class HealthMonitorBase extends Construct implements IHealthMonitor {
  * 5) The Alarm if the healthy host percentage if lower than allowed;
  * 4) A single Lambda function that sets fleet size to 0 when triggered.
  *
- * Residual Risk
- * ------------------------
- * - CloudWatch has permissions to send encrypted messages
- * - CloudWatch has topic publishing permissions
- * - Lambda has permissions to change min, max and desired size
- *   of all ASGs in the account with the specified tag key and value
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class HealthMonitor extends HealthMonitorBase {
 

--- a/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
@@ -78,16 +78,7 @@ export interface ImportedAcmCertificateProps {
  * 2) Lambda Function, with Role - Used to create/update/delete the CustomResource.
  * 3) ACM Certificate - Created by the CustomResource.
  *
- * Residual Risk
- * ------------------------
- * - The Lambda role's policy gives it full access to the DynamoDB Table and access to get the X.509 certificate,
- *   private key, certificate chain, and passphrase Secrets that are taken as input.
- * - The Lambda also has permission to add tags to and import certificates to ACM that have the unique tag generated
- *   in this Construct. The permissions to delete and get certificates are open to all resources as ACM has not
- *   implemented policy conditions to restrict those operations to the unique tag.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class ImportedAcmCertificate extends Construct implements ICertificate {
   private static IMPORTER_UUID = '2d20d8f2-7b84-444e-b738-c75b499a9eaa';

--- a/packages/aws-rfdk/lib/core/lib/mongodb-installer.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-installer.ts
@@ -86,17 +86,7 @@ export interface MongoDbInstallerProps {
  * ------------------------
  * - A CDK Asset package containing the installation scripts is deployed to your CDK staging bucket.
  *
- * Residual Risk
- * ------------------------
- * - Since this class installs MongoDB from official sources dynamically during instance start-up, it is succeptable to an attacker compromising
- * the official MongoDB Inc. distribution channel for MongoDB. Such a compromise may result in the installation of unauthorized MongoDB binaries.
- * Executing this attack would require an attacker compromise both the official installation packages and the MongoDB Inc. gpg key with which they are
- * signed.
- * - This installer uses scripts that are deployed to your CDK staging bucket. An attacker that modifies those scripts can cause an instance that
- * uses this installer to perform any actions when it is first launched.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class MongoDbInstaller {
 

--- a/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
@@ -306,13 +306,7 @@ export interface IMongoDb extends IConnectable, IConstruct {
  * - An encrypted EBS Volume on which the MongoDB data is stored.
  * - Amazon CloudWatch log group that contains instance-launch and MongoDB application logs.
  *
- * Residual Risk
- * ------------------------
- * - The administrator credentials for MongoDB are stored in a Secret within AWS SecretsManager; you must limit access to this secret.
- * - Any risk present in {@link StaticPrivateIpServer} and {@link MongoDbInstaller}.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class MongoDbInstance extends Construct implements IMongoDb, IGrantable {
   // How often Cloudwatch logs will be flushed.

--- a/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
@@ -145,14 +145,7 @@ export interface MongoDbPostInstallSetupProps {
  * - A CloudFormation Custom Resource that triggers execution of the Lambda on stack deployment, update, and deletion.
  * - An Amazon CloudWatch log group that records history of the AWS Lambda's execution.
  *
- * Residual Risk
- * ------------------------
- * - The AWS Lambda function that is created by this resource has access to both the MongoDB administrator credentials,
- * and the MongoDB application port. An attacker that can find a way to execute this lambda could use it to modify or read
- * any data in the database.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class MongoDbPostInstallSetup extends Construct {
   constructor(scope: Construct, id: string, props: MongoDbPostInstallSetupProps) {

--- a/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
@@ -104,11 +104,6 @@ export interface MountableBlockVolumeProps {
  * @remark If using this script with an instance within an AWS Auto Scaling Group (ASG) and you resize
  * the EBS volume, then you can terminate the instance to let the ASG replace the instance and benefit
  * from the larger volume size when this script resizes the filesystem on instance launch.
- *
- * Residual Risk
- * --------------
- *
- * - The instance that is using this scripting will be able to get any object from your CDK bootstrap S3 bucket.
  */
 export class MountableBlockVolume implements IMountableLinuxFilesystem {
   constructor(protected readonly scope: Construct, protected readonly props: MountableBlockVolumeProps) {}

--- a/packages/aws-rfdk/lib/core/lib/script-assets.ts
+++ b/packages/aws-rfdk/lib/core/lib/script-assets.ts
@@ -127,13 +127,7 @@ export interface ScriptAssetProps extends AssetProps {}
  * ------------------------
  * 1) An Asset which is uploaded to the bootstrap S3 bucket.
  *
- * Residual Risk
- * ------------------------
- * - Every principal that has permissions to read this script asset,
- *   also has permissions to read ***everything*** in the bootstrap bucket.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class ScriptAsset extends Asset {
   /**

--- a/packages/aws-rfdk/lib/core/lib/staticip-server.ts
+++ b/packages/aws-rfdk/lib/core/lib/staticip-server.ts
@@ -164,18 +164,9 @@ export interface StaticPrivateIpServerProps {
  * 3) Security Group for the ASG;
  * 4) Instance Role and corresponding IAM Policy
  * 5) SNS Topic & Role for instance-launch lifecycle events -- max one of each per stack; and
- * 6) Lambda function, with role, to attach the ENI in response to instace-launch lifecycle events -- max one per stack.
- *
- * Residual Risk
- * ------------------------
- * - The Lambda's Role grants the Lambda permission:
- *    1) The ability to attach **any** Elastic Network Interface to **any** instance.
- *    2) To invoke autoscaling:CompleteLifecycleAction on **any** Auto Scaling Group that is tagged with the
- *       key 'RfdkStaticPrivateIpServerGrantConditionKey' and a unique value derived from this construct's
- *       scope.
+ * 6) Lambda function, with role, to attach the ENI in response to instance-launch lifecycle events -- max one per stack.
  *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class StaticPrivateIpServer extends Construct implements IConnectable, IGrantable {
 

--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -240,14 +240,7 @@ abstract class X509CertificateBase extends Construct {
  * 2) Secrets - 4 in total, for the certificate, it's private key, the passphrase to the key, and the cert chain.
  * 3) Lambda Function, with role - Used to create/update/delete the Custom Resource
  *
- * Residual Risk
- * ------------------------
- * - The Lambda role's policy gives it full access to the DynamoDB Table and access to get the passphrase Secret.
- *   It also has permission to create/delete/put Secrets with a resource tag that is generated uniquely for each
- *   instance of this Construct.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class X509CertificatePem extends X509CertificateBase implements IX509CertificatePem {
   public readonly cert: ISecret;
@@ -390,14 +383,7 @@ export interface IX509CertificatePkcs12 extends IConstruct {
  * 2) Secrets - 2 in total, The binary of the PKCS #12 certificate and its passphrase.
  * 3) Lambda Function, with role - Used to create/update/delete the CustomResource.
  *
- * Residual Risk
- * ------------------------
- * - The Lambda role's policy gives it full access to the DynamoDB Table and access to get the passphrase secret.
- *   It also has permission to create/delete/put Secrets with a resource tag that is uniquely generated for each
- *   instance of this Construct.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class X509CertificatePkcs12 extends X509CertificateBase implements IX509CertificatePkcs12 {
 

--- a/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
@@ -76,8 +76,6 @@ export interface MongoDbInstanceConnectionOptions {
 
 /**
  * Helper class for connecting Thinkbox's Deadline to a specific Database.
- *
- * Each Database has it's own implementation and provides separate residual risks see the for<Database> methods for more information.
  */
 export abstract class DatabaseConnection {
   /**
@@ -87,16 +85,7 @@ export abstract class DatabaseConnection {
    * ------------------------
    * This construct does not deploy any resources
    *
-   * Residual Risk
-   * ------------------------
-   * This construct is used to grant the following IAM permissions:
-   * - Read permissions to the DocumentDB's Login Secret
-   *
-   * The following security group changes are made by this construct
-   *  - TCP access to the DocumentDB Cluster over it's default port
-   *
    * @ResourcesDeployed
-   * @ResidualRisk
    */
   public static forDocDB(options: DocDBConnectionOptions): DatabaseConnection {
     return new DocDBDatabaseConnection(options);
@@ -109,17 +98,7 @@ export abstract class DatabaseConnection {
    * ------------------------
    * This construct does not deploy any resources
    *
-   * Residual Risk
-   * ------------------------
-   * This construct is used to grant the following IAM permissions:
-   * - Read permissions to the MongoDB's Login Secret
-   * - Read permissions to the client PKCS#12 certificate and its password.
-   *
-   * The following security group changes are made by this construct
-   *  - TCP access to the MongoDB over it's default port
-   *
    * @ResourcesDeployed
-   * @ResidualRisk
    */
   public static forMongoDbInstance(options: MongoDbInstanceConnectionOptions): DatabaseConnection {
     return new MongoDbInstanceDatabaseConnection(options);

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -134,16 +134,7 @@ abstract class RenderQueueBase extends Construct implements IRenderQueue {
  * 4) A CloudWatch bucket for streaming logs from the RCS container
  * 5) An application load balancer, listener and target group that balance incoming traffic among the RCS containers
  *
- * Residual Risk
- * ------------------------
- * - Grants full read permission to the ASG to CDK's assets bucket.
- * - Care must be taken to secure what can connect to the RenderQueue. The RenderQueue does not authenticate API
- *   requests made against it. Users must take responsibility for limiting access to the RenderQueue endpoint to only
- *   trusted hosts. Those hosts should be governed carefully, as malicious software could use the API to
- *   remotely execute code across the entire render farm.
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class RenderQueue extends RenderQueueBase implements IGrantable {
   /**

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -355,17 +355,7 @@ export interface RepositoryProps {
  * 5) A Script Asset which is uploaded to your deployment bucket to run the installer
  * 6) An aws-rfdk.CloudWatchAgent to configure sending logs to cloudwatch.
  *
- * Residual Risk
- * ------------------------
- * The instance in the AutoScaling group is given a role with the following permissions:
- * - Read permissions to the bucket containing the S3 Assets
- *
- * The Following Security Group changes are made by this construct:
- * - TCP access to the DocumentDB Cluster over it's default port
- * - TCP access to the Provided File system over it's default port
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class Repository extends Construct implements IRepository {
   /**

--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -384,15 +384,7 @@ export interface UsageBasedLicensingProps {
  * 2) Elastic Block Store device(s) associated with the EC2 instance(s) in the ASG. The default volume size is 30 GiB.
  * 3) The LogGroup if it doesn't exist already.
  *
- * Residual Risk
- * ------------------------
- * - Any machine that has ingress network access to the License Forwarder is able to receive the licenses.
- *   Make sure the security group of the license forwarder is tightly restricted
- *   to allow only ingress from the machines that require it
- * - Docker container has permissions to read a secret with 3rd Party Licensing Certificates
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class UsageBasedLicensing extends Construct implements IGrantable {
   /**

--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -279,16 +279,7 @@ abstract class WorkerInstanceFleetBase extends Construct implements IWorkerFleet
  * 3) A script asset which is uploaded to your deployment bucket used to configure the worker so it can connect to the Render Queue
  * 4) An aws-rfdk.CloudWatchAgent to configure sending logs to cloudwatch.
  *
- * Residual Risk
- * ------------------------
- * The instance in the AutoScaling group is given a role with the following permissions:
- * - Read permissions to the bucket containing the S3 Assets
- *
- * The Following Security Group changes are made by this construct:
- * - TCP access to the Render Queue's Load Balancer
- *
  * @ResourcesDeployed
- * @ResidualRisk
  */
 export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
 

--- a/tools/awslint/lib/rules/docs.ts
+++ b/tools/awslint/lib/rules/docs.ts
@@ -47,20 +47,6 @@ docsLinter.add({
 });
 
 docsLinter.add({
-  code:'docs-constructs-residualRisk',
-  message: 'Constructs must contain an @ResidualRisk tag',
-  eval: e => {
-    if (e.ctx.kind !== 'type') { return; }
-    if (isCfnType(e.ctx)) { return; }
-    const ConstructClass = e.ctx.assembly.system.findFqn("@aws-cdk/core.Construct");
-    const property = e.ctx.documentable;
-    if (!property.extends(ConstructClass)) { return; }
-  
-    e.assert(property.docs.docs.custom?.['ResidualRisk'], e.ctx.errorKey)
-  }
-});
-
-docsLinter.add({
   code:'docs-constructs-resourcesDeployed',
   message: 'Constructs must contain an @ResourcesDeployed tag',
   eval: e => {


### PR DESCRIPTION
This PR removes all the occurrences of `Residual Risk` sections from the doc-strings for RFDK construct.
This is the first step for replacing `Residual Risk` s with `Security Considerations` in the future.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
