### PR TITLE
fix(deadline): Disable client SSL config for HTTP Render Queue

### DIFF
--- a/packages/aws-rfdk/lib/deadline/scripts/python/client-rq-connection.py
+++ b/packages/aws-rfdk/lib/deadline/scripts/python/client-rq-connection.py
@@ -24,7 +24,7 @@ FILE_URI_RE = re.compile(r'^file:///(?P<FilePath>((?:[^/]*/)*)(.*))$')
 # Regex for counting the number of certificates in a cert chain
 CERT_COUNT_RE = re.compile(r'-----BEGIN CERTIFICATE-----')
 
-# Named tuples for storing arguments 
+# Named tuples for storing arguments
 RenderQueue = namedtuple('RenderQueue','uri,scheme,address')
 AwsSecret = namedtuple('AwsSecret','arn,region')
 FileSecret = namedtuple('FileSecret', 'filepath')
@@ -42,7 +42,7 @@ def parse_args(args):
     :param args: A list of command line arguments
     :return: A configuration object containing the parsed arguments
     """
-    
+
     def _secret(value):
         """
         A type function for converting args that represent secrets into a named Tuple
@@ -61,7 +61,7 @@ def parse_args(args):
         if match:
             named_groups = match.groupdict()
             return FileSecret( arn=named_groups['FilePath'] )
-        
+
         raise argparse.ArgumentTypeError('Given argument "%s" is not a valid secret' % value)
 
     def _render_queue(value):
@@ -69,7 +69,7 @@ def parse_args(args):
         A type function for converting args that represent render queue URI's into a named Tuple
 
         :param value: The string representing the argument
-        :return: A RenderQueue named tuple 
+        :return: A RenderQueue named tuple
         :exception argparse.ArgumentTypeError: if the argument cannot be converted properly.
         """
 
@@ -130,15 +130,17 @@ def configure_deadline( config ):
 
     :param config: The parsed configuration object
     """
-    
+
     repo_args = ['ChangeRepository','Proxy',config.render_queue.address]
     if config.render_queue.scheme == 'http':
         print( "Configuring Deadline to connect to the Render Queue (%s) using HTTP Traffic" % config.render_queue.address )
-        #Ensure SSL is disbaled
+        #Ensure SSL is disabled
         call_deadline_command(['SetIniFileSetting','ProxyUseSSL','False'])
+        call_deadline_command(['SetIniFileSetting', 'ProxySSLCA', ''])
+        call_deadline_command(['SetIniFileSetting', 'ClientSSLAuthentication', 'NotRequired'])
 
     else:
-        print("Configuring Deadline to connect to the Render Queue using HTTP Traffic")
+        print("Configuring Deadline to connect to the Render Queue using HTTPS Traffic")
         call_deadline_command(['SetIniFileSetting','ProxyUseSSL','True'])
 
         try:

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -38,6 +38,6 @@ export const REPO_DC_ASSET = {
 };
 
 export const RQ_CONNECTION_ASSET = {
-  Bucket: 'AssetParameters63694479464606109bdbd3525fb2bef7b2abfbf196d8a132832c8e5d8a3c4796S3BucketF3231D14',
-  Key: 'AssetParameters63694479464606109bdbd3525fb2bef7b2abfbf196d8a132832c8e5d8a3c4796S3VersionKeyE501DFB8',
+  Bucket: 'AssetParameters89a29e05a2a88ec4d4a02e847e3c3c9461d0154b326492f4cad655d4ca0bda98S3BucketC22E185C',
+  Key: 'AssetParameters89a29e05a2a88ec4d4a02e847e3c3c9461d0154b326492f4cad655d4ca0bda98S3VersionKey0833D670',
 };


### PR DESCRIPTION
We were failing to start workers up using an HTTP connection to the render queue due to new default settings that were applied in Deadline 10.1.10.

Fixes #165


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
