### PR TITLE
chore: Mark packages as stable

### DIFF
--- a/lambda-layers/package.json
+++ b/lambda-layers/package.json
@@ -26,8 +26,8 @@
   "engines": {
     "node": ">= 10.13.0 <13 || >=13.7.0"
   },
-  "stability": "experimental",
-  "maturity": "experimental",
+  "stability": "stable",
+  "maturity": "stable",
   "devDependencies": {
     "@types/node": "^14.0.12",
     "typescript": "~3.9.6"

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -1,13 +1,5 @@
 # AWS Thinkbox Deadline Construct Library
 
-<!--BEGIN STABILITY BANNER-->
----
-
-![cdk-constructs: Experimental](https://img.shields.io/static/v1?label=CDK-CONSTRUCTS&message=EXPERIMENTAL&color=orange&style=for-the-badge)
-
----
-<!--END STABILITY BANNER-->
-
 The `aws-rfdk/deadline` sub-module contains Deadline-specific constructs that can be used to deploy and manage a Deadline render farm in the cloud.
 
 ```ts nofixture

--- a/packages/aws-rfdk/package.json
+++ b/packages/aws-rfdk/package.json
@@ -186,6 +186,6 @@
   "engines": {
     "node": ">= 10.13.0 <13 || >=13.7.0"
   },
-  "stability": "experimental",
-  "maturity": "experimental"
+  "stability": "stable",
+  "maturity": "stable"
 }


### PR DESCRIPTION
Our packages should be marked stable. This fixes that.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
