### PR TITLE
fix(deadline): WorkerFleet should not create a securitygroups when given one

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -387,6 +387,7 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
       vpcSubnets: props.vpcSubnets ? props.vpcSubnets : {
         subnetType: SubnetType.PRIVATE,
       },
+      securityGroup: props.securityGroup,
       minCapacity: props.minCapacity,
       maxCapacity: props.maxCapacity,
       desiredCapacity: props.desiredCapacity,
@@ -421,10 +422,6 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
       granularity: '1Minute',
       metrics: ['GroupDesiredCapacity'],
     }];
-
-    if (props.securityGroup) {
-      this.fleet.addSecurityGroup(props.securityGroup);
-    }
 
     this.grantPrincipal = this.fleet.grantPrincipal;
     this.connections = this.fleet.connections;

--- a/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
@@ -504,9 +504,7 @@ describe('UsageBasedLicensing', () => {
               'GroupId',
             ],
           },
-          SourceSecurityGroupId: {
-            'Fn::ImportValue': stringLike(`${Stack.of(workerFleet)}:ExportsOutputFnGetAttworkerFleetInstanceSecurityGroupB00C2885GroupId60416F0A`),
-          },
+          SourceSecurityGroupId: 'sg-123456789',
         }));
       });
     });

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -158,6 +158,27 @@ test('security group is added to fleet after its creation', () => {
   }));
 });
 
+test('WorkerFleet uses given security group', () => {
+  // WHEN
+  new WorkerInstanceFleet(stack, 'workerFleet', {
+    vpc,
+    workerMachineImage: new GenericWindowsImage({
+      'us-east-1': 'ami-any',
+    }),
+    renderQueue,
+    securityGroup: SecurityGroup.fromSecurityGroupId(stack, 'SG', 'sg-123456789', {
+      allowAllOutbound: false,
+    }),
+  });
+
+  // THEN
+  expectCDK(stack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+    SecurityGroups: [
+      'sg-123456789',
+    ],
+  }));
+});
+
 test('default worker fleet is created correctly with linux image', () => {
   // WHEN
   new WorkerInstanceFleet(stack, 'workerFleet', {


### PR DESCRIPTION
The current WorkerFleet was always letting its AutoScalingGroup create a SecurityGroup and then adding any given SecurityGroup to that one. The result was that when given a SecurityGroup in the WorkerFleet props, the WorkerFleet would have two SGs instead of one.

This fixes that oversight. Now, the WorkerFleet no longer creates an extra security group when given one.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
