### PR TITLE
chore: Tell dependendabot not to update constructs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions: ">=11.0.0-0"
+      - dependency-name: "constructs"
+        versions: ">=3.0.2"
       - dependency-name: "@aws-cdk/*"
     commit-message:
       prefix: "chore(deps):"


### PR DESCRIPTION
Tells dependabot not to update the dependency 'construtcs' since we have a linter rule specifying the exact version.

This PR fixes the issue that was discovered in https://github.com/aws/aws-rfdk/pull/31

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
