### PR TITLE
fix(deadline): Close RenderQueue to ingress traffic by default

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -347,6 +347,8 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       // cloudformation updates.
       minHealthyPercent: 0,
       maxHealthyPercent: 100,
+      // This is required to ensure that the ALB listener's security group does not allow any ingress by default.
+      openListener: false,
     });
 
     // An explicit dependency is required from the Service to the Client certificate

--- a/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
@@ -128,6 +128,15 @@ describe('RenderQueue', () => {
     expectCDK(stack).to(haveResource('AWS::ECS::TaskDefinition'));
   });
 
+  test('closed ingress by default', () => {
+    // THEN
+    expectCDK(stack).notTo(haveResource('AWS::EC2::SecurityGroup', {
+      // The openListener=true option would create an ingress rule in the listener's SG.
+      // make sure that we don't have that.
+      SecurityGroupIngress: arrayWith(objectLike({})),
+    }));
+  });
+
   test('creates load balancer with default values', () => {
     // THEN
     expectCDK(stack).to(countResourcesLike('AWS::ElasticLoadBalancingV2::LoadBalancer', 1, {


### PR DESCRIPTION
The RenderQueue's ALB listener currently allows world-ingress, but it should be locked down to allow no ingress by default; with code being explicitly required to allow ingress.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
