### PR TITLE
chore: add linting for type annotation spacing

### DIFF
--- a/integ/components/_infrastructure/lib/network-tier.ts
+++ b/integ/components/_infrastructure/lib/network-tier.ts
@@ -7,9 +7,9 @@ import { Vpc }from '@aws-cdk/aws-ec2';
 import { Construct, Stack, StackProps } from '@aws-cdk/core';
 
 export class NetworkTier extends Stack {
-  public readonly vpc:Vpc;
+  public readonly vpc: Vpc;
 
-  constructor(scope:Construct, id:string, props?:StackProps) {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // Workaround: the maxAZs are limited to prevent exceeding account limits on subaddresses

--- a/integ/components/deadline/common/functions/awaitSsmCommand.ts
+++ b/integ/components/deadline/common/functions/awaitSsmCommand.ts
@@ -8,13 +8,13 @@ import * as SSM from 'aws-sdk/clients/ssm';
 const ssm = new SSM;
 
 interface CommandResponse {
-  output:string;
-  responseCode:number;
+  output: string;
+  responseCode: number;
 }
 
 // Custom function to send SSM command to run a particular script on the bastion instance,
 // wait for it to finish executing, then return the response.
-export default function awaitSsmCommand(bastionId:string, params:SSM.SendCommandRequest){
+export default function awaitSsmCommand(bastionId: string, params: SSM.SendCommandRequest){
   return new Promise<CommandResponse>( async (res) => {
 
     // Send the command

--- a/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
+++ b/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
@@ -17,7 +17,7 @@ const integStackTag = process.env.INTEG_STACK_TAG!.toString();
 
 const componentTier = new Stack(app, 'RFDKInteg-DL-ComponentTier' + integStackTag, {env});
 
-const structs:Array<StorageStruct> = [
+const structs: Array<StorageStruct> = [
   new StorageStruct(componentTier, 'StorageStruct1', {
     integStackTag,
   }),

--- a/integ/components/deadline/deadline_01_repository/lib/repository-testing-tier.ts
+++ b/integ/components/deadline/deadline_01_repository/lib/repository-testing-tier.ts
@@ -18,7 +18,7 @@ export interface RepositoryTestingTierProps extends TestingTierProps {
   /**
    * Array of StorageStructs representing different test cases
    */
-  readonly structs:Array<StorageStruct>;
+  readonly structs: Array<StorageStruct>;
 }
 
 /**
@@ -37,7 +37,7 @@ export interface RepositoryTestingTierProps extends TestingTierProps {
  *   At execution the tests retrieve the value of secrets for the database password and authentication cert.
  */
 export class RepositoryTestingTier extends TestingTier {
-  constructor(scope:Construct, id:string, props:RepositoryTestingTierProps) {
+  constructor(scope: Construct, id: string, props: RepositoryTestingTierProps) {
     super(scope, id, props);
 
     const structs = props.structs;
@@ -72,7 +72,7 @@ export class RepositoryTestingTier extends TestingTier {
    * @param testSuiteId Test case to configure the repository for
    * @param repo Repository object to connect to the test Bastion
    */
-  private configureRepo(testSuiteId:string, repo:Repository) {
+  private configureRepo(testSuiteId: string, repo: Repository) {
 
     repo.fileSystem.mountToLinuxInstance(this.testInstance.instance, {
       location: '/mnt/efs/fs' + testSuiteId.toLowerCase(),

--- a/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
+++ b/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
@@ -20,15 +20,15 @@ const dbRegex = /DatabaseSecretARNDL(\d)/;
 const logRegex = /logGroupNameDL(\d)/;
 const certRegex = /CertSecretARNDL(\d)/;
 
-const testCases:Array<Array<any>> = [
+const testCases: Array<Array<any>> = [
   [ 'RFDK-created DB and EFS', 1 ],
   [ 'User-created DB and EFS', 2 ],
   [ 'User-created MongoDB', 3],
 ];
-let bastionId:string;
-let dbSecretARNs:Array<any> = [];
-let logGroupNames:Array<any> = [];
-let certSecretARNs:Array<any> = [];
+let bastionId: string;
+let dbSecretARNs: Array<any> = [];
+let logGroupNames: Array<any> = [];
+let certSecretARNs: Array<any> = [];
 
 
 beforeAll( () => {

--- a/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
+++ b/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
@@ -26,7 +26,7 @@ const storage = new StorageStruct(componentTier, 'StorageStruct', {
   databaseType: DatabaseType.DocDB,
 });
 
-const structs:Array<RenderStruct> = [
+const structs: Array<RenderStruct> = [
   // Create test struct for Render Queue in http mode
   new RenderStruct(componentTier, 'RenderStructRQ1', {
     integStackTag,

--- a/integ/components/deadline/deadline_02_renderQueue/lib/renderQueue-testing-tier.ts
+++ b/integ/components/deadline/deadline_02_renderQueue/lib/renderQueue-testing-tier.ts
@@ -15,7 +15,7 @@ export interface RenderQueueTestingTierProps extends TestingTierProps {
   /**
    * Array of RenderStructs representing different test cases
    */
-  readonly structs:Array<RenderStruct>;
+  readonly structs: Array<RenderStruct>;
 }
 
 /**
@@ -34,7 +34,7 @@ export interface RenderQueueTestingTierProps extends TestingTierProps {
  *   At execution the tests retrieve the value of secrets for the authentication cert.
  */
 export class RenderQueueTestingTier extends TestingTier {
-  constructor(scope:Construct, id:string, props:RenderQueueTestingTierProps) {
+  constructor(scope: Construct, id: string, props: RenderQueueTestingTierProps) {
     super(scope, id, props);
 
     const structs = props.structs;

--- a/integ/components/deadline/deadline_02_renderQueue/test/deadline_02_renderQueue.test.ts
+++ b/integ/components/deadline/deadline_02_renderQueue/test/deadline_02_renderQueue.test.ts
@@ -16,13 +16,13 @@ const bastionRegex = /bastionId/;
 const rqRegex = /renderQueueEndpointRQ(\d)/;
 const certRegex = /CertSecretARNRQ(\d)/;
 
-const testCases:Array<Array<any>> = [
+const testCases: Array<Array<any>> = [
   [ 'HTTP mode', 1 ],
   [ 'HTTPS mode (TLS)', 2],
 ];
-let bastionId:any;
-let renderQueueEndpoints:Array<string> = [];
-let secretARNs:Array<string> = [];
+let bastionId: any;
+let renderQueueEndpoints: Array<string> = [];
+let secretARNs: Array<string> = [];
 
 beforeAll( () => {
   // Query the TestingStack and await its outputs to use as test inputs

--- a/integ/components/deadline/deadline_03_workerFleet/bin/deadline_03_workerFleet.ts
+++ b/integ/components/deadline/deadline_03_workerFleet/bin/deadline_03_workerFleet.ts
@@ -22,7 +22,7 @@ const integStackTag = process.env.INTEG_STACK_TAG!.toString();
 const oss = ['Linux','Windows'];
 const protocols = ['http','https'];
 
-let structs:Array<WorkerStruct> = [];
+let structs: Array<WorkerStruct> = [];
 let i = 1;
 oss.forEach( os => {
   protocols.forEach( protocol => {

--- a/integ/components/deadline/deadline_03_workerFleet/lib/workerFleet-testing-tier.ts
+++ b/integ/components/deadline/deadline_03_workerFleet/lib/workerFleet-testing-tier.ts
@@ -17,7 +17,7 @@ export interface WorkerFleetTestingTierProps extends TestingTierProps {
   /**
    * Array of WorkerStructs representing different test cases
    */
-  readonly structs:Array<WorkerStruct>;
+  readonly structs: Array<WorkerStruct>;
 }
 
 /**
@@ -36,7 +36,7 @@ export interface WorkerFleetTestingTierProps extends TestingTierProps {
  *   At execution the tests retrieve the value of secrets for the authentication cert.
  */
 export class WorkerFleetTestingTier extends TestingTier {
-  constructor(scope:Construct, id:string, props:WorkerFleetTestingTierProps) {
+  constructor(scope: Construct, id: string, props: WorkerFleetTestingTierProps) {
     super(scope, id, props);
 
     const structs = props.structs;
@@ -65,7 +65,7 @@ export class WorkerFleetTestingTier extends TestingTier {
    *
    * @param workerFleet Array of worker instances to connect to the test Bastion
    */
-  public configureWorkerFleet(workerFleet:Array<IWorkerFleet>) {
+  public configureWorkerFleet(workerFleet: Array<IWorkerFleet>) {
     workerFleet.forEach( worker => {
       this.testInstance.connections.allowTo(worker, Port.tcp(22));
     });

--- a/integ/components/deadline/deadline_03_workerFleet/test/deadline_03_workerFleet.test.ts
+++ b/integ/components/deadline/deadline_03_workerFleet/test/deadline_03_workerFleet.test.ts
@@ -16,15 +16,15 @@ const bastionRegex = /bastionId/;
 const rqRegex = /renderQueueEndpointWF(\d)/;
 const certRegex = /CertSecretARNWF(\d)/;
 
-const testCases:Array<Array<any>> = [
+const testCases: Array<Array<any>> = [
   [ 'Linux Worker HTTP mode', 1 ],
   [ 'Linux Worker HTTPS (TLS) mode', 2 ],
   [ 'Windows Worker HTTP mode', 3 ],
   [ 'Windows Worker HTTPS (TLS) mode', 4 ],
 ];
-let bastionId:any;
-let renderQueueEndpoints:Array<string> = [];
-let secretARNs:Array<string> = [];
+let bastionId: any;
+let renderQueueEndpoints: Array<string> = [];
+let secretARNs: Array<string> = [];
 
 beforeAll( () => {
   // Query the TestingStack and await its outputs to use as test inputs

--- a/integ/lib/render-struct.ts
+++ b/integ/lib/render-struct.ts
@@ -11,16 +11,16 @@ import { X509CertificatePem } from 'aws-rfdk';
 import { IRepository, RenderQueue, Stage, ThinkboxDockerRecipes } from 'aws-rfdk/deadline';
 
 export interface RenderStructProps {
-  readonly integStackTag:string;
-  readonly repository:IRepository;
-  readonly protocol:string;
+  readonly integStackTag: string;
+  readonly repository: IRepository;
+  readonly protocol: string;
 }
 
 export class RenderStruct extends Construct {
-  public readonly renderQueue:RenderQueue;
-  public readonly cert:X509CertificatePem | undefined;
+  public readonly renderQueue: RenderQueue;
+  public readonly cert: X509CertificatePem | undefined;
 
-  constructor(scope:Construct, id:string, props:RenderStructProps) {
+  constructor(scope: Construct, id: string, props: RenderStructProps) {
     super(scope, id);
 
     // Collect environment variables

--- a/integ/lib/storage-struct.ts
+++ b/integ/lib/storage-struct.ts
@@ -15,9 +15,9 @@ import { DatabaseConnection, Repository, Stage, ThinkboxDockerRecipes } from 'aw
 
 // Interface for supplying database connection and accompanying secret for credentials
 export interface IRenderFarmDb {
-  db:DatabaseCluster | MongoDbInstance,
-  secret:ISecret,
-  cert?:X509CertificatePem,
+  db: DatabaseCluster | MongoDbInstance,
+  secret: ISecret,
+  cert?: X509CertificatePem,
 }
 
 export enum DatabaseType {
@@ -26,16 +26,16 @@ export enum DatabaseType {
 }
 
 export interface StorageStructProps {
-  readonly integStackTag:string;
-  readonly databaseType?:DatabaseType;
+  readonly integStackTag: string;
+  readonly databaseType?: DatabaseType;
 }
 
 export class StorageStruct extends Construct {
-  public readonly repo:Repository;
-  public readonly database:IRenderFarmDb;
-  public readonly efs:FileSystem;
+  public readonly repo: Repository;
+  public readonly database: IRenderFarmDb;
+  public readonly efs: FileSystem;
 
-  constructor(scope:Construct, id:string, props:StorageStructProps) {
+  constructor(scope: Construct, id: string, props: StorageStructProps) {
     super(scope, id);
 
     // Confirm that user has accepted SSPL license to use mongoDB

--- a/integ/lib/testing-tier.ts
+++ b/integ/lib/testing-tier.ts
@@ -18,7 +18,7 @@ interface UserDataConfigProps {
   /**
    * Local path to the framework directory containing the testing script to be copied to the Bastion
    */
-  readonly testingScriptPath:string;
+  readonly testingScriptPath: string;
 }
 
 /**
@@ -28,7 +28,7 @@ export interface TestingTierProps extends StackProps {
   /**
    * The unique suffix given to all stacks in the testing app
    */
-  readonly integStackTag:string;
+  readonly integStackTag: string;
 }
 
 /**
@@ -38,19 +38,19 @@ export abstract class TestingTier extends Stack {
   /**
    * The Bastion instance used for communicating with the farm and executing test cases
    */
-  public readonly testInstance:BastionHostLinux;
+  public readonly testInstance: BastionHostLinux;
 
   /**
    * The version of Deadline used for installing DeadlineClient. Must be set by env variable before test execution.
    */
-  private deadlineVersion:string = process.env.DEADLINE_VERSION!.toString();
+  private deadlineVersion: string = process.env.DEADLINE_VERSION!.toString();
 
   /**
    * Full path to locally staged Deadline assets. Must be set by env variable before test execution.
    */
-  private stagePath:string = process.env.DEADLINE_STAGING_PATH!.toString();
+  private stagePath: string = process.env.DEADLINE_STAGING_PATH!.toString();
 
-  constructor(scope:Construct, id:string, props:TestingTierProps) {
+  constructor(scope: Construct, id: string, props: TestingTierProps) {
     super(scope, id, props);
 
     const infrastructureStackName = 'RFDKIntegInfrastructure' + props.integStackTag;
@@ -82,7 +82,7 @@ export abstract class TestingTier extends Stack {
    * @param testSuiteId Test case to configure the cert for
    * @param cert Certificate for authenticating to the database/render queue used for this test case
    */
-  public configureCert(testSuiteId:string, cert?:X509CertificatePem) {
+  public configureCert(testSuiteId: string, cert?: X509CertificatePem) {
     if(cert) {
       cert.cert.grantRead(this.testInstance);
       new CfnOutput(this, 'CertSecretARN' + testSuiteId, {
@@ -97,7 +97,7 @@ export abstract class TestingTier extends Stack {
    * @param testSuiteId Test case to configure the database for
    * @param database Database object to connect to the test Bastion
    */
-  public configureDatabase(testSuiteId:string, database:IRenderFarmDb) {
+  public configureDatabase(testSuiteId: string, database: IRenderFarmDb) {
     const db = database.db;
     const dbSecret = database.secret!;
 
@@ -115,7 +115,7 @@ export abstract class TestingTier extends Stack {
    * @param testSuiteId Test case to configure the render queue for
    * @param renderQueue Render queue object to connect to the test Bastion
    */
-  public configureRenderQueue(testSuiteId: string, renderQueue:RenderQueue) {
+  public configureRenderQueue(testSuiteId: string, renderQueue: RenderQueue) {
 
     const port = renderQueue.endpoint.portAsString();
     const zoneName = Stack.of(renderQueue).stackName + '.local';
@@ -169,7 +169,7 @@ export abstract class TestingTier extends Stack {
    *
    * @param props Options for configuring Bastion userData
    */
-  public configureBastionUserData(props:UserDataConfigProps) {
+  public configureBastionUserData(props: UserDataConfigProps) {
     this.testInstance.instance.instance.cfnOptions.creationPolicy = {
       ...this.testInstance.instance.instance.cfnOptions.creationPolicy,
       resourceSignal: {

--- a/integ/lib/worker-struct.ts
+++ b/integ/lib/worker-struct.ts
@@ -10,18 +10,18 @@ import { IWorkerFleet, RenderQueue, WorkerInstanceFleet } from 'aws-rfdk/deadlin
 import { RenderStruct } from './render-struct';
 
 export interface WorkerStructProps {
-  readonly integStackTag:string;
-  readonly renderStruct:RenderStruct;
-  readonly os:string;
+  readonly integStackTag: string;
+  readonly renderStruct: RenderStruct;
+  readonly os: string;
 }
 
 export class WorkerStruct extends Construct {
 
-  readonly workerFleet:Array<IWorkerFleet> = [];
-  readonly renderQueue:RenderQueue;
-  readonly cert?:X509CertificatePem;
+  readonly workerFleet: Array<IWorkerFleet> = [];
+  readonly renderQueue: RenderQueue;
+  readonly cert?: X509CertificatePem;
 
-  constructor(scope:Construct, id:string, props:WorkerStructProps) {
+  constructor(scope: Construct, id: string, props: WorkerStructProps) {
     super(scope, id);
 
     // Collect environment variables

--- a/tools/cdk-build-tools/.eslintrc.js
+++ b/tools/cdk-build-tools/.eslintrc.js
@@ -1,4 +1,7 @@
 const baseConfig = require('./config/eslintrc');
 baseConfig.parserOptions.project = __dirname + '/tsconfig.json';
 baseConfig.rules["license-header/header"][0] = 'off';
+// Disable linting of white-space between the TyepScript type annotation syntax on this package to help merge
+// upstream code.
+baseConfig.rules["@typescript-eslint/type-annotation-spacing"][0] = 'off';
 module.exports = baseConfig;

--- a/tools/cdk-build-tools/config/eslintrc.js
+++ b/tools/cdk-build-tools/config/eslintrc.js
@@ -42,6 +42,28 @@ module.exports = {
     // Require use of the `import { foo } from 'bar';` form instead of `import foo = require('bar');`
     '@typescript-eslint/no-require-imports': [ 'error' ],
     '@typescript-eslint/indent': [ 'error', 2 ],
+    // Rule to lint white-space between the TyepScript type annotation syntax
+    // e.g.
+    //    const foo: number; // Good
+    //    const foo :number; // Bad
+    //    const foo:number;  // Bad
+    '@typescript-eslint/type-annotation-spacing': [
+      // Error level (fail the lint)
+      'error',
+      // Rule options
+      {
+        // No whitespace before the colon
+        before: false,
+        // Must have whitespace after the colon
+        after: true,
+        overrides: {
+          arrow: {
+            before: true,
+            after: true,
+          },
+        },
+      },
+    ],
 
     // Style
     'quotes': [ 'error', 'single', { avoidEscape: true } ],

--- a/tools/pkglint/.eslintrc.js
+++ b/tools/pkglint/.eslintrc.js
@@ -1,4 +1,7 @@
 const baseConfig = require('cdk-build-tools/config/eslintrc');
 baseConfig.parserOptions.project = __dirname + '/tsconfig.json';
 baseConfig.rules["license-header/header"][0] = 'off';
+// Disable linting of white-space between the TyepScript type annotation syntax on this package to help merge
+// upstream code.
+baseConfig.rules["@typescript-eslint/type-annotation-spacing"][0] = 'off';
 module.exports = baseConfig;


### PR DESCRIPTION
# Change

Fixes: #132 

Enables linting of the whitespace between variables and their TypeScript type annotations. I disabled the rule for the `cdk-build` and `pkglint` source code. They have violations to this rule, but this helps remove merge conflicts when integrating upstream changes from CDK.

Fixed all rule violations - only ones found were in the `integ` package.

# Testing

Ran the build before fixing violations and confirmed that the linter successfully identified violations and failed the build. After fixing the violations, re-ran the build and confirmed that the linting passed.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
