### PR TITLE
chore: add GitHub links to changelogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,6 @@
     "release": "standard-version"
   },
   "standard-version": {
-    "releaseCommitMessageFormat": "v{{currentTag}}",
-    "commitUrlFormat": ") (full hash: {{hash}}",
-    "compareUrlFormat": ") (Link not implemented",
-    "issueUrlFormat": ") (Link not implemented",
-    "userUrlFormat": ") (Link not implemented",
     "scripts": {
       "prebump": "echo $(node -pe \"require('./lerna.json').version\")",
       "precommit": "git add ."


### PR DESCRIPTION
## Change

This change removes the configuration in `package.json` that caused the "(Link not implemented)" to be generated in our `CHANGELOG.md` file when creating a new release.

Removing the configuration causes `standard-version` to automatically generate hyperlinks to the GitHub commits.

## Testing

Ran the `./bump.sh` script and previewed the rendered `CHANGELOG.md` markdown in VSCode. All hyperlinks work as expected 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
