### PR TITLE
fix(integ): disables deletion protection on renderqueue for integ test

### DIFF
--- a/integ/lib/render-struct.ts
+++ b/integ/lib/render-struct.ts
@@ -82,8 +82,10 @@ export class RenderStruct extends Construct {
       },
       hostname,
       trafficEncryption,
+      deletionProtection: false,
     };
     this.renderQueue = new RenderQueue(this, 'RenderQueue', renderQueueProps);
+
     this.cert = cacert;
 
   }


### PR DESCRIPTION
----
Another hotfix, this one prevents the deletion protection on the render queue from failing tear-down at the end of the test. I'm submitting the PR as a draft and will mark it final and merge it in once I can fully confirm that the test executes cleanly.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
