### PR TITLE
fix(core): I-named interfaces could not be created in Python

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
@@ -44,7 +44,7 @@ import {
  * User added to the $external admin database.
  * Referencing: https://docs.mongodb.com/v3.6/core/security-x.509/#member-certificate-requirements
  */
-export interface IMongoDbX509User {
+export interface MongoDbX509User {
   /**
    * The certificate of the user that they will use for authentication. This must be a secret
    * containing the plaintext string contents of the certificate in PEM format. For example,
@@ -70,7 +70,7 @@ export interface IMongoDbX509User {
  * This interface is for defining a set of users to pass to MongoDbPostInstallSetup so that it can
  * create them in the MongoDB.
  */
-export interface IMongoDbUsers {
+export interface MongoDbUsers {
   /**
    * Zero or more secrets containing credentials, and specification for users to be created in the
    * admin database for authentication using SCRAM. See: https://docs.mongodb.com/v3.6/core/security-scram/
@@ -95,7 +95,7 @@ export interface IMongoDbUsers {
    *
    * @default No x.509 authenticated users are created.
    */
-  readonly x509AuthUsers?: IMongoDbX509User[];
+  readonly x509AuthUsers?: MongoDbX509User[];
 }
 
 /**
@@ -124,7 +124,7 @@ export interface MongoDbPostInstallSetupProps {
    * The Users that should be created in the MongoDB database. This construct will create these
    * users only if they do not already exist. If a user does already exist, then it will not be modified.
    */
-  readonly users: IMongoDbUsers;
+  readonly users: MongoDbUsers;
 }
 
 /**

--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -44,7 +44,7 @@ import { IX509CertificateEncodePkcs12, IX509CertificateGenerate } from '../lambd
  * These fields are industry standard, and can be found in rfc1779 (see: https://tools.ietf.org/html/rfc1779)
  * or the X.520 specification (see: ITU-T Rec.X.520)
  */
-export interface IDistinguishedName {
+export interface DistinguishedName {
   /**
    * Common Name for the identity.
    *  a) For servers -- The fully qualified domain name (aka: fqdn) of the server.
@@ -72,7 +72,7 @@ export interface X509CertificatePemProps {
   /**
    * The subject, or identity, for the generated certificate.
    */
-  readonly subject: IDistinguishedName;
+  readonly subject: DistinguishedName;
 
   /**
    * If provided, then this KMS is used to secure the cert, key, and passphrase Secrets created by the construct.

--- a/packages/aws-rfdk/lib/core/test/mongodb-post-install.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-post-install.test.ts
@@ -24,8 +24,8 @@ import {
 } from '@aws-cdk/core';
 
 import {
-  IMongoDbUsers,
-  IMongoDbX509User,
+  MongoDbUsers,
+  MongoDbX509User,
   MongoDbInstance,
   MongoDbPostInstallSetup,
   MongoDbSsplLicenseAcceptance,
@@ -43,8 +43,8 @@ describe('MongoDbPostInstall', () => {
   let pwUser2: ISecret;
   let x509User1Arn: string;
   let x509User2Arn: string;
-  let x509User1: IMongoDbX509User;
-  let x509User2: IMongoDbX509User;
+  let x509User1: MongoDbX509User;
+  let x509User2: MongoDbX509User;
 
   beforeEach(() => {
     const hostname = 'mongodb';
@@ -99,7 +99,7 @@ describe('MongoDbPostInstall', () => {
 
   test('created correctly: both user types', () => {
     // GIVEN
-    const users: IMongoDbUsers = {
+    const users: MongoDbUsers = {
       passwordAuthUsers: [ pwUser1, pwUser2 ],
       x509AuthUsers: [ x509User1, x509User2 ],
     };
@@ -227,7 +227,7 @@ describe('MongoDbPostInstall', () => {
 
   test('created correctly: only password users', () => {
     // GIVEN
-    const users: IMongoDbUsers = {
+    const users: MongoDbUsers = {
       passwordAuthUsers: [ pwUser1, pwUser2 ],
     };
 
@@ -309,7 +309,7 @@ describe('MongoDbPostInstall', () => {
 
   test('created correctly: only x509 users', () => {
     // GIVEN
-    const users: IMongoDbUsers = {
+    const users: MongoDbUsers = {
       x509AuthUsers: [ x509User1, x509User2 ],
     };
 
@@ -350,7 +350,7 @@ describe('MongoDbPostInstall', () => {
 
   test('use selected subnets', () => {
     // GIVEN
-    const users: IMongoDbUsers = {
+    const users: MongoDbUsers = {
       passwordAuthUsers: [ pwUser1, pwUser2 ],
       x509AuthUsers: [ x509User1, x509User2 ],
     };
@@ -378,7 +378,7 @@ describe('MongoDbPostInstall', () => {
 
   test('assert bad x509 role', () => {
     // GIVEN
-    const users: IMongoDbUsers = {
+    const users: MongoDbUsers = {
       x509AuthUsers: [
         {
           certificate: x509User1.certificate,


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-rfdk/issues/72

Renaming the three interfaces in question to remove the leading 'I' fixes the issue.

These are the only three interfaces that need to change; all of the rest of the RFDK interfaces are either purely Typescript (in Lambda source) or are true interfaces that are not directly instantiated:

```bash
% grep 'interface I' -r .
./lib/core/lib/mountable-filesystem.ts:export interface IMountingInstance extends IConnectable, IScriptHost {
./lib/core/lib/mountable-filesystem.ts:export interface IMountableLinuxFilesystem {
./lib/core/lib/health-monitor.ts:export interface IMonitorableFleet extends IConnectable {
./lib/core/lib/health-monitor.ts:export interface IHealthMonitor extends IResource {
./lib/core/lib/mongodb-post-install.ts:export interface IMongoDbX509User {
./lib/core/lib/mongodb-post-install.ts:export interface IMongoDbUsers {
./lib/core/lib/x509-certificate.ts:export interface IDistinguishedName {
./lib/core/lib/x509-certificate.ts:export interface IX509CertificatePem extends IConstruct {
./lib/core/lib/x509-certificate.ts:export interface IX509CertificatePkcs12 extends IConstruct {
./lib/core/lib/mongodb-instance.ts:export interface IMongoDb extends IConnectable, IConstruct {
./lib/core/lib/script-assets.ts:export interface IScriptHost extends IGrantable {
./lib/core/lib/imported-acm-certificate.ts:export interface ImportedAcmCertificateProps {
./lib/core/lambdas/nodejs/lib/x509-certs/certificate.ts:export interface ICertificate {
./lib/core/lambdas/nodejs/mongodb/types.ts:export interface IConnectionOptions {
./lib/core/lambdas/nodejs/mongodb/types.ts:export interface IX509AuthenticatedUser {
./lib/core/lambdas/nodejs/mongodb/types.ts:export interface IMongoDbConfigureResource {
./lib/core/lambdas/nodejs/x509-certificate/types.ts:export interface ISecretCertificate {
./lib/core/lambdas/nodejs/x509-certificate/types.ts:export interface INewSecretProps {
./lib/core/lambdas/nodejs/x509-certificate/types.ts:export interface IX509ResourceProperties {
./lib/core/lambdas/nodejs/x509-certificate/types.ts:export interface IAcmImportCertProps {
./lib/core/lambdas/nodejs/x509-certificate/types.ts:export interface IX509CertificateGenerate extends IX509ResourceProperties {
./lib/core/lambdas/nodejs/x509-certificate/types.ts:export interface IX509CertificateEncodePkcs12 extends IX509ResourceProperties {
./lib/deadline/lib/render-queue.ts:export interface IRenderQueue extends IConstruct, IConnectable {
./lib/deadline/lib/host-ref.ts:export interface IHost extends IConnectable, IConstruct, IScriptHost {
./lib/deadline/lib/render-queue-ref.ts:export interface InstanceConnectOptions {
./lib/deadline/lib/worker-fleet.ts:export interface IWorkerFleet extends IResource, IConnectable, IGrantable {
./lib/deadline/lib/version-ref.ts:export interface Installer {
./lib/deadline/lib/version-ref.ts:export interface IReleaseVersion {
./lib/deadline/lib/version-ref.ts:export interface IPatchVersion extends IReleaseVersion {
./lib/deadline/lib/version-ref.ts:export interface IVersion extends IReleaseVersion {
./lib/deadline/lib/repository.ts:export interface IContainerDirectRepositoryConnection {
./lib/deadline/lib/repository.ts:export interface InstanceDirectConnectProps {
./lib/deadline/lib/repository.ts:export interface IRepository extends IConstruct {
```

## Testing

```bash
% python3 -m venv test_env
% source test_env/bin/activate
% pip install aws-rfdk/dist/python/aws-rfdk-0.16.0.tar.gz 
>>> import aws_rfdk as rfdk
>>> name = rfdk.DistinguishedName()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() missing 1 required keyword-only argument: 'cn'
>>> users = rfdk.MongoDbUsers()
>>> user = rfdk.MongoDbX509User()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() missing 2 required keyword-only arguments: 'certificate' and 'roles'
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
