### PR TITLE
chore(repo): auto approve Dependabot PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
       - dependency-name: "@aws-cdk/*"
     commit-message:
       prefix: "chore(deps):"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of .github/workflows
+    schedule:
+      interval: "daily"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,15 @@
+# Automatically approve PRs made by Dependabot
+
+name: Auto Approve Dependabot PR's
+
+on:
+  pull_request
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
- Adds support for using the auto approve GitHub action to automatically
approve PR's from Dependabot
- Adds support for using Dependabot to update the version of any GitHub
actions we are using
- Closes #112 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
