### PR TITLE
fix(core): Remove encryption on lifecycle SNS Topic

### DIFF
--- a/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
+++ b/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
@@ -8,7 +8,6 @@ import {
   countResources,
   countResourcesLike,
   expect as cdkExpect,
-  expect as expectCDK,
   haveResourceLike,
   objectLike,
   ResourcePart,
@@ -93,48 +92,8 @@ describe('Test StaticIpServer', () => {
       Description: 'Created by RFDK StaticPrivateIpServer to process instance launch lifecycle events in stack \'StackName\'. This lambda attaches an ENI to newly launched instances.',
     }));
 
-    expectCDK(stack).to(haveResourceLike('AWS::KMS::Key', {
-      UpdateReplacePolicy: 'Delete',
-      DeletionPolicy: 'Delete',
-    }, ResourcePart.CompleteDefinition));
-    expectCDK(stack).to(haveResourceLike('AWS::KMS::Key', {
-      KeyPolicy: {
-        Statement: [
-          {
-            Action: 'kms:*',
-            Effect: 'Allow',
-            Principal: {
-              AWS: {
-                'Fn::Join': [
-                  '',
-                  [
-                    'arn:',
-                    {
-                      Ref: 'AWS::Partition',
-                    },
-                    ':iam::',
-                    {
-                      Ref: 'AWS::AccountId',
-                    },
-                    ':root',
-                  ],
-                ],
-              },
-            },
-            Resource: '*',
-          },
-        ],
-      },
-      EnableKeyRotation: true,
-    }));
     cdkExpect(stack).to(haveResourceLike('AWS::SNS::Topic', {
       DisplayName: 'For RFDK instance-launch notifications for stack \'StackName\'',
-      KmsMasterKeyId: {
-        'Fn::GetAtt': [
-          'SNSEncryptionKey255e9e52ad034ddf8ff8274bc10d63d1EDF79FFE',
-          'Arn',
-        ],
-      },
     }));
 
     cdkExpect(stack).to(haveResourceLike('AWS::SNS::Subscription', {
@@ -214,19 +173,6 @@ describe('Test StaticIpServer', () => {
     cdkExpect(stack).to(countResourcesLike('AWS::IAM::Policy', 1, {
       PolicyDocument: {
         Statement: [
-          {
-            Action: [
-              'kms:Decrypt',
-              'kms:GenerateDataKey',
-            ],
-            Effect: 'Allow',
-            Resource: {
-              'Fn::GetAtt': [
-                'SNSEncryptionKey255e9e52ad034ddf8ff8274bc10d63d1EDF79FFE',
-                'Arn',
-              ],
-            },
-          },
           {
             Action: 'sns:Publish',
             Effect: 'Allow',


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-rfdk/issues/162

The problem is that something changed in the KMS service that the AutoScalingGroup now needs some additional permissions to be able to publish lifecycle events to a KMS-encrypted SNS Topic.  RFDK is not applying whatever those permissions are, and so a deployment will fail.

Solution: Remove encryption from the SNS Topic. An earlier security review concluded that this encryption is not necessary since there is no sensitive information in this SNS Topic -- it is purely Lifecycle Event control messages.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
