### PR TITLE
fix(integ): fix when PRE_COMPONENT_HOOK is undefined

### DIFF
--- a/integ/scripts/bash/rfdk-integ-e2e.sh
+++ b/integ/scripts/bash/rfdk-integ-e2e.sh
@@ -74,7 +74,7 @@ for COMPONENT in **/cdk.json; do
     COMPONENT_ROOT="$(dirname "$COMPONENT")"
     COMPONENT_NAME=$(basename "$COMPONENT_ROOT")
     # Invoke hook function if it is exported and name is defined in PRE_COMPONENT_HOOK variable
-    if [ -n "$PRE_COMPONENT_HOOK" ]  && [ "$(type -t $PRE_COMPONENT_HOOK)" == "function" ]
+    if [ ! -z "${PRE_COMPONENT_HOOK+x}" ]  && [ "$(type -t $PRE_COMPONENT_HOOK)" == "function" ]
     then
       $PRE_COMPONENT_HOOK $COMPONENT_NAME
     fi


### PR DESCRIPTION
Fixes a bug where we were referencing the environment variable PRE_COMPONENT_HOOK in a way that would fail if it were unassigned.

The integration tests were failing during start-up without this fix. They are now able to run with the fix applied.

Fixes #164

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
