### PR TITLE
chore(examples): Clean unused example app code and README 

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/README.md
@@ -74,7 +74,7 @@ This sample application deploys a basic Deadline Render farm using Usage-Based L
 | |                                                   |   v     v     v   |              | Health Monitor |            | |
 | |                                                   | +-++         ++-+ |              |                |            | |
 | |                                                   | |  |   ...   |  | |    Monitors  |   +-------+    |            | |
-| |                                                   | +--+         +--+ <--------------+   |  NLB  |    |            | |
+| |                                                   | +--+         +--+ <--------------+   |  ALB  |    |            | |
 | |                                                   |                   |              |   +-------+    |            | |
 | |                                                   +-------------------+              |                |            | |
 | |                                                                                      +----------------+            | |

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
@@ -66,10 +66,7 @@ const network = new NetworkTier(app, 'NetworkTier', { env });
 // --- Security Tier --- //
 // --------------------- //
 
-const security = new SecurityTier(app, 'SecurityTier', {
-  env,
-  vpc: network.vpc,
-});
+const security = new SecurityTier(app, 'SecurityTier', { env });
 
 // -------------------- //
 // --- Storage Tier --- //

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/security-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/security-tier.ts
@@ -3,23 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  IVpc,
-} from '@aws-cdk/aws-ec2';
 import * as cdk from '@aws-cdk/core';
 import {
   X509CertificatePem,
 } from 'aws-rfdk';
-
-/**
- * Properties for {@link SecurityTier}.
- */
-export interface SecurityTierProps extends cdk.StackProps {
-  /**
-   * The VPC to deploy resources into.
-   */
-  readonly vpc: IVpc;
-}
 
 /**
  * The security tier of the render farm. This stack contains resources used to
@@ -37,7 +24,7 @@ export class SecurityTier extends cdk.Stack {
    * @param id The ID of this construct.
    * @param props The properties for the security tier.
    */
-  constructor(scope: cdk.Construct, id: string, props: SecurityTierProps) {
+  constructor(scope: cdk.Construct, id: string, props: cdk.StackProps) {
     super(scope, id, props);
 
     this.rootCa = new X509CertificatePem(this, 'RootCA', {


### PR DESCRIPTION
Removed unused code found in the Typescript that was discovered while reviewing the Python version of it. Also fixed a typo in the README.md.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
