### PR TITLE
fix(core): Fix mounting filesystems if fstab does not end in newline

### DIFF
--- a/packages/aws-rfdk/lib/core/scripts/bash/mountEbsBlockVolume.sh
+++ b/packages/aws-rfdk/lib/core/scripts/bash/mountEbsBlockVolume.sh
@@ -224,6 +224,13 @@ function mount_volume() {
     VOL_UUID=$(identify_volume ${DEVICE_NAME})
     VOL_TYPE=$(identify_filesystem ${DEVICE_NAME})
 
+    # fstab may be missing a newline at end of file.
+    if test $(tail -c 1 /etc/fstab | wc -l) -eq 0
+    then
+        # Newline was missing, so add one.
+        echo "" | sudo tee -a /etc/fstab
+    fi
+
     echo "UUID=${VOL_UUID} ${MOUNT_POINT} ${VOL_TYPE} defaults,nofail,${EXTRA_MOUNT_OPTIONS} 0 2" | sudo tee -a /etc/fstab
     sudo mount "${MOUNT_POINT}"
 }

--- a/packages/aws-rfdk/lib/core/scripts/bash/mountEfs.sh
+++ b/packages/aws-rfdk/lib/core/scripts/bash/mountEfs.sh
@@ -56,6 +56,13 @@ function use_nfs_mount() {
 
 # Attempt to mount the EFS file system
 
+# fstab may be missing a newline at end of file.
+if test $(tail -c 1 /etc/fstab | wc -l) -eq 0
+then
+  # Newline was missing, so add one.
+  echo "" | sudo tee -a /etc/fstab
+fi
+
 if use_amazon_efs_mount
 then
   echo "${FILESYSTEM_ID}:/ ${MOUNT_PATH} efs defaults,tls,_netdev,${MOUNT_OPTIONS}" | sudo tee -a /etc/fstab

--- a/packages/aws-rfdk/lib/core/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/core/test/asset-constants.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { stringLike } from '@aws-cdk/assert';
+
 // ConfigureCloudWatchAgent.sh
 export const CWA_ASSET_LINUX = {
   Bucket: 'AssetParameters3793207e75b2a1b5dd4ebe458ab7a5cc20154224e846267d2c22da1d0631f94fS3Bucket352E624B',
@@ -17,7 +19,7 @@ export const CWA_ASSET_WINDOWS = {
 
 // mountEbsBlockVolume.sh + metadataUtilities.sh
 export const MOUNT_EBS_SCRIPT_LINUX = {
-  Bucket: 'AssetParameters1856f943f329125e99ad6da55707ea210edc1fd0eef29bd399044e7855a37aadS3BucketEDE8B69C',
+  Bucket: stringLike('AssetParameters*S3BucketE9BCAE61'),
 };
 
 export const INSTALL_MONGODB_3_6_SCRIPT_LINUX = {


### PR DESCRIPTION
Discovered a bug with Deadline's AWSPortal AMIs -- they have an fstab that does not end in newline. This breaks our scripts, so now we check for a missing newline and add it explicitly if it's not there.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
