### PR TITLE
feat(deadline): add ability to add spot event plugin managed policies to RenderQueue

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -39,6 +39,7 @@ import {
 import {
   IGrantable,
   IPrincipal,
+  ManagedPolicy,
   PolicyStatement,
   ServicePrincipal,
 } from '@aws-cdk/aws-iam';
@@ -456,6 +457,23 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
   public configureClientInstance(param: InstanceConnectOptions): void {
     this.addChildDependency(param.host);
     this.rqConnection.configureClientInstance(param);
+  }
+
+  /**
+   * Adds AWS Managed Policies to the Render Queue so it is able to control Deadlines Spot Event Plugin.
+   *
+   * See: https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/event-spot.html for additonal information.
+   *
+   * @param includeResourceTracker Whether or not the Resource tracker admin policy should also be addd (Default: True)
+   */
+  public addSEPPolicies( includeResourceTracker: boolean = true): void {
+    const sepPolicy = ManagedPolicy.fromAwsManagedPolicyName('AWSThinkboxDeadlineSpotEventPluginAdminPolicy');
+    this.taskDefinition.taskRole.addManagedPolicy(sepPolicy);
+
+    if (includeResourceTracker) {
+      const rtPolicy = ManagedPolicy.fromAwsManagedPolicyName('AWSThinkboxDeadlineResourceTrackerAdminPolicy');
+      this.taskDefinition.taskRole.addManagedPolicy(rtPolicy);
+    }
   }
 
   /**

--- a/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
@@ -6,14 +6,14 @@
 import {
   ABSENT,
   arrayWith,
-  not,
+  countResourcesLike,
   deepObjectLike,
   expect as expectCDK,
   haveResource,
   haveResourceLike,
+  not,
   objectLike,
   ResourcePart,
-  countResourcesLike,
 } from '@aws-cdk/assert';
 import {
   Certificate,
@@ -2197,5 +2197,76 @@ describe('RenderQueue', () => {
         'AWS::ECS::Service': 1,
       },
     });
+  });
+
+  describe('SEP Policies', () => {
+    test('with resource tracker', () => {
+      renderQueueCommon.addSEPPolicies();
+      expectCDK(stack).to(countResourcesLike('AWS::IAM::Role', 1, {
+        ManagedPolicyArns: arrayWith(
+          {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                {
+                  Ref: 'AWS::Partition',
+                },
+                ':iam::aws:policy/AWSThinkboxDeadlineSpotEventPluginAdminPolicy',
+              ],
+            ],
+          },
+          {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                {
+                  Ref: 'AWS::Partition',
+                },
+                ':iam::aws:policy/AWSThinkboxDeadlineResourceTrackerAdminPolicy',
+              ],
+            ],
+          },
+        ),
+      }));
+    });
+
+    test('no resource tracker', () => {
+      renderQueueCommon.addSEPPolicies(false);
+      expectCDK(stack).to(haveResourceLike('AWS::IAM::Role', {
+        ManagedPolicyArns: arrayWith(
+          {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                {
+                  Ref: 'AWS::Partition',
+                },
+                ':iam::aws:policy/AWSThinkboxDeadlineSpotEventPluginAdminPolicy',
+              ],
+            ],
+          },
+        ),
+      }));
+      expectCDK(stack).notTo(haveResourceLike('AWS::IAM::Role', {
+        ManagedPolicyArns: arrayWith(
+          {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                {
+                  Ref: 'AWS::Partition',
+                },
+                ':iam::aws:policy/AWSThinkboxDeadlineResourceTrackerAdminPolicy',
+              ],
+            ],
+          },
+        ),
+      }));
+    });
+
   });
 });


### PR DESCRIPTION
Adds a helper function to the RenderQueue to add the requisite managed policies
for the SEP.


### Testing
Tested by launching a renderfarm and configuring the SEP without setting any credentials in deadline to confirm the EC2 Instance role worked correctly.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
