### PR TITLE
chore(examples): update RFDK version in python app

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
 
     install_requires=[
         "aws-cdk.core==1.70.0",
-        "aws-rfdk==0.18.1"
+        "aws-rfdk==0.19.0"
     ],
 
     python_requires=">=3.7",


### PR DESCRIPTION
The Python example app still uses RFDK v0.18.1 in it's `setup.py`, but we have released v0.19.0. This PR updates the RFDK version in `setup.py` to 0.19.0.

### Testing
- Deployed python sample app successfully

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
