### PR TITLE
chore(examples): Update Python example deps

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/.gitignore
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/.gitignore
@@ -8,4 +8,5 @@ __pycache__
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+cdk.context.json
 stage

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/config.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/config.py
@@ -29,7 +29,7 @@ class AppConfig:
         self.ubl_licenses: List[UsageBasedLicense] = []
 
         # (Optional) The name of the EC2 keypair to associate with the instances.
-        self.key_pair_name: Optional[str] = ''
+        self.key_pair_name: Optional[str] = None
 
         # Whether to use MongoDB to back the render farm.
         # If false, then we use Amazon DocumentDB to back the render farm.

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
@@ -17,8 +17,8 @@ setuptools.setup(
     packages=setuptools.find_packages(where="package"),
 
     install_requires=[
-        "aws-cdk.core==1.57.0",
-        "aws-rfdk==0.17.0"
+        "aws-cdk.core==1.66.0",
+        "aws-rfdk==0.18.0"
     ],
 
     python_requires=">=3.7",


### PR DESCRIPTION
Fixes https://github.com/aws/aws-rfdk/issues/172

Upgrades the AWS CDK and RFDK versions used by the All in AWS infrastructure Python example app.

This was tested by deploying a render farm using this upgrade and Deadline 10.1.10.6.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
