### PR TITLE
feat(integ): add ability to use hook function before each component test

### DIFF
--- a/integ/scripts/bash/rfdk-integ-e2e.sh
+++ b/integ/scripts/bash/rfdk-integ-e2e.sh
@@ -73,6 +73,12 @@ export INFRASTRUCTURE_DEPLOY_FINISH_TIME=$SECONDS
 for COMPONENT in **/cdk.json; do
     COMPONENT_ROOT="$(dirname "$COMPONENT")"
     COMPONENT_NAME=$(basename "$COMPONENT_ROOT")
+    # Invoke hook function if it is exported and name is defined in PRE_COMPONENT_HOOK variable
+    if [ -n "$PRE_COMPONENT_HOOK" ]  && [ "$(type -t $PRE_COMPONENT_HOOK)" == "function" ]
+    then
+      $PRE_COMPONENT_HOOK $COMPONENT_NAME
+    fi
+
     # Use a pattern match to exclude the infrastructure app from the results
     export ${COMPONENT_NAME}_START_TIME=$SECONDS
     if [[ "$COMPONENT_NAME" != _* ]]; then


### PR DESCRIPTION
## Problem
In the main integ-rfdk-e2e.sh we need to add the ability to run an extra function if it is designed.

## Solution
Added functionality to invoke script in case when environment variable `PRE_COMPONENT_HOOK` is defined and function with such name was exported.

## Testing
Script was tested locally with all cases like: correct function, undefined variable or function name is incorrect.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
