### PR TITLE
chore: Remove kitchen-sink from build pipeline

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -11,8 +11,6 @@ phases:
   build:
     commands:
       - /bin/bash ./build.sh
-      - chmod a+x examples/kitchen-sink/end-to-end-test.sh
-      - chmod a+x examples/kitchen-sink/scripts/*
   post_build:
     commands:
       - "[ -f .BUILD_COMPLETED ] && /bin/bash ./pack.sh"


### PR DESCRIPTION
A quick fix to repair a broken build pipeline. The kitchen-sink sample app was deleted, but the `buildspec.yaml` for the pipeline still referenced it.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
