### PR TITLE
chore: updates to the bump script

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -43,8 +43,11 @@ npx standard-version --skip.tag=true --commit-all
 # Get the new version number to do some manual find and replaces
 new_version=$(node -p "require('./package.json').version")
 
-# Update the version of RFDK used in the python example
-sed -i "s/\"aws-rfdk==[0-9]*\.[0-9]*\.[0-9]*\"/\"aws-rfdk==$new_version\"/" ./examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
+# Update the version of RFDK used in the python examples
+for exampleSetupPy in $(find ./examples/ -name 'setup.py')
+do
+  sed -i "s/\"aws-rfdk==[0-9]*\.[0-9]*\.[0-9]*\"/\"aws-rfdk==$new_version\"/" "$exampleSetupPy"
+done
 
 # When standard-version adds a patch release to the changelog, it makes it a smaller header size. This undoes that.
 if [[ $version == "patch" ]]; then

--- a/bump.sh
+++ b/bump.sh
@@ -22,13 +22,13 @@ version=${1:-minor}
 
 cd "$(dirname "$0")"
 
-echo "Starting ${version} version bump"
+echo "Starting $version version bump"
 
 export NODE_OPTIONS="--max-old-space-size=4096 ${NODE_OPTIONS:-}"
 
 /bin/bash ./install.sh
 
-npx lerna version ${version} --yes --exact --no-git-tag-version --no-push
+npx lerna version $version --yes --exact --no-git-tag-version --no-push
 
 # Another round of install to fix package-lock.jsons
 /bin/bash ./install.sh
@@ -39,3 +39,24 @@ npx lerna version ${version} --yes --exact --no-git-tag-version --no-push
 
 # Generate CHANGELOG and create a commit
 npx standard-version --skip.tag=true --commit-all
+
+# Get the new version number to do some manual find and replaces
+new_version=$(node -p "require('./package.json').version")
+
+# Update the version of RFDK used in the python example
+sed -i "s/\"aws-rfdk==[0-9]*\.[0-9]*\.[0-9]*\"/\"aws-rfdk==$new_version\"/" ./examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
+
+# When standard-version adds a patch release to the changelog, it makes it a smaller header size. This undoes that.
+if [[ $version == "patch" ]]; then
+  version_header="#\(## \[$new_version](.*) (.*)\)"
+  sed -i "s|$version_header|\1|" ./CHANGELOG.md
+fi
+
+# Add a section to the changelog that state the version of CDK being used
+version_header="# \[$new_version](.*) (.*)"
+cdk_version=$(node -p "require('./package.json').devDependencies['aws-cdk']")
+cdk_version_section="\n\n\n### Supported CDK Version\n\n* [$cdk_version](https://github.com/aws/aws-cdk/releases/tag/v$cdk_version)"
+sed -i "s|\($version_header\)|\1$cdk_version_section|" ./CHANGELOG.md
+
+git add .
+git commit --amend --no-edit


### PR DESCRIPTION
Fixes #173 and #200

* Added automation for bumping the RFDK version in the python example
* Added automation for adding a section to the changelog that lists the
version of CDK that this version of RFDK depends on

I tested this by running the bump script using both `minor` and `patch` to test both kinds of version bumps.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
