### PR TITLE
fix(examples): Fix instructions and formatting in example app README

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
@@ -12,66 +12,86 @@ These instructions assume that your working directory is `examples/deadline/All-
 
 ---
 
-1. Install the dependencies of the sample app:
-```bash
-pip install -r requirements.txt
-```
-2. Change the value in the `deadline_client_linux_ami_map` variable in `package/config.py` to include the region + AMI ID mapping of your EC2 AMI(s) with Deadline Worker.
-```python
-# For example, in the us-west-2 region
-self.deadline_client_linux_ami_map: Mapping[str, str] = {'us-west-2': '<your ami id'}
+1.  Install the dependencies of the sample app:
 
-```
-3. Create a binary secret in [SecretsManager](https://aws.amazon.com/secrets-manager/) that contains your [Usage-Based Licensing](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/aws-portal/licensing-setup.html?highlight=usage%20based%20licensing) certificates in a `.zip` file:
-```bash
-aws secretsmanager create-secret --name <name> --secret-binary fileb://<path-to-zip-file>
-```
-4. The output from the previous step will contain the secret's ARN. Change the value of the `ubl_certificate_secret_arn` variable in `package/config.py` to the secret's ARN:
-```python
-self.ubl_certificate_secret_arn: str = '<your secret arn>'
-```
-5. Choose your UBL limits and change the value of the `ubl_licenses` variable in `package/config.py` accordingly:
-```python
-self.ubl_licenses: List[UsageBasedLicense] = [<your-ubl-limits> (e.g. UsageBasedLicense.forMaya(10))]
-```
----
+    ```bash
+    pip install -r requirements.txt
+    ```
+2.  Change the value in the `deadline_client_linux_ami_map` variable in `package/config.py` to include the region + AMI ID mapping of your EC2 AMI(s) with Deadline Worker.
 
-**Note:** The next two steps are optional. You may skip these if you do not need SSH access into your render farm.
+    ```python
+    # For example, in the us-west-2 region
+    self.deadline_client_linux_ami_map: Mapping[str, str] = {'us-west-2': '<your ami id'}
+    ```
+3.  Create a binary secret in [SecretsManager](https://aws.amazon.com/secrets-manager/) that contains your [Usage-Based Licensing](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/aws-portal/licensing-setup.html?highlight=usage%20based%20licensing) certificates in a `.zip` file:
 
----
-6. Create an EC2 key pair to give you SSH access to the render farm:
-```bash
-aws ec2 create-key-pair --key-name <key-name>
-```
+    ```bash
+    aws secretsmanager create-secret --name <name> --secret-binary fileb://<path-to-zip-file>
+    ```
+4.  The output from the previous step will contain the secret's ARN. Change the value of the `ubl_certificate_secret_arn` variable in `package/config.py` to the secret's ARN:
+
+    ```python
+    self.ubl_certificate_secret_arn: str = '<your secret arn>'
+    ```
+5.  Choose your UBL limits and change the value of the `ubl_licenses` variable in `package/config.py` accordingly. For example:
+
+    ```python
+    self.ubl_licenses: List[UsageBasedLicense] = [
+        # your UBL limits, for example:
+        #
+        # up to 10 concurrent Maya licenses used at once
+        UsageBasedLicense.for_maya(10),
+        #
+        # unlimited Arnold licenses
+        UsageBasedLicense.for_arnold()
+    ]
+    ```
+
+    ---
+
+    **Note:** The next two steps are optional. You may skip these if you do not need SSH access into your render farm.
+
+    ---
+6.  Create an EC2 key pair to give you SSH access to the render farm:
+
+    ```bash
+    aws ec2 create-key-pair --key-name <key-name>
+    ```
 7.  Change the value of the `key_pair_name` variable in `package/config.py` to your value for `<key-name>` in the previous step: <br><br>**Note:** Save the value of the "KeyMaterial" field as a file in a secure location. This is your private key that you can use to SSH into the render farm.
-```python
-self.key_pair_name: Optional[str] = '<your key pair name>'
-```
-8. Choose the type of database you would like to deploy and change the value of the `deploy_mongo_db` variable in `package/config.py` accordingly:
-```python
-# True = MongoDB, False = Amazon DocumentDB
-self.deploy_mongo_db: bool = False
-```
-9. If you set `deploy_mongo_db` to `True`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `accept_sspl_license` in `package/config.py`:
-```python
-self.accept_sspl_license: MongoDbSsplLicenseAcceptance = MongoDbSsplLicenseAcceptance.USER_REJECTS_SSPL
-```
+
+    ```python
+    self.key_pair_name: Optional[str] = '<your key pair name>'
+    ```
+8.  Choose the type of database you would like to deploy and change the value of the `deploy_mongo_db` variable in `package/config.py` accordingly:
+
+    ```python
+    # True = MongoDB, False = Amazon DocumentDB
+    self.deploy_mongo_db: bool = False
+    ```
+9.  If you set `deploy_mongo_db` to `True`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `accept_sspl_license` in `package/config.py`:
+
+    ```python
+    self.accept_sspl_license: MongoDbSsplLicenseAcceptance = MongoDbSsplLicenseAcceptance.USER_REJECTS_SSPL
+    ```
 10. Stage the Docker recipes for `RenderQueue` and `UBLLicensing`:
-```bash
-# Set this value to the version of RFDK your application targets
-RFDK_VERSION=
-# Set this value to the version of AWS Thinkbox Deadline you'd like to deploy to your farm
-RFDK_DEADLINE_VERSION=
-npx --package=aws-rfdk@${RFDK_VERSION} stage-deadline \
-    --deadlineInstallerURI s3://thinkbox-installers/Deadline/${RFDK_DEADLINE_VERSION}/Linux/DeadlineClient-${RFDK_DEADLINE_VERSION}-linux-x64-installer.run \
-    --dockerRecipesURI s3://thinkbox-installers/DeadlineDocker/${RFDK_DEADLINE_VERSION}/DeadlineDocker-${RFDK_DEADLINE_VERSION}.tar.gz \
-    --output stage
-```
+
+    ```bash
+    # Set this value to the version of RFDK your application targets
+    RFDK_VERSION=
+    # Set this value to the version of AWS Thinkbox Deadline you'd like to deploy to your farm
+    RFDK_DEADLINE_VERSION=
+    npx --package=aws-rfdk@${RFDK_VERSION} stage-deadline \
+        --deadlineInstallerURI s3://thinkbox-installers/Deadline/${RFDK_DEADLINE_VERSION}/Linux/DeadlineClient-${RFDK_DEADLINE_VERSION}-linux-x64-installer.run \
+        --dockerRecipesURI s3://thinkbox-installers/DeadlineDocker/${RFDK_DEADLINE_VERSION}/DeadlineDocker-${RFDK_DEADLINE_VERSION}.tar.gz \
+        --output stage
+    ```
 11. Deploy all the stacks in the sample app:
-```bash
-cdk deploy "*"
-```
+
+    ```bash
+    cdk deploy "*"
+    ```
 13. Once you are finished with the sample app, you can tear it down by running:
-```bash
-cdk destroy "*"
-```
+
+    ```bash
+    cdk destroy "*"
+    ```

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
@@ -21,7 +21,9 @@ These instructions assume that your working directory is `examples/deadline/All-
 
     ```python
     # For example, in the us-west-2 region
-    self.deadline_client_linux_ami_map: Mapping[str, str] = {'us-west-2': '<your ami id'}
+    self.deadline_client_linux_ami_map: Mapping[str, str] = {
+        'us-west-2': '<your ami id>'
+    }
     ```
 3.  Create a binary secret in [SecretsManager](https://aws.amazon.com/secrets-manager/) that contains your [Usage-Based Licensing](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/aws-portal/licensing-setup.html?highlight=usage%20based%20licensing) certificates in a `.zip` file:
 
@@ -38,10 +40,10 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```python
     self.ubl_licenses: List[UsageBasedLicense] = [
         # your UBL limits, for example:
-        #
+
         # up to 10 concurrent Maya licenses used at once
         UsageBasedLicense.for_maya(10),
-        #
+
         # unlimited Arnold licenses
         UsageBasedLicense.for_arnold()
     ]
@@ -57,12 +59,16 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```bash
     aws ec2 create-key-pair --key-name <key-name>
     ```
-7.  Change the value of the `key_pair_name` variable in `package/config.py` to your value for `<key-name>` in the previous step: <br><br>**Note:** Save the value of the "KeyMaterial" field as a file in a secure location. This is your private key that you can use to SSH into the render farm.
+7.  Change the value of the `key_pair_name` variable in `package/config.py` to your value for `<key-name>` in the previous step:
+
+    **Note:** Save the value of the `"KeyMaterial"` field as a file in a secure location. This is your private key that you can use to SSH into the render farm.
 
     ```python
     self.key_pair_name: Optional[str] = '<your key pair name>'
     ```
-8.  Choose the type of database you would like to deploy and change the value of the `deploy_mongo_db` variable in `package/config.py` accordingly:
+8.  Choose the type of database you would like to deploy (AWS DocumentDB or MongoDB).
+    If you would like to use MongoDB, you will need to accept the Mongo SSPL (see next step).
+    Once you've decided on a database type, change the value of the `deploy_mongo_db` variable in `package/config.py` accordingly:
 
     ```python
     # True = MongoDB, False = Amazon DocumentDB
@@ -71,15 +77,18 @@ These instructions assume that your working directory is `examples/deadline/All-
 9.  If you set `deploy_mongo_db` to `True`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `accept_sspl_license` in `package/config.py`:
 
     ```python
+    # To accept the MongoDB SSPL, change from USER_REJECTS_SSPL to USER_ACCEPTS_SSPL
     self.accept_sspl_license: MongoDbSsplLicenseAcceptance = MongoDbSsplLicenseAcceptance.USER_REJECTS_SSPL
     ```
 10. Stage the Docker recipes for `RenderQueue` and `UBLLicensing`:
 
     ```bash
     # Set this value to the version of RFDK your application targets
-    RFDK_VERSION=
-    # Set this value to the version of AWS Thinkbox Deadline you'd like to deploy to your farm
-    RFDK_DEADLINE_VERSION=
+    RFDK_VERSION=<version_of_RFDK>
+
+    # Set this value to the version of AWS Thinkbox Deadline you'd like to deploy to your farm. Deadline 10.1.9 and up are supported.
+    RFDK_DEADLINE_VERSION=<version_of_deadline>
+
     npx --package=aws-rfdk@${RFDK_VERSION} stage-deadline \
         --deadlineInstallerURI s3://thinkbox-installers/Deadline/${RFDK_DEADLINE_VERSION}/Linux/DeadlineClient-${RFDK_DEADLINE_VERSION}-linux-x64-installer.run \
         --dockerRecipesURI s3://thinkbox-installers/DeadlineDocker/${RFDK_DEADLINE_VERSION}/DeadlineDocker-${RFDK_DEADLINE_VERSION}.tar.gz \

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
@@ -12,65 +12,79 @@ These instructions assume that your working directory is `examples/deadline/All-
 
 ---
 
-1. Install the dependencies of the sample app:
-```
-yarn install
-```
-2. Change the value in the `deadlineClientLinuxAmiMap` variable in `bin/config.ts` to include the region + AMI ID mapping of your EC2 AMI(s) with Deadline Worker.
-```ts
-// For example, in the us-west-2 region
-public readonly deadlineClientLinuxAmiMap: Record<string, string> = {
-  ['us-west-2']: '<your-ami-id>',
-  // ...
-  };
-```
-3. Create a binary secret in [SecretsManager](https://aws.amazon.com/secrets-manager/) that contains your [Usage-Based Licensing](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/aws-portal/licensing-setup.html?highlight=usage%20based%20licensing) certificates in a `.zip` file:
-```
-aws secretsmanager create-secret --name <name> --secret-binary fileb://<path-to-zip-file>
-```
-4. The output from the previous step will contain the secret's ARN. Change the value of the `ublCertificatesSecretArn` variable in `bin/config.ts` to the secret's ARN:
-```ts
-public readonly ublCertificatesSecretArn: string = '<your-secret-arn>';
-```
-5. Choose your UBL limits and change the value of the `ublLicenses` variable in `bin/config.ts` accordingly:
-```ts
-public readonly ublLicenses: UsageBasedLicense[] = [ /* <your-ubl-limits> (e.g. UsageBasedLicense.forMaya(10)) */ ];
-```
----
+1.  Install the dependencies of the sample app:
 
-**Note:** The next two steps are optional. You may skip these if you do not need SSH access into your render farm.
+    ```
+    yarn install
+    ```
+2.  Change the value in the `deadlineClientLinuxAmiMap` variable in `bin/config.ts` to include the region + AMI ID mapping of your EC2 AMI(s) with Deadline Worker.
 
----
-6. Create an EC2 key pair to give you SSH access to the render farm:
-```
-aws ec2 create-key-pair --key-name <key-name>
-```
+    ```ts
+    // For example, in the us-west-2 region
+    public readonly deadlineClientLinuxAmiMap: Record<string, string> = {
+      ['us-west-2']: '<your-ami-id>',
+      // ...
+      };
+    ```
+3.  Create a binary secret in [SecretsManager](https://aws.amazon.com/secrets-manager/) that contains your [Usage-Based Licensing](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/aws-portal/licensing-setup.html?highlight=usage%20based%20licensing) certificates in a `.zip` file:
+
+    ```
+    aws secretsmanager create-secret --name <name> --secret-binary fileb://  <path-to-zip-file>
+    ```
+4.  The output from the previous step will contain the secret's ARN. Change the value of the `ublCertificatesSecretArn` variable in `bin/config.ts` to the secret's ARN:
+
+    ```ts
+    public readonly ublCertificatesSecretArn: string = '<your-secret-arn>';
+    ```
+5.  Choose your UBL limits and change the value of the `ublLicenses` variable in `bin/config.ts` accordingly:
+
+    ```ts
+    public readonly ublLicenses: UsageBasedLicense[] = [ /* <your-ubl-limits> (e.g.   UsageBasedLicense.forMaya(10)) */ ];
+    ```
+
+    ---
+
+    **Note:** The next two steps are optional. You may skip these if you do not need   SSH access into your render farm.
+
+    ---
+6.  Create an EC2 key pair to give you SSH access to the render farm:
+
+    ```
+    aws ec2 create-key-pair --key-name <key-name>
+    ```
 7.  Change the value of the `keyPairName` variable in `bin/config.ts` to your value for `<key-name>` in the previous step: <br><br>**Note:** Save the value of the "KeyMaterial" field as a file in a secure location. This is your private key that you can use to SSH into the render farm.
-```ts
-public readonly keyPairName: string = '<key-name>';
-```
-8. Choose the type of database you would like to deploy and change the value of the `deployMongoDB` variable in `bin/config.ts` accordingly:
-```ts
-// true = MongoDB, false = Amazon DocumentDB
-public readonly deployMongoDB: boolean = false;
-```
-9. If you set `deployMongoDB` to `true`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `acceptSsplLicense` in `bin/config.ts`:
-```ts
-public readonly acceptSsplLicense: MongoDbSsplLicenseAcceptance = <value>;
-```
+
+    ```ts
+    public readonly keyPairName: string = '<key-name>';
+    ```
+8.  Choose the type of database you would like to deploy and change the value of the `deployMongoDB` variable in `bin/config.ts` accordingly:
+
+    ```ts
+    // true = MongoDB, false = Amazon DocumentDB
+    public readonly deployMongoDB: boolean = false;
+    ```
+9.  If you set `deployMongoDB` to `true`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `acceptSsplLicense` in `bin/config.ts`:
+
+    ```ts
+    public readonly acceptSsplLicense: MongoDbSsplLicenseAcceptance = <value>;
+    ```
 10. Modify the `deadline_ver` field in the `config` block of `package.json` as desired, then stage the Docker recipes for `RenderQueue` and `UBLLicensing`:
-```
-yarn stage
-```
+
+    ```
+    yarn stage
+    ```
 11. Build the sample app:
-```
-yarn build
-```
+
+    ```
+    yarn build
+    ```
 12. Deploy all the stacks in the sample app:
-```
-cdk deploy "*"
-```
+
+    ```
+    cdk deploy "*"
+    ```
 13. Once you are finished with the sample app, you can tear it down by running:
-```
-cdk destroy "*"
-```
+
+    ```
+    cdk destroy "*"
+    ```

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
@@ -29,17 +29,25 @@ These instructions assume that your working directory is `examples/deadline/All-
 3.  Create a binary secret in [SecretsManager](https://aws.amazon.com/secrets-manager/) that contains your [Usage-Based Licensing](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/aws-portal/licensing-setup.html?highlight=usage%20based%20licensing) certificates in a `.zip` file:
 
     ```
-    aws secretsmanager create-secret --name <name> --secret-binary fileb://  <path-to-zip-file>
+    aws secretsmanager create-secret --name <name> --secret-binary fileb://<path-to-zip-file>
     ```
 4.  The output from the previous step will contain the secret's ARN. Change the value of the `ublCertificatesSecretArn` variable in `bin/config.ts` to the secret's ARN:
 
     ```ts
     public readonly ublCertificatesSecretArn: string = '<your-secret-arn>';
     ```
-5.  Choose your UBL limits and change the value of the `ublLicenses` variable in `bin/config.ts` accordingly:
+5.  Choose your UBL limits and change the value of the `ublLicenses` variable in `bin/config.ts` accordingly. For example:
 
     ```ts
-    public readonly ublLicenses: UsageBasedLicense[] = [ /* <your-ubl-limits> (e.g.   UsageBasedLicense.forMaya(10)) */ ];
+    public readonly ublLicenses: UsageBasedLicense[] = [
+      // your UBL limits, for example:
+
+      // up to 10 concurrent Maya licenses used at once
+      UsageBasedLicense.forMaya(10),
+
+      // unlimited Arnold licenses
+      UsageBasedLicense.forArnold()
+    ];
     ```
 
     ---
@@ -52,12 +60,16 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```
     aws ec2 create-key-pair --key-name <key-name>
     ```
-7.  Change the value of the `keyPairName` variable in `bin/config.ts` to your value for `<key-name>` in the previous step: <br><br>**Note:** Save the value of the "KeyMaterial" field as a file in a secure location. This is your private key that you can use to SSH into the render farm.
+7.  Change the value of the `keyPairName` variable in `bin/config.ts` to your value for `<key-name>` in the previous step:
+
+    **Note:** Save the value of the `"KeyMaterial"` field as a file in a secure location. This is your private key that you can use to SSH into the render farm.
 
     ```ts
     public readonly keyPairName: string = '<key-name>';
     ```
-8.  Choose the type of database you would like to deploy and change the value of the `deployMongoDB` variable in `bin/config.ts` accordingly:
+8.  Choose the type of database you would like to deploy (AWS DocumentDB or MongoDB).
+    If you would like to use MongoDB, you will need to accept the Mongo SSPL (see next step).
+    Once you've decided on a database type, change the value of the `deployMongoDB` variable in `bin/config.ts` accordingly:
 
     ```ts
     // true = MongoDB, false = Amazon DocumentDB
@@ -66,9 +78,10 @@ These instructions assume that your working directory is `examples/deadline/All-
 9.  If you set `deployMongoDB` to `true`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `acceptSsplLicense` in `bin/config.ts`:
 
     ```ts
-    public readonly acceptSsplLicense: MongoDbSsplLicenseAcceptance = <value>;
+    // To accept the MongoDB SSPL, change from USER_REJECTS_SSPL to USER_ACCEPTS_SSPL
+    public readonly acceptSsplLicense: MongoDbSsplLicenseAcceptance = MongoDbSsplLicenseAcceptance.USER_REJECTS_SSPL;
     ```
-10. Modify the `deadline_ver` field in the `config` block of `package.json` as desired, then stage the Docker recipes for `RenderQueue` and `UBLLicensing`:
+10. Modify the `deadline_ver` field in the `config` block of `package.json` as desired (Deadline 10.1.9 and up are supported), then stage the Docker recipes for `RenderQueue` and `UBLLicensing`:
 
     ```
     yarn stage


### PR DESCRIPTION
## Issue(s)

Fixes #105

## Changes

- The python example app README gave instructions for using the TypeScript `UsageBasedLicense` API. Fixed to use the python API.
- Also fix up formatting in README markdown for both example app languages. The code blocks are now indented properly with each step's list item

## Testing

-   Visually inspected the rendered markdown in VSCode's and GitHub's rendered markdown
-   Confirmed that the example APIs mentioned in the docs work properly using RFDK python packages:

    ```py
    UsageBasedLicense.for_maya(10)
    UsageBasedLicense.for_arnold()
    ```


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
