### PR TITLE
fix: Set load balancers to drop invalid http headers

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/load-balancer-manager.ts
+++ b/packages/aws-rfdk/lib/core/lib/load-balancer-manager.ts
@@ -195,11 +195,14 @@ export class LoadBalancerFactory {
     loadBalancerindex: number,
     healthMonitorProps: HealthMonitorProps,
   ): ApplicationLoadBalancer {
-    return new ApplicationLoadBalancer(scope, `ALB_${loadBalancerindex}`, {
+    const loadBalancer = new ApplicationLoadBalancer(scope, `ALB_${loadBalancerindex}`, {
       vpc: this.vpc,
       internetFacing: false,
       deletionProtection: healthMonitorProps.deletionProtection ?? true,
     });
+    // Enabling dropping of invalid HTTP header fields on the load balancer to prevent http smuggling attacks.
+    loadBalancer.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true');
+    return loadBalancer;
   }
 }
 

--- a/packages/aws-rfdk/lib/core/test/health-monitor.test.ts
+++ b/packages/aws-rfdk/lib/core/test/health-monitor.test.ts
@@ -11,6 +11,7 @@ import {
   expect as expectCDK,
   haveResource,
   haveResourceLike,
+  not,
   ABSENT,
 } from '@aws-cdk/assert';
 import {
@@ -502,9 +503,36 @@ test('validating deletion protection', () => {
   healthMonitor.registerFleet(fleet, {});
 
   // THEN
+  expectCDK(hmStack).to(not(haveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+    LoadBalancerAttributes: arrayWith(
+      {
+        Key: 'deletion_protection.enabled',
+        Value: 'true',
+      },
+    ),
+    Scheme: ABSENT,
+    Type: ABSENT,
+  })));
+});
+
+test('drop invalid http header fields enabled', () => {
+  // WHEN
+  healthMonitor = new HealthMonitor(hmStack, 'healthMonitor2', {
+    vpc,
+  });
+
+  const fleet = new TestMonitorableFleet(wfStack, 'workerFleet', {
+    vpc,
+  });
+  healthMonitor.registerFleet(fleet, {});
+
+  // THEN
   expectCDK(hmStack).to(haveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
-    LoadBalancerAttributes: ABSENT,
-    Scheme: 'internal',
-    Type: 'application',
+    LoadBalancerAttributes: arrayWith(
+      {
+        Key: 'routing.http.drop_invalid_header_fields.enabled',
+        Value: 'true',
+      },
+    ),
   }));
 });

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -353,6 +353,8 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
     this.pattern.service.node.addDependency(this.asg);
 
     this.loadBalancer = this.pattern.loadBalancer;
+    // Enabling dropping of invalid HTTP header fields on the load balancer to prevent http smuggling attacks.
+    this.loadBalancer.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true');
 
     if (props.accessLogs) {
       const accessLogsBucket = props.accessLogs.destinationBucket;

--- a/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
@@ -6,6 +6,7 @@
 import {
   ABSENT,
   arrayWith,
+  not,
   deepObjectLike,
   expect as expectCDK,
   haveResource,
@@ -1768,10 +1769,39 @@ describe('RenderQueue', () => {
     new RenderQueue(isolatedStack, 'RenderQueue', props);
 
     // THEN
+    expectCDK(isolatedStack).to(not(haveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      LoadBalancerAttributes: arrayWith(
+        {
+          Key: 'deletion_protection.enabled',
+          Value: 'true',
+        },
+      ),
+      Scheme: ABSENT,
+      Type: ABSENT,
+    })));
+  });
+
+  test('drop invalid http header fields enabled', () => {
+    // GIVEN
+    const props: RenderQueueProps = {
+      images,
+      repository,
+      version,
+      vpc,
+    };
+    const isolatedStack = new Stack(app, 'IsolatedStack');
+
+    // WHEN
+    new RenderQueue(isolatedStack, 'RenderQueue', props);
+
+    // THEN
     expectCDK(isolatedStack).to(haveResourceLike('AWS::ElasticLoadBalancingV2::LoadBalancer', {
-      LoadBalancerAttributes: ABSENT,
-      Scheme: 'internal',
-      Type: 'application',
+      LoadBalancerAttributes: arrayWith(
+        {
+          Key: 'routing.http.drop_invalid_header_fields.enabled',
+          Value: 'true',
+        },
+      ),
     }));
   });
 


### PR DESCRIPTION
## Changes

This PR enables dropping of invalid http header fields for all load balancers. This includes:
* Set the `routing.http.drop_invalid_header_fields.enabled` attribute to `"true"` in both places load balancers are being created
* Fixed the invalid assumption that was being made when testing other attributes of load balancers which assumed no other attributes would ever be set
* Added tests to make sure the attribute is applied

## Testing

Aside from running the automated tests, I deployed a render farm with this change applied and checked that:
* The attribute in question was showing the correct value in the AWS console
* The Deadline client could still connect to the farm

Note that this testing was done before also adding the attribute in `load-balancer-manager.ts`. This is not an issue because load balancers created through that code path do not get any traffic.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
