### PR TITLE
fix(core): Remove AcmCertificateImporter race condition

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
@@ -159,6 +159,7 @@ export class ImportedAcmCertificate extends Construct implements ICertificate {
     lambda.addToRolePolicy(new PolicyStatement({
       actions: [
         'acm:DeleteCertificate',
+        'acm:DescribeCertificate',
         'acm:GetCertificate',
       ],
       resources: ['*'],

--- a/packages/aws-rfdk/lib/core/test/imported-acm-certificate.test.ts
+++ b/packages/aws-rfdk/lib/core/test/imported-acm-certificate.test.ts
@@ -129,6 +129,7 @@ test('Import cert', () => {
         {
           Action: [
             'acm:DeleteCertificate',
+            'acm:DescribeCertificate',
             'acm:GetCertificate',
           ],
           Resource: '*',


### PR DESCRIPTION
Removes a race condition where certificates would attempt to be deleted while ACM thinks the certificates are still in use.

This bug and following fix mirrors the following merge request https://github.com/aws/aws-cdk/pull/4191 in CDK.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
