### PR TITLE
chore: Update aws-rfdk package-level README

### DIFF
--- a/packages/aws-rfdk/README.md
+++ b/packages/aws-rfdk/README.md
@@ -10,13 +10,8 @@ libraries provided by the CDK and RFDK together and with other CDK-compatible li
 an object from the CDK and RFDK libraries represents the creation of a resource, or collection of resources, in your AWS account when the application is deployed
 via AWS CloudFormation by the CDK toolkit. The parameters of an object’s creation control the configuration of the resource.
 
-## Contents of this package
-
-* The root module/namespace (`aws-rfdk` in Typescript/Javascript, or `aws_rfdk` in Python) contains constructs that are not particular to any specific
- render management software. They are common building blocks that may be used in any deployed render farm. For more detailed information on the contents of this module, please see:
-  1. The [official API documentation](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk-construct-library.html)
-  2. Sample usage snipits in the [README](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/core/README.md)
-* The `deadline` module/namespace (`aws-rfdk/deadline` in Typescript/Javascript, or `aws_rfdk.deadline` in Python) contains constructs that are specific to
- deploying a render farm that is operated by [AWS Thinkbox](https://www.awsthinkbox.com/) [Deadline software](https://www.awsthinkbox.com/deadline). For more detailed information on the contents of this module, please see:
-   1. The [official API documentation](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk-construct-library.html)
-   2. Sample usage snipits in the [README](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/deadline/README.md)
+Please see the following sources for additional information:
+* The [AWS RFDK Developer Guide](https://docs.aws.amazon.com/rfdk/latest/guide/what-is-rfdk.html)
+* The [AWS RFDK API Documentation](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk-construct-library.html)
+* The [README for the main module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/core/README.md)
+* The [README for the Deadline module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/deadline/README.md)


### PR DESCRIPTION
Changing the contents of the package-level README for aws-rfdk. The contents of this README appear as:
1. The 'Overview' page in our API documentation.
2. The README in the landing page for aws-rfdk on npmjs.org: https://www.npmjs.com/package/aws-rfdk
3. The README in the landing page for aws-rfdk on pypi.org: https://pypi.org/project/aws-rfdk/

I'm trying to strike a balance between those two use-cases for this one file. If it was just the API documentation, then I think we'd want to just make this file contain the combination of the core & deadline directory READMEs. However, that's probably too much information for the package README on npmjs.org and pypi.org.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
