### PR TITLE
feat(deadline): add WorkerInstanceConfiguration construct

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/script-assets.ts
+++ b/packages/aws-rfdk/lib/core/lib/script-assets.ts
@@ -52,6 +52,11 @@ export interface ConventionalScriptPathParams {
  */
 function getConventionalScriptPath(params: ConventionalScriptPathParams): string {
   const { rootDir: scriptDir, baseName: scriptName, osType } = params;
+  // Make sure we have a known osType. The error message is pretty obtuse if we don't:
+  //  The "path" argument must be of type string. Received undefined
+  if (ScriptPathPrefix[osType] === undefined || ScriptExtension[osType] == undefined) {
+    throw Error(`Unknown osType: ${osType}`);
+  }
   return path.join(
     scriptDir,
     ScriptPathPrefix[osType],

--- a/packages/aws-rfdk/lib/core/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/core/test/asset-constants.ts
@@ -29,3 +29,228 @@ export const INSTALL_MONGODB_3_6_SCRIPT_LINUX = {
 export const MONGODB_INSTANCE_3_6_SCRIPT = {
   Bucket: stringLike('AssetParameters*S3Bucket352E624B'),
 };
+
+export function linuxDownloadRunScriptBoilerplate(script: { Bucket: string, Key: string }) {
+  return [
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\')\naws s3 cp \'s3://',
+    {Ref: script.Bucket},
+    '/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' \'/tmp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\'\n' +
+    'set -e\n' +
+    'chmod +x \'/tmp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {
+              Ref: script.Key,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\'\n\'/tmp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+export function windowsDownloadRunScriptBoilerplate(script: { Bucket: string, Key: string }) {
+  return [
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' ) -ea 0\nRead-S3Object -BucketName \'',
+    {Ref: script.Bucket},
+    '\' -key \'',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' -file \'C:/temp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' -ErrorAction Stop\n&\'C:/temp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {
+              Ref: script.Key,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+  ];
+}

--- a/packages/aws-rfdk/lib/deadline/lib/index.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/index.ts
@@ -15,3 +15,4 @@ export * from './thinkbox-docker-recipes';
 export * from './version';
 export * from './version-query';
 export * from './version-ref';
+export * from './worker-configuration';

--- a/packages/aws-rfdk/lib/deadline/lib/worker-configuration.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-configuration.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path';
+
+import {
+  OperatingSystemType,
+} from '@aws-cdk/aws-ec2';
+import {
+  IGrantable,
+} from '@aws-cdk/aws-iam';
+import {
+  Construct,
+  Duration,
+} from '@aws-cdk/core';
+import {
+  CloudWatchAgent,
+  CloudWatchConfigBuilder,
+  IScriptHost,
+  LogGroupFactory,
+  LogGroupFactoryProps,
+  ScriptAsset,
+} from '../../core';
+import { Version } from './version';
+
+/**
+ * Interface for Deadline clients that can be configured via the ClientConfiguration
+ * helper class.
+ */
+export interface IConfigurableWorker extends IScriptHost, IGrantable {
+}
+
+/**
+ * The Deadline Worker settings that can be configured via the configureWorkerSettings method
+ * of the WorkerConfiguration helper class.
+ */
+export interface WorkerSettings {
+  /**
+   * Deadline groups these workers needs to be assigned to. The group is
+   * created if it does not already exist.
+   *
+   * @default - Worker is not assigned to any group
+   */
+  readonly groups?: string[];
+
+  /**
+   * Deadline pools these workers needs to be assigned to. The pool is created
+   * if it does not already exist.
+   *
+   * @default - Worker is not assigned to any pool.
+   */
+  readonly pools?: string[];
+
+  /**
+   * Deadline region these workers needs to be assigned to.
+   *
+   * @default - Worker is not assigned to any region
+   */
+  readonly region?: string;
+}
+
+/**
+ * This is a helper construct for configuring Deadline Workers to connect to a RenderQueue, send their
+ * log files to CloudWatch, and similar common actions.
+ *
+ * Security Considerations
+ * ------------------------
+ * - The instances configured by this construct will download and run scripts from your CDK bootstrap bucket when that instance
+ *   is launched. You must limit write access to your CDK bootstrap bucket to prevent an attacker from modifying the actions
+ *   performed by these scripts. We strongly recommend that you either enable Amazon S3 server access logging on your CDK
+ *   bootstrap bucket, or enable AWS CloudTrail on your account to assist in post-incident analysis of compromised production
+ *   environments.
+ */
+export class WorkerConfiguration extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+
+  /**
+   * This method can be used to configure a Deadline Worker instance to stream its logs to the AWS CloudWatch
+   * service. The logs that this configures to stream are:
+   * - EC2 Instance UserData execution; this is the startup scripting that is run when the instance launches
+   *   for the first time.
+   * - Deadline Worker logs.
+   * - Deadline Launcher logs.
+   *
+   * @param worker The worker to configure. This can be an instance, auto scaling group, launch template, etc.
+   * @param id Identifier to disambiguate the resources that are created.
+   * @param logGroupProps Configuration for the log group in CloudWatch.
+   */
+  public configureCloudWatchLogStream(worker: IConfigurableWorker, id: string, logGroupProps?: LogGroupFactoryProps): void {
+    const logGroup = LogGroupFactory.createOrFetch(this, `${id}LogGroupWrapper`, `${id}`, logGroupProps);
+
+    logGroup.grantWrite(worker);
+
+    const cloudWatchConfigurationBuilder = new CloudWatchConfigBuilder(Duration.seconds(15));
+
+    if (worker.osType === OperatingSystemType.WINDOWS) {
+      cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
+        'UserdataExecution',
+        'C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Log\\UserdataExecution.log');
+      cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
+        'WorkerLogs',
+        'C:\\ProgramData\\Thinkbox\\Deadline10\\logs\\deadlineslave*.log');
+      cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
+        'LauncherLogs',
+        'C:\\ProgramData\\Thinkbox\\Deadline10\\logs\\deadlinelauncher*.log');
+    } else {
+      cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
+        'cloud-init-output',
+        '/var/log/cloud-init-output.log');
+      cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
+        'WorkerLogs',
+        '/var/log/Thinkbox/Deadline10/deadlineslave*.log');
+      cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
+        'LauncherLogs',
+        '/var/log/Thinkbox/Deadline10/deadlinelauncher*.log');
+    }
+
+    new CloudWatchAgent(this, `${id}WorkerFleetLogsConfig`, {
+      cloudWatchConfig: cloudWatchConfigurationBuilder.generateCloudWatchConfiguration(),
+      host: worker,
+    });
+  }
+
+  /**
+   * This method can be used to set up the Deadline Worker application on an EC2 instance. From a practical
+   * perspective, this is executing the script found in aws-rfdk/lib/deadline/scripts/[bash,powershell]/configureWorker.[sh,ps1]
+   * to configure the Deadline Worker application.
+   *
+   * @param worker The worker to configure. This can be an instance, auto scaling group, launch template, etc.
+   * @param id Identifier to disambiguate the resources that are created.
+   * @param settings The Deadline Worker settings to apply.
+   */
+  public configureWorkerSettings(worker: IConfigurableWorker, id: string, settings?: WorkerSettings): void {
+    const configureWorkerScriptAsset = ScriptAsset.fromPathConvention(this, `${id}WorkerConfigurationScript`, {
+      osType: worker.osType,
+      baseName: 'configureWorker',
+      rootDir: path.join(
+        __dirname,
+        '..',
+        'scripts/',
+      ),
+    });
+
+    // Converting to lower case, as groups and pools are all stored in lower case in deadline.
+    const groups = settings?.groups?.map(val => val.toLowerCase()).join(',') ?? ''; // props.groups ? props.groups.map(val => val.toLowerCase()).join(',') : '';
+    const pools = settings?.pools?.map(val => val.toLowerCase()).join(',') ?? ''; // props.pools ? props.pools.map(val => val.toLowerCase()).join(',') : '';
+
+    configureWorkerScriptAsset.executeOn({
+      host: worker,
+      args: [
+        `'${groups}'`,
+        `'${pools}'`,
+        `'${settings?.region ?? ''}'`,
+        `'${Version.MINIMUM_SUPPORTED_DEADLINE_VERSION.toString()}'`,
+      ],
+    });
+  }
+}

--- a/packages/aws-rfdk/lib/deadline/lib/worker-configuration.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-configuration.ts
@@ -30,8 +30,7 @@ import {
 } from './version';
 
 /**
- * The Deadline Worker settings that can be configured via the configureWorkerSettings method
- * of the WorkerConfiguration helper class.
+ * Configuration settings for Deadline Workers
  */
 export interface WorkerSettings {
   /**
@@ -90,8 +89,10 @@ export interface WorkerInstanceConfigurationProps {
 }
 
 /**
- * This is a helper construct for configuring Deadline Workers to connect to a RenderQueue, send their
- * log files to CloudWatch, and similar common actions.
+ * This construct can be used to configure Deadline Workers on an instance to connect to a RenderQueue, stream their
+ * log files to CloudWatch, and configure various settings of the Deadline Worker.
+ *
+ * The configuration happens on instance start-up using user data scripting.
  *
  * Security Considerations
  * ------------------------

--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -40,13 +40,10 @@ import {
   Stack,
 } from '@aws-cdk/core';
 import {
-  CloudWatchAgent,
-  CloudWatchConfigBuilder,
   HealthCheckConfig,
   HealthMonitor,
   IHealthMonitor,
   IMonitorableFleet,
-  LogGroupFactory,
   LogGroupFactoryProps,
   ScriptAsset,
 } from '../../core';
@@ -57,6 +54,10 @@ import {
   IRenderQueue,
 } from './render-queue';
 import { Version } from './version';
+import {
+  WorkerConfiguration,
+  WorkerSettings,
+} from './worker-configuration';
 
 /**
  * Interface for Deadline Worker Fleet.
@@ -67,7 +68,7 @@ export interface IWorkerFleet extends IResource, IConnectable, IGrantable {
 /**
  * Properties for the Deadline Worker Fleet.
  */
-export interface WorkerInstanceFleetProps {
+export interface WorkerInstanceFleetProps extends WorkerSettings {
   /**
    * VPC to launch the worker fleet in.
    */
@@ -149,29 +150,6 @@ export interface WorkerInstanceFleetProps {
    * Endpoint for the RenderQueue, to which the worker fleet needs to be connected.
    */
   readonly renderQueue: IRenderQueue;
-
-  /**
-   * Deadline groups these workers needs to be assigned to. The group is
-   * created if it does not already exist.
-   *
-   * @default - Worker is not assigned to any group
-   */
-  readonly groups?: string[];
-
-  /**
-   * Deadline pools these workers needs to be assigned to. The pool is created
-   * if it does not already exist.
-   *
-   * @default - Worker is not assigned to any pool.
-   */
-  readonly pools?: string[];
-
-  /**
-   * Deadline region these workers needs to be assigned to.
-   *
-   * @default - Worker is not assigned to any region
-   */
-  readonly region?: string;
 
   /**
    * Properties for setting up the Deadline Worker's LogGroup
@@ -458,25 +436,23 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
     this.grantPrincipal = this.fleet.grantPrincipal;
     this.connections = this.fleet.connections;
 
-    this.connections.allowToDefaultPort(props.renderQueue);
-
-    let healthCheckPort = HealthMonitor.DEFAULT_HEALTH_CHECK_PORT;
-    if (props.healthCheckConfig && props.healthCheckConfig.port) {
-      healthCheckPort = props.healthCheckConfig.port;
-    }
-
     // Configure the health monitoring if provided
-    this.configureHealthMonitor(props, healthCheckPort);
+    this.configureHealthMonitor(props);
+
+    const workerConfig = new WorkerConfiguration(this, 'Config');
 
     // Updating the user data with installation logs stream.
-    this.configureCloudWatchLogStream(this.fleet, id, props.logGroupProps);
+    workerConfig.configureCloudWatchLogStream(this.fleet, id, {
+      logGroupPrefix: WorkerInstanceFleet.DEFAULT_LOG_GROUP_PREFIX,
+      ...props.logGroupProps,
+    });
 
     props.renderQueue.configureClientInstance({
       host: this.fleet,
     });
 
     // Updating the user data with deadline repository installation commands.
-    this.configureWorkerScript(this.fleet, props, healthCheckPort);
+    workerConfig.configureWorkerSettings(this.fleet, id, props);
 
     // Updating the user data with successful cfn-signal commands.
     this.fleet.userData.addSignalOnExitCommand(this.fleet);
@@ -492,70 +468,6 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
    */
   public addSecurityGroup(securityGroup: ISecurityGroup): void {
     this.fleet.addSecurityGroup(securityGroup);
-  }
-
-  private configureCloudWatchLogStream(fleetInstance: AutoScalingGroup, id: string, logGroupProps?: LogGroupFactoryProps) {
-    const prefix = logGroupProps?.logGroupPrefix ?? WorkerInstanceFleet.DEFAULT_LOG_GROUP_PREFIX;
-    const defaultedLogGroupProps = {
-      ...logGroupProps,
-      logGroupPrefix: prefix,
-    };
-    const logGroup = LogGroupFactory.createOrFetch(this, `${id}LogGroupWrapper`, `${id}`, defaultedLogGroupProps);
-
-    logGroup.grantWrite(fleetInstance);
-
-    const cloudWatchConfigurationBuilder = new CloudWatchConfigBuilder(Duration.seconds(15));
-
-    cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
-      'UserdataExecution',
-      'C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Log\\UserdataExecution.log');
-    cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
-      'WorkerLogs',
-      'C:\\ProgramData\\Thinkbox\\Deadline10\\logs\\deadlineslave*.log');
-    cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
-      'LauncherLogs',
-      'C:\\ProgramData\\Thinkbox\\Deadline10\\logs\\deadlinelauncher*.log');
-    cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
-      'cloud-init-output',
-      '/var/log/cloud-init-output.log');
-    cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
-      'WorkerLogs',
-      '/var/log/Thinkbox/Deadline10/deadlineslave*.log');
-    cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
-      'LauncherLogs',
-      '/var/log/Thinkbox/Deadline10/deadlinelauncher*.log');
-
-    new CloudWatchAgent(this, 'WorkerFleetLogsConfig', {
-      cloudWatchConfig: cloudWatchConfigurationBuilder.generateCloudWatchConfiguration(),
-      host: fleetInstance,
-    });
-  }
-
-  private configureWorkerScript(fleetInstance: AutoScalingGroup, props: WorkerInstanceFleetProps, healthCheckPort: number) {
-    const configureWorkerScriptAsset = ScriptAsset.fromPathConvention(this, 'WorkerConfigurationScript', {
-      osType: fleetInstance.osType,
-      baseName: 'configureWorker',
-      rootDir: path.join(
-        __dirname,
-        '..',
-        'scripts/',
-      ),
-    });
-
-    // Converting to lower case, as groups and pools are all stored in lower case in deadline.
-    const groups = props.groups ? props.groups.map(val => val.toLowerCase()).join(',') : '';
-    const pools = props.pools ? props.pools.map(val => val.toLowerCase()).join(',') : '';
-
-    configureWorkerScriptAsset.executeOn({
-      host: fleetInstance,
-      args: [
-        `'${healthCheckPort}'`,
-        `'${groups}'`,
-        `'${pools}'`,
-        `'${props.region || ''}'`,
-        `'${Version.MINIMUM_SUPPORTED_DEADLINE_VERSION.toString()}'`,
-      ],
-    });
   }
 
   private validateProps(props: WorkerInstanceFleetProps) {
@@ -609,8 +521,28 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
     }
   }
 
-  private configureHealthMonitor(props: WorkerInstanceFleetProps, healthCheckPort: number) {
+  private configureHealthMonitor(props: WorkerInstanceFleetProps) {
     if (props.healthMonitor) {
+      const healthCheckPort = props.healthCheckConfig?.port ?? HealthMonitor.DEFAULT_HEALTH_CHECK_PORT;
+
+      const configureHealthMonitorScriptAsset = ScriptAsset.fromPathConvention(this, 'WorkerConfigurationScript', {
+        osType: this.fleet.osType,
+        baseName: 'configureWorkerHealthCheck',
+        rootDir: path.join(
+          __dirname,
+          '..',
+          'scripts/',
+        ),
+      });
+
+      configureHealthMonitorScriptAsset.executeOn({
+        host: this.fleet,
+        args: [
+          `'${healthCheckPort}'`,
+          `'${Version.MINIMUM_SUPPORTED_DEADLINE_VERSION.toString()}'`,
+        ],
+      });
+
       props.healthMonitor.registerFleet(this, props.healthCheckConfig || {
         port: healthCheckPort,
       });

--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -436,7 +436,9 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
     this.grantPrincipal = this.fleet.grantPrincipal;
     this.connections = this.fleet.connections;
 
-    // Configure the health monitoring if provided
+    // Configure the health monitoring if provided.
+    // Note: This must be done *BEFORE* configuring the worker. We rely on the worker configuration
+    // script restarting the launcher.
     this.configureHealthMonitor(props);
 
     new WorkerInstanceConfiguration(this, id, {

--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -55,7 +55,7 @@ import {
 } from './render-queue';
 import { Version } from './version';
 import {
-  WorkerConfiguration,
+  WorkerInstanceConfiguration,
   WorkerSettings,
 } from './worker-configuration';
 
@@ -439,20 +439,15 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
     // Configure the health monitoring if provided
     this.configureHealthMonitor(props);
 
-    const workerConfig = new WorkerConfiguration(this, 'Config');
-
-    // Updating the user data with installation logs stream.
-    workerConfig.configureCloudWatchLogStream(this.fleet, id, {
-      logGroupPrefix: WorkerInstanceFleet.DEFAULT_LOG_GROUP_PREFIX,
-      ...props.logGroupProps,
+    new WorkerInstanceConfiguration(this, id, {
+      worker: this.fleet,
+      cloudwatchLogSettings: {
+        logGroupPrefix: WorkerInstanceFleet.DEFAULT_LOG_GROUP_PREFIX,
+        ...props.logGroupProps,
+      },
+      renderQueue: props.renderQueue,
+      workerSettings: props,
     });
-
-    props.renderQueue.configureClientInstance({
-      host: this.fleet,
-    });
-
-    // Updating the user data with deadline repository installation commands.
-    workerConfig.configureWorkerSettings(this.fleet, id, props);
 
     // Updating the user data with successful cfn-signal commands.
     this.fleet.userData.addSignalOnExitCommand(this.fleet);

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
@@ -5,20 +5,18 @@
 
 # This script configures the deadline.ini file with the Remote Server endpoints and restart the launcher service
 # Arguments:
-# $1: healthCheckPort
-# $2: comma separated groups
-# $3: comma separated pools
-# $4: region
-# $5: minimum supported deadline version
+# $1: comma separated groups
+# $2: comma separated pools
+# $3: region
+# $4: minimum supported deadline version
 
 # exit when any command fails
 set -xeuo pipefail
 
-HEALTH_CHECK_PORT="$1"
-WORKER_GROUPS=(${2//,/ })
-WORKER_POOLS=(${3//,/ })
-WORKER_REGION="$4"
-MINIMUM_SUPPORTED_DEADLINE_VERSION=$5
+WORKER_GROUPS=(${1//,/ })
+WORKER_POOLS=(${2//,/ })
+WORKER_REGION="$3"
+MINIMUM_SUPPORTED_DEADLINE_VERSION=$4
 
 # Cloud-init does not load system environment variables. Cherry-pick the
 # environment variable installed by the Deadline Client installer.
@@ -61,10 +59,6 @@ fi
 "$DEADLINE_COMMAND" -SetIniFileSetting RestartStalledSlave True
 # auto update
 "$DEADLINE_COMMAND" -SetIniFileSetting AutoUpdateOverride False
-# enabling the health check port
-"$DEADLINE_COMMAND" -SetIniFileSetting ResourceTrackerVersion V2
-# health check port
-"$DEADLINE_COMMAND" -SetIniFileSetting LauncherHealthCheckPort $HEALTH_CHECK_PORT
 # Disable S3Backed Cache
 "$DEADLINE_COMMAND" -SetIniFileSetting UseS3BackedCache False
 # Blank the S3BackedCache Url

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorkerHealthCheck.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorkerHealthCheck.sh
@@ -52,13 +52,4 @@ fi
 # health check port
 "$DEADLINE_COMMAND" -SetIniFileSetting LauncherHealthCheckPort $HEALTH_CHECK_PORT
 
-# Restart service, if it exists, else restart application
-if service --status-all | grep -q 'Deadline 10 Launcher'; then
-  service deadline10launcher restart
-else
-  DEADLINE_LAUNCHER="$DEADLINE_PATH/deadlinelauncher"
-  "$DEADLINE_LAUNCHER" -shutdownall
-  "$DEADLINE_LAUNCHER"
-fi
-
 echo "Script completed successfully."

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorkerHealthCheck.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorkerHealthCheck.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script configures the deadline.ini file with the settings for the HealthMonitor
+# Arguments:
+# $1: healthCheckPort
+# $2: minimum supported deadline version
+
+# exit when any command fails
+set -xeuo pipefail
+
+HEALTH_CHECK_PORT="$1"
+MINIMUM_SUPPORTED_DEADLINE_VERSION=$2
+
+# Cloud-init does not load system environment variables. Cherry-pick the
+# environment variable installed by the Deadline Client installer.
+if [ -f "/etc/profile.d/deadlineclient.sh" ]; then
+    source "/etc/profile.d/deadlineclient.sh"
+fi
+
+# Find Deadline
+if [ -z "$DEADLINE_PATH" ]; then
+    echo "ERROR: DEADLINE_PATH environment variable not set"
+    exit 1
+fi
+
+DEADLINE_COMMAND="$DEADLINE_PATH/deadlinecommand"
+if [ ! -f "$DEADLINE_COMMAND" ]; then
+    echo "ERROR: $DEADLINE_COMMAND not found!"
+    exit 1
+fi
+
+isVersionLessThan() {
+    python -c "import sys;sys.exit(0 if tuple(map(int, sys.argv[-2].split('.'))) < tuple(map(int, sys.argv[-1].split('.'))) else 1)" "$1" "$2"
+}
+
+DEADLINE_VERSION=$("$DEADLINE_COMMAND" -Version | grep -oP '[v]\K\d+\.\d+\.\d+\.\d+\b')
+if [ -z "$DEADLINE_VERSION" ]; then
+    echo "ERROR: Unable to identify the version of installed Deadline Client. Exiting..."
+    exit 1
+fi
+
+if isVersionLessThan $DEADLINE_VERSION $MINIMUM_SUPPORTED_DEADLINE_VERSION; then
+    echo "ERROR: Installed Deadline Version ($DEADLINE_VERSION) is less than the minimum supported version ($MINIMUM_SUPPORTED_DEADLINE_VERSION). Exiting..."
+    exit 1
+fi
+
+# enabling the health check port
+"$DEADLINE_COMMAND" -SetIniFileSetting ResourceTrackerVersion V2
+# health check port
+"$DEADLINE_COMMAND" -SetIniFileSetting LauncherHealthCheckPort $HEALTH_CHECK_PORT
+
+# Restart service, if it exists, else restart application
+if service --status-all | grep -q 'Deadline 10 Launcher'; then
+  service deadline10launcher restart
+else
+  DEADLINE_LAUNCHER="$DEADLINE_PATH/deadlinelauncher"
+  "$DEADLINE_LAUNCHER" -shutdownall
+  "$DEADLINE_LAUNCHER"
+fi
+
+echo "Script completed successfully."

--- a/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorker.ps1
+++ b/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorker.ps1
@@ -3,8 +3,6 @@
 
 param (
     [Parameter(Mandatory=$True)]
-    $healthCheckPort,
-    [Parameter(Mandatory=$True)]
     $workerGroups,
     [Parameter(Mandatory=$True)]
     $workerPools,
@@ -49,16 +47,10 @@ if([System.Version]$DeadlineVersion -lt  [System.Version]$minimumSupportedDeadli
 & $DEADLINE_COMMAND -SetIniFileSetting RestartStalledSlave True | Out-Default
 # auto update
 & $DEADLINE_COMMAND -SetIniFileSetting AutoUpdateOverride False | Out-Default
-# enabling the health check port
-& $DEADLINE_COMMAND -SetIniFileSetting ResourceTrackerVersion V2 | Out-Default
-# health check port
-& $DEADLINE_COMMAND -SetIniFileSetting LauncherHealthCheckPort $healthCheckPort | Out-Default
 # Disable S3Backed Cache
 & $DEADLINE_COMMAND -SetIniFileSetting UseS3BackedCache False | Out-Default
 # Blank the S3BackedCache Url
 & $DEADLINE_COMMAND -SetIniFileSetting S3BackedCacheUrl "" | Out-Default
-# Adding firewall rule to allow health-checks
-& New-NetFirewallRule -DisplayName "Allow Deadline Health-Checks" -Direction Inbound -Action Allow -Protocol TCP -LocalPort $healthCheckPort  | Out-Default
 
 # setting the group, pool and region for this worker
 if (![string]::IsNullOrEmpty($workerRegion)) {

--- a/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorkerHealthCheck.ps1
+++ b/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorkerHealthCheck.ps1
@@ -42,14 +42,4 @@ if([System.Version]$DeadlineVersion -lt  [System.Version]$minimumSupportedDeadli
 # Adding firewall rule to allow health-checks
 & New-NetFirewallRule -DisplayName "Allow Deadline Health-Checks" -Direction Inbound -Action Allow -Protocol TCP -LocalPort $healthCheckPort  | Out-Default
 
-
-$serviceName="deadline10launcherservice"
-If (Get-Service $serviceName -ErrorAction SilentlyContinue) {
-    Restart-Service $serviceName
-} Else {
-    $DEADLINE_LAUNCHER = $DEADLINE_PATH + '/deadlinelauncher.exe'
-    & $DEADLINE_LAUNCHER -shutdownall | Out-Default
-    & $DEADLINE_LAUNCHER
-}
-
 Write-Host "Script completed successfully."

--- a/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorkerHealthCheck.ps1
+++ b/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorkerHealthCheck.ps1
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+param (
+    [Parameter(Mandatory=$True)]
+    $healthCheckPort,
+    [Parameter(Mandatory=$True)]
+    $minimumSupportedDeadlineVersion
+)
+
+Set-PSDebug -Trace 1
+
+$ErrorActionPreference = "Stop"
+
+$DEADLINE_PATH = (get-item env:"DEADLINE_PATH").Value
+if (!(Test-Path $DEADLINE_PATH)) {
+    Write-Host "DEADLINE_PATH does not exists. Exiting..."
+    exit 1
+}
+$DEADLINE_COMMAND = $DEADLINE_PATH + '/deadlinecommand.exe'
+
+if (!(Test-Path $DEADLINE_COMMAND)) {
+    Write-Host "DeadlineCommand.exe does not exists. Exiting..."
+    exit 1
+}
+
+$DeadlineVersion = (& $DEADLINE_COMMAND -Version | Out-String) | Select-String -Pattern '[v](\d+\.\d+\.\d+\.\d+)\b' | % {$_.Matches.Groups[1].Value}
+if ([string]::IsNullOrEmpty($DeadlineVersion)) {
+    Write-Host "ERROR: Unable to identify the version of installed Deadline Client. Exiting..."
+    exit 1
+}
+
+if([System.Version]$DeadlineVersion -lt  [System.Version]$minimumSupportedDeadlineVersion) {
+    Write-Host "ERROR: Installed Deadline Version ($($DeadlineVersion)) is less than the minimum supported version ($($minimumSupportedDeadlineVersion)). Exiting..."
+    exit 1
+}
+
+# enabling the health check port
+& $DEADLINE_COMMAND -SetIniFileSetting ResourceTrackerVersion V2 | Out-Default
+# health check port
+& $DEADLINE_COMMAND -SetIniFileSetting LauncherHealthCheckPort $healthCheckPort | Out-Default
+# Adding firewall rule to allow health-checks
+& New-NetFirewallRule -DisplayName "Allow Deadline Health-Checks" -Direction Inbound -Action Allow -Protocol TCP -LocalPort $healthCheckPort  | Out-Default
+
+
+$serviceName="deadline10launcherservice"
+If (Get-Service $serviceName -ErrorAction SilentlyContinue) {
+    Restart-Service $serviceName
+} Else {
+    $DEADLINE_LAUNCHER = $DEADLINE_PATH + '/deadlinelauncher.exe'
+    & $DEADLINE_LAUNCHER -shutdownall | Out-Default
+    & $DEADLINE_LAUNCHER
+}
+
+Write-Host "Script completed successfully."

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -6,18 +6,22 @@
 // TODO: Properly import from aws-rfdk. Not ideal
 // to use a relative path here.
 import { stringLike } from '@aws-cdk/assert';
-import {CWA_ASSET_LINUX} from '../../core/test/asset-constants';
-export {CWA_ASSET_LINUX};
+import {
+  CWA_ASSET_LINUX,
+  CWA_ASSET_WINDOWS,
+} from '../../core/test/asset-constants';
+export { CWA_ASSET_LINUX, CWA_ASSET_WINDOWS };
 
 // configureWorker.sh
 export const CONFIG_WORKER_ASSET_LINUX = {
-  Bucket: 'AssetParameters3915f098ad4813270754c05c4e236d137da778773dfb13912fa54f387cc5929aS3BucketE7DA333E',
-  Key: 'AssetParameters3915f098ad4813270754c05c4e236d137da778773dfb13912fa54f387cc5929aS3VersionKey1C0D482D',
+  Bucket: 'AssetParameterscfbac966c059b6d160d9fe1be830ff2b4e3b3e8583d44c5e6a9ef3cc617cae52S3BucketEC9648BD',
+  Key: 'AssetParameterscfbac966c059b6d160d9fe1be830ff2b4e3b3e8583d44c5e6a9ef3cc617cae52S3VersionKey14E8A825',
 };
 
 // configureWorker.ps1
 export const CONFIG_WORKER_ASSET_WINDOWS = {
-  // NOT USED IN ANY TESTS CURRENTLY
+  Bucket: 'AssetParametersb78a6a7981377c750b127331abdcbd9f1ab312242da73512424611e965eea4c1S3BucketFDCB6ECC',
+  Key: 'AssetParametersb78a6a7981377c750b127331abdcbd9f1ab312242da73512424611e965eea4c1S3VersionKey20AFBF6B',
 };
 
 // installDeadlineRepository.sh

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -9,8 +9,10 @@ import { stringLike } from '@aws-cdk/assert';
 import {
   CWA_ASSET_LINUX,
   CWA_ASSET_WINDOWS,
+  linuxDownloadRunScriptBoilerplate,
+  windowsDownloadRunScriptBoilerplate,
 } from '../../core/test/asset-constants';
-export { CWA_ASSET_LINUX, CWA_ASSET_WINDOWS };
+export { CWA_ASSET_LINUX, CWA_ASSET_WINDOWS, linuxDownloadRunScriptBoilerplate, windowsDownloadRunScriptBoilerplate };
 
 // configureWorker.sh
 export const CONFIG_WORKER_ASSET_LINUX = {

--- a/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
@@ -387,12 +387,7 @@ describe('Test WorkerInstanceConfiguration connect to RenderQueue', () => {
     stack = new Stack();
     vpc = new Vpc(stack, 'Vpc');
     const rcsImage = ContainerImage.fromAsset(__dirname);
-    const version = VersionQuery.exact(stack, 'Version', {
-      majorVersion: 10,
-      minorVersion: 0,
-      releaseVersion: 0,
-      patchVersion: 0,
-    });
+    const version = new VersionQuery(stack, 'Version');
     renderQueue = new RenderQueue(stack, 'RQ', {
       version,
       vpc,

--- a/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  expect as expectCDK,
+  haveResource,
+  // haveResourceLike,
+} from '@aws-cdk/assert';
+import {
+  AmazonLinuxGeneration,
+  Instance,
+  InstanceType,
+  IVpc,
+  MachineImage,
+  Vpc,
+  WindowsVersion,
+} from '@aws-cdk/aws-ec2';
+import {
+  Stack,
+} from '@aws-cdk/core';
+import {
+  LogGroupFactoryProps,
+} from '../../core/lib';
+import {
+  WorkerConfiguration, WorkerSettings,
+} from '../lib';
+import {
+  CONFIG_WORKER_ASSET_LINUX,
+  CONFIG_WORKER_ASSET_WINDOWS,
+  CWA_ASSET_LINUX,
+  CWA_ASSET_WINDOWS,
+} from './asset-constants';
+
+function linuxDownloadRunScriptBoilerplate(script: { Bucket: string, Key: string }) {
+  return [
+    '#!/bin/bash\nmkdir -p $(dirname \'/tmp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\')\naws s3 cp \'s3://',
+    {Ref: script.Bucket},
+    '/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' \'/tmp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\'\n' +
+    'set -e\n' +
+    'chmod +x \'/tmp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {
+              Ref: script.Key,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\'\n\'/tmp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+function windowsDownloadRunScriptBoilerplate(script: { Bucket: string, Key: string }) {
+  return [
+    '<powershell>mkdir (Split-Path -Path \'C:/temp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' ) -ea 0\nRead-S3Object -BucketName \'',
+    {Ref: script.Bucket},
+    '\' -key \'',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' -file \'C:/temp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+    '\' -ErrorAction Stop\n&\'C:/temp/',
+    {
+      'Fn::Select': [
+        0,
+        {
+          'Fn::Split': [
+            '||',
+            {
+              Ref: script.Key,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      'Fn::Select': [
+        1,
+        {
+          'Fn::Split': [
+            '||',
+            {Ref: script.Key},
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+describe('Test WorkerConfiguration', () => {
+  let stack: Stack;
+  let vpc: IVpc;
+
+  beforeEach(() => {
+    stack = new Stack();
+    vpc = new Vpc(stack, 'Vpc');
+  });
+
+  test('configure log stream for Linux', () => {
+    // GIVEN
+    const instance = new Instance(stack, 'Instance', {
+      vpc,
+      instanceType: new InstanceType('t3.small'),
+      machineImage: MachineImage.latestAmazonLinux({ generation: AmazonLinuxGeneration.AMAZON_LINUX_2 }),
+    });
+    const logGroupProps: LogGroupFactoryProps = {
+      logGroupPrefix: '/test-prefix/',
+    };
+    const config = new WorkerConfiguration(stack, 'Config');
+
+    // WHEN
+    config.configureCloudWatchLogStream(instance, 'Worker', logGroupProps);
+    const userData = stack.resolve(instance.userData.render());
+
+    // THEN
+    expect(userData).toStrictEqual({
+      'Fn::Join': [
+        '',
+        [
+          ...linuxDownloadRunScriptBoilerplate(CWA_ASSET_LINUX),
+          '\' ',
+          {Ref: 'ConfigStringParameterC2BE550F'},
+        ],
+      ],
+    });
+    expectCDK(stack).to(haveResource('AWS::SSM::Parameter', {
+      Value: {
+        'Fn::Join': [
+          '',
+          [
+            '{\"logs\":{\"logs_collected\":{\"files\":{\"collect_list\":[{\"log_group_name\":\"',
+            {
+              'Fn::GetAtt': [
+                'ConfigWorkerLogGroupWrapperDC3AF2E7',
+                'LogGroupName',
+              ],
+            },
+            '\",\"log_stream_name\":\"cloud-init-output-{instance_id}\",\"file_path\":\"/var/log/cloud-init-output.log\",\"timezone\":\"Local\"},{\"log_group_name\":\"',
+            {
+              'Fn::GetAtt': [
+                'ConfigWorkerLogGroupWrapperDC3AF2E7',
+                'LogGroupName',
+              ],
+            },
+            '\",\"log_stream_name\":\"WorkerLogs-{instance_id}\",\"file_path\":\"/var/log/Thinkbox/Deadline10/deadlineslave*.log\",\"timezone\":\"Local\"},{\"log_group_name\":\"',
+            {
+              'Fn::GetAtt': [
+                'ConfigWorkerLogGroupWrapperDC3AF2E7',
+                'LogGroupName',
+              ],
+            },
+            '\",\"log_stream_name\":\"LauncherLogs-{instance_id}\",\"file_path\":\"/var/log/Thinkbox/Deadline10/deadlinelauncher*.log\",\"timezone\":\"Local\"}]}},\"log_stream_name\":\"DefaultLogStream-{instance_id}\",\"force_flush_interval\":15}}',
+          ],
+        ],
+      },
+    }));
+  });
+
+  test('configure log stream for Windows', () => {
+    // GIVEN
+    const instance = new Instance(stack, 'Instance', {
+      vpc,
+      instanceType: new InstanceType('t3.small'),
+      machineImage: MachineImage.latestWindows(WindowsVersion.WINDOWS_SERVER_2019_ENGLISH_FULL_BASE),
+    });
+    const logGroupProps: LogGroupFactoryProps = {
+      logGroupPrefix: '/test-prefix/',
+    };
+    const config = new WorkerConfiguration(stack, 'Config');
+
+    // WHEN
+    config.configureCloudWatchLogStream(instance, 'Worker', logGroupProps);
+    const userData = stack.resolve(instance.userData.render());
+
+    // THEN
+    expect(userData).toStrictEqual({
+      'Fn::Join': [
+        '',
+        [
+          ...windowsDownloadRunScriptBoilerplate(CWA_ASSET_WINDOWS),
+          '\' ',
+          {Ref: 'ConfigStringParameterC2BE550F'},
+          '\nif (!$?) { Write-Error \'Failed to execute the file \"C:/temp/',
+          {
+            'Fn::Select': [
+              0,
+              {
+                'Fn::Split': [
+                  '||',
+                  {
+                    Ref: CWA_ASSET_WINDOWS.Key,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            'Fn::Select': [
+              1,
+              {
+                'Fn::Split': [
+                  '||',
+                  {Ref: CWA_ASSET_WINDOWS.Key},
+                ],
+              },
+            ],
+          },
+          '\"\' -ErrorAction Stop }</powershell>',
+        ],
+      ],
+    });
+    expectCDK(stack).to(haveResource('AWS::SSM::Parameter', {
+      Value: {
+        'Fn::Join': [
+          '',
+          [
+            '{\"logs\":{\"logs_collected\":{\"files\":{\"collect_list\":[{\"log_group_name\":\"',
+            {
+              'Fn::GetAtt': [
+                'ConfigWorkerLogGroupWrapperDC3AF2E7',
+                'LogGroupName',
+              ],
+            },
+            '\",\"log_stream_name\":\"UserdataExecution-{instance_id}\",\"file_path\":\"C:\\\\ProgramData\\\\Amazon\\\\EC2-Windows\\\\Launch\\\\Log\\\\UserdataExecution.log\",\"timezone\":\"Local\"},{\"log_group_name\":\"',
+            {
+              'Fn::GetAtt': [
+                'ConfigWorkerLogGroupWrapperDC3AF2E7',
+                'LogGroupName',
+              ],
+            },
+            '\",\"log_stream_name\":\"WorkerLogs-{instance_id}\",\"file_path\":\"C:\\\\ProgramData\\\\Thinkbox\\\\Deadline10\\\\logs\\\\deadlineslave*.log\",\"timezone\":\"Local\"},{\"log_group_name\":\"',
+            {
+              'Fn::GetAtt': [
+                'ConfigWorkerLogGroupWrapperDC3AF2E7',
+                'LogGroupName',
+              ],
+            },
+            '\",\"log_stream_name\":\"LauncherLogs-{instance_id}\",\"file_path\":\"C:\\\\ProgramData\\\\Thinkbox\\\\Deadline10\\\\logs\\\\deadlinelauncher*.log\",\"timezone\":\"Local\"}]}},\"log_stream_name\":\"DefaultLogStream-{instance_id}\",\"force_flush_interval\":15}}',
+          ],
+        ],
+      },
+    }));
+  });
+
+  test('setup Worker for Linux', () => {
+    // GIVEN
+    const instance = new Instance(stack, 'Instance', {
+      vpc,
+      instanceType: new InstanceType('t3.small'),
+      machineImage: MachineImage.latestAmazonLinux({ generation: AmazonLinuxGeneration.AMAZON_LINUX_2 }),
+    });
+    const workerSettings: WorkerSettings = {
+      groups: ['g1', 'g2'],
+      pools: ['p1', 'p2'],
+      region: 'r1',
+    };
+    const config = new WorkerConfiguration(stack, 'Config');
+
+    // WHEN
+    config.configureWorkerSettings(instance, 'Worker', workerSettings);
+    const userData = stack.resolve(instance.userData.render());
+
+    // THEN
+    expect(userData).toStrictEqual({
+      'Fn::Join': [
+        '',
+        [
+          ...linuxDownloadRunScriptBoilerplate(CONFIG_WORKER_ASSET_LINUX),
+          '\' \'g1,g2\' \'p1,p2\' \'r1\' \'10.1.9.2\'',
+        ],
+      ],
+    });
+  });
+
+  test('setup Worker for Windows', () => {
+    // GIVEN
+    const instance = new Instance(stack, 'Instance', {
+      vpc,
+      instanceType: new InstanceType('t3.small'),
+      machineImage: MachineImage.latestWindows(WindowsVersion.WINDOWS_SERVER_2019_ENGLISH_FULL_BASE),
+    });
+    const workerSettings: WorkerSettings = {
+      groups: ['g1', 'g2'],
+      pools: ['p1', 'p2'],
+      region: 'r1',
+    };
+    const config = new WorkerConfiguration(stack, 'Config');
+
+    // WHEN
+    config.configureWorkerSettings(instance, 'Worker', workerSettings);
+    const userData = stack.resolve(instance.userData.render());
+
+    // THEN
+    expect(userData).toStrictEqual({
+      'Fn::Join': [
+        '',
+        [
+          ...windowsDownloadRunScriptBoilerplate(CONFIG_WORKER_ASSET_WINDOWS),
+          '\' \'g1,g2\' \'p1,p2\' \'r1\' \'10.1.9.2\'' +
+          '\nif (!$?) { Write-Error \'Failed to execute the file \"C:/temp/',
+          {
+            'Fn::Select': [
+              0,
+              {
+                'Fn::Split': [
+                  '||',
+                  {
+                    Ref: CONFIG_WORKER_ASSET_WINDOWS.Key,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            'Fn::Select': [
+              1,
+              {
+                'Fn::Split': [
+                  '||',
+                  {Ref: CONFIG_WORKER_ASSET_WINDOWS.Key},
+                ],
+              },
+            ],
+          },
+          '\"\' -ErrorAction Stop }</powershell>',
+        ],
+      ],
+    });
+  });
+});

--- a/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
@@ -423,7 +423,7 @@ describe('Test WorkerInstanceConfiguration connect to RenderQueue', () => {
     const instanceSGId = stack.resolve(instanceSG.securityGroupId);
 
     // THEN
-    // White-box testing. We know that we invoked the connection method on the
+    // Open-box testing. We know that we invoked the connection method on the
     // render queue if the security group for the instance has an ingress rule to the RQ.
     expectCDK(stack).to(haveResourceLike('AWS::EC2::SecurityGroupIngress', {
       IpProtocol: 'tcp',
@@ -450,7 +450,7 @@ describe('Test WorkerInstanceConfiguration connect to RenderQueue', () => {
     const instanceSGId = stack.resolve(instanceSG.securityGroupId);
 
     // THEN
-    // White-box testing. We know that we invoked the connection method on the
+    // Open-box testing. We know that we invoked the connection method on the
     // render queue if the security group for the instance has an ingress rule to the RQ.
     expectCDK(stack).to(haveResourceLike('AWS::EC2::SecurityGroupIngress', {
       IpProtocol: 'tcp',

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -433,7 +433,7 @@ test('default worker fleet is created correctly custom subnet values', () => {
           ],
         },
         '\' ',
-        {Ref: 'workerFleetConfigStringParameterF5B0A632'},
+        {Ref: 'workerFleetStringParameterDB3717DA'},
         '\nmkdir -p $(dirname \'/tmp/',
         {
           'Fn::Select': [
@@ -833,7 +833,7 @@ test('default worker fleet is created correctly with groups, pools and region', 
         ],
       },
       "' ",
-      {Ref: 'workerFleetConfigStringParameterF5B0A632'},
+      {Ref: 'workerFleetStringParameterDB3717DA'},
       '\nmkdir -p $(dirname \'/tmp/',
       {
         'Fn::Select': [

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -41,6 +41,9 @@ import {
   testConstructTags,
 } from '../../core/test/tag-helpers';
 import {
+  escapeTokenRegex,
+} from '../../core/test/token-regex-helpers';
+import {
   IRenderQueue,
   RenderQueue,
   Repository,
@@ -430,7 +433,7 @@ test('default worker fleet is created correctly custom subnet values', () => {
           ],
         },
         '\' ',
-        {Ref: 'workerFleetStringParameterE88827AB'},
+        {Ref: 'workerFleetConfigStringParameterF5B0A632'},
         '\nmkdir -p $(dirname \'/tmp/',
         {
           'Fn::Select': [
@@ -681,7 +684,7 @@ test('default worker fleet is created correctly custom subnet values', () => {
             },
           ],
         },
-        `' '6161' '' '' '' '${Version.MINIMUM_SUPPORTED_DEADLINE_VERSION}'`,
+        `' '' '' '' '${Version.MINIMUM_SUPPORTED_DEADLINE_VERSION}'`,
       ],
     ],
   });
@@ -830,7 +833,7 @@ test('default worker fleet is created correctly with groups, pools and region', 
         ],
       },
       "' ",
-      {Ref: 'workerFleetStringParameterE88827AB'},
+      {Ref: 'workerFleetConfigStringParameterF5B0A632'},
       '\nmkdir -p $(dirname \'/tmp/',
       {
         'Fn::Select': [
@@ -1081,7 +1084,7 @@ test('default worker fleet is created correctly with groups, pools and region', 
           },
         ],
       },
-      `' '63415' 'a,b' 'c,d' 'E' '${Version.MINIMUM_SUPPORTED_DEADLINE_VERSION}'`,
+      `' 'a,b' 'c,d' 'E' '${Version.MINIMUM_SUPPORTED_DEADLINE_VERSION}'`,
     ]],
   });
 });
@@ -1390,6 +1393,73 @@ describe('Block Device Tests', () => {
     }));
 
     expect(fleet.node.metadata).toHaveLength(0);
+  });
+});
+
+describe('HealthMonitor Tests', () => {
+  let healthMonitor: HealthMonitor;
+
+  beforeEach(() => {
+    // create a health monitor so it does not trigger warnings
+    healthMonitor = new HealthMonitor(wfstack,'healthMonitor', {
+      vpc,
+    });
+  });
+
+  test('Monitor is configured for Windows', () => {
+    // WHEN
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericWindowsImage({
+        'us-east-1': 'ami-any',
+      }),
+      renderQueue,
+      healthMonitor,
+    });
+    const userData = fleet.fleet.userData.render();
+
+    // THEN
+    // Ensure the configuration script is executed with the expected arguments.
+    expect(userData).toMatch(new RegExp(escapeTokenRegex('&\'C:/temp/${Token[TOKEN.\\d+]}${Token[TOKEN.\\d+]}\' \'63415\' \'10.1.9.2\'')));
+    // Ensure that the health monitor target group has been set up.
+    //  Note: It's sufficient to just check for any resource created by the HealthMonitor registration.
+    //   The HealthMonitor tests cover ensuring that all of the resources are set up.
+    expectCDK(wfstack).to(haveResourceLike('AWS::ElasticLoadBalancingV2::TargetGroup', {
+      HealthCheckIntervalSeconds: 300,
+      HealthCheckPort: '63415',
+      HealthCheckProtocol: 'HTTP',
+      Port: 8081,
+      Protocol: 'HTTP',
+      TargetType: 'instance',
+    }));
+  });
+
+  test('Monitor is configured for Linux', () => {
+    // WHEN
+    const fleet = new WorkerInstanceFleet(wfstack, 'workerFleet', {
+      vpc,
+      workerMachineImage: new GenericLinuxImage({
+        'us-east-1': 'ami-any',
+      }),
+      renderQueue,
+      healthMonitor,
+    });
+    const userData = fleet.fleet.userData.render();
+
+    // THEN
+    // Ensure the configuration script is executed with the expected arguments.
+    expect(userData).toMatch(new RegExp(escapeTokenRegex('\'/tmp/${Token[TOKEN.\\d+]}${Token[TOKEN.\\d+]}\' \'63415\' \'10.1.9.2\'')));
+    // Ensure that the health monitor target group has been set up.
+    //  Note: It's sufficient to just check for any resource created by the HealthMonitor registration.
+    //   The HealthMonitor tests cover ensuring that all of the resources are set up.
+    expectCDK(wfstack).to(haveResourceLike('AWS::ElasticLoadBalancingV2::TargetGroup', {
+      HealthCheckIntervalSeconds: 300,
+      HealthCheckPort: '63415',
+      HealthCheckProtocol: 'HTTP',
+      Port: 8081,
+      Protocol: 'HTTP',
+      TargetType: 'instance',
+    }));
   });
 });
 


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-rfdk/issues/208

This is a construct that provides helper methods for configuring a Deadline Worker in the RFDK context.

## Testing

This was tested by deploying both a WorkerInstanceFleet and a single instance using the WorkerConfiguration construct. Deployments were in the context of the simple app that's in the RFDK docs here -- https://docs.aws.amazon.com/rfdk/latest/guide/what-is-rfdk.html#why-use-the-rfdk . After deployment, I ensured that the setup was correct via the generated CloudWatch logs.

Python test code for the test was:

```python
import os
import jsii
import aws_cdk.core as core
import aws_cdk.aws_ec2 as ec2
import aws_cdk.aws_iam as iam
import aws_cdk.aws_efs as efs
import aws_rfdk as rfdk_core
import aws_rfdk.deadline as rfdk_deadline

@jsii.implements(rfdk_deadline.IHost)
class WorkerInstance(core.Construct):
  def __init__(self, scope: core.Construct, id: str, *, vpc: ec2.Vpc, render_queue: rfdk_deadline.RenderQueue) -> None:
    super().__init__(scope, id)

    deployment_region = core.Stack.of(self).region

    machine_image=ec2.MachineImage.generic_linux({
      deployment_region: "ami-05d4887175201bde8" # Deadline 10.1.10.6 AWSPortal Worker for Linux, us-west-2
    })
    self.os_type = machine_image.get_image(self).os_type
    self.grant_principal = iam.Role(self, 'WorkerRole', assumed_by=iam.ServicePrincipal('ec2.amazonaws.com'))
    self.user_data = ec2.UserData.for_linux()
    security_group = ec2.SecurityGroup(self, 'WorkerSecGrp',
      vpc=vpc,
      description='Security group for Fleet [fleet identifier]'
    )
    self.connections = ec2.Connections(security_groups=[security_group])

    # Note: Must configure userData before we render it
    config = rfdk_deadline.WorkerInstanceConfiguration(self, 'Config', 
      worker=self,
      render_queue=render_queue,
      cloudwatch_log_settings=rfdk_core.LogGroupFactoryProps(
        log_group_prefix='/test-worker/'
      ),
      worker_settings=rfdk_deadline.WorkerSettings(
        groups= ['g1'],
      )
    )

    worker_subnet = vpc.select_subnets(subnet_type=ec2.SubnetType.PRIVATE).subnets[0]
    worker_instance = ec2.CfnInstance(self, 'Worker', 
      image_id=machine_image.get_image(self).image_id,
      instance_type='t3.small',
      security_group_ids=[security_group.security_group_id],
      iam_instance_profile=iam.CfnInstanceProfile(self, 'WorkerProfile', 
        roles=[self.grant_principal.role_name],
      ).ref,
      user_data=core.Fn.base64(self.user_data.render()),
      subnet_id=worker_subnet.subnet_id,
      availability_zone=worker_subnet.availability_zone,
    )

  # =====================================
  # Properties for the IHost interface = (IConnection, IGrantable, IScriptHost)

  # --------
  #  ec2.IConnection
  @property
  def connections(self):
    return self._connections

  @connections.setter
  def connections(self, value):
    self._connections = value

  # -------
  #  iam.IGrantable
  @property
  def grant_principal(self):
    return self._grant_principal

  @grant_principal.setter
  def grant_principal(self, value):
    self._grant_principal = value

  # -----
  #  rfdk.IScriptHost
  @property
  def os_type(self):
    return self._os_type

  @os_type.setter
  def os_type(self, value):
    self._os_type = value

  @property
  def user_data(self):
    return self._user_data

  @user_data.setter
  def user_data(self, value):
    self._user_data = value

class InfrastructureStack(core.Stack):

  def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
    super().__init__(scope, id, **kwargs)

    self.vpc = ec2.Vpc(self, "Vpc", max_azs=2)

    script_dir = os.path.dirname(os.path.abspath(__file__))
    stage_dir = os.path.abspath(os.path.join(script_dir, '..', 'stage'))
    local_recipe_stage = rfdk_deadline.Stage.from_directory(stage_dir)
    server_recipes = rfdk_deadline.ThinkboxDockerRecipes(self, 'ServerImages',
      stage=local_recipe_stage
    )

    self.repository = rfdk_deadline.Repository(self, 'Repository',
      vpc=self.vpc,
      version=server_recipes.version,
      # Allow resources to be deleted when we delete the sample
      removal_policy=rfdk_deadline.RepositoryRemovalPolicies(
        database=core.RemovalPolicy.DESTROY,
        filesystem=core.RemovalPolicy.DESTROY
      )
    )
    
    self.render_queue = rfdk_deadline.RenderQueue(self, 'RenderQueue',
      vpc=self.vpc, 
      version=server_recipes.version,
      images=server_recipes.render_queue_images,
      repository=self.repository,
      # Allow the load-balancer to be deleted when we delete the sample
      deletion_protection=False,
    )



class WorkersStack(core.Stack):

  def __init__(self, scope: core.Construct, id: str, *, render_queue, vpc, **kwargs) -> None:
    super().__init__(scope, id, **kwargs)

    worker = WorkerInstance(self, 'Worker', vpc=vpc, render_queue=render_queue)

    health_monitor = rfdk_core.HealthMonitor(self, 'HealthMonitor',
      vpc=vpc,
      deletion_protection=False,
    )

    fleet = rfdk_deadline.WorkerInstanceFleet(self, 'LinWorkers',
      vpc=vpc, 
      render_queue=render_queue,
      worker_machine_image=ec2.MachineImage.generic_linux({
        # Fill in your AMI id here
        core.Stack.of(self).region: "ami-05d4887175201bde8" # Deadline 10.1.10.6 AWSPortal Worker for Linux, us-west-2
      }),
      min_capacity=5,
      instance_type=ec2.InstanceType("c5.large"),
      spot_price=0.15,
      health_monitor=health_monitor
    )

    fleet2 = rfdk_deadline.WorkerInstanceFleet(self, 'WinWorkers',
      vpc=vpc, 
      render_queue=render_queue,
      worker_machine_image=ec2.MachineImage.generic_windows({
        # Fill in your AMI id here
        core.Stack.of(self).region: "ami-09c712180218564f2" # Deadline 10.1.10.6 AWSPortal Worker for Windows, us-west-2
      }),
      min_capacity=5,
      instance_type=ec2.InstanceType("c5.large"),
      spot_price=0.25,
      health_monitor=health_monitor
    )
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
