### PR TITLE
fix(examples): fix mismatched cdk core module version in ts example

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/package.json
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/package.json
@@ -24,7 +24,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.57.0",
+    "@aws-cdk/core": "1.61.1",
     "aws-rfdk": "0.17.0",
     "source-map-support": "^0.5.19"
   }


### PR DESCRIPTION
## Problem

The TypeScript example app in `examples/deadline/All-In-AWS-Infrastructure-Basic/ts` had specified a mismatched version of `@aws-cdk/core` in its dependencies. When trying to build the example with:

```bash
yarn run build
```

The following errors like the following were being output:

```bash
lib/compute-tier.ts:77:44 - error TS2345: Argument of type 'this' is not assignable to parameter of type 'Construct'.
  Type 'ComputeTier' is not assignable to type 'Construct'.
    Types of property 'node' are incompatible.
      Type 'import("/my/checkout/rfdk-example/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/node_modules/@aws-cdk/core/lib/construct-compat").ConstructNode' is not assignable to type 'import("/my/checkout/rfdk-example/node_modules/@aws-cdk/core/lib/construct-compat").ConstructNode'.
```

## Change

Correcting the dependency version from ~~1.57.0~~ &rarr; 1.61.1 resolved the errors.

## Testing

Followed the instructions in the example's `README.md` file and successfully deployed the example app.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
