### PR TITLE
feat(integ): add ability to run integration tests using ECR images

### DIFF
--- a/integ/lib/ThinkboxDockerImageOverrides.ts
+++ b/integ/lib/ThinkboxDockerImageOverrides.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Repository } from '@aws-cdk/aws-ecr';
+import { ContainerImage } from '@aws-cdk/aws-ecs';
+import { Construct } from '@aws-cdk/core';
+import {
+  RenderQueueImages,
+  ThinkboxManagedDeadlineDockerRecipes as Recipes,
+  UsageBasedLicensingImages,
+} from 'aws-rfdk/deadline';
+
+type DeadlineDockerImageOverrides = {[key in Recipes]?: string};
+
+/**
+ * Interface for Docker image overrides stored in an ECR repository.
+ */
+interface IECRImageOverrides {
+  /**
+   * The ARN of the ECR repository.
+   */
+  readonly repositoryArn: string;
+  /**
+   * A mapping of Deadline Docker recipe names (see ThinkboxManagedDeadlineDockerRecipes in aws-rfdk) to tags of the override Docker images
+   */
+  readonly imageOverrides: DeadlineDockerImageOverrides;
+}
+
+/**
+ * Implementation of {@link IECRImageOverrides}.
+ */
+class ECRImageOverrides implements IECRImageOverrides {
+  /**
+   * Creates an {@link ECRImageOverrides} from a JSON string.
+   * @param json The JSON string.
+   */
+  public static fromJSON(json: string): ECRImageOverrides {
+    const obj = JSON.parse(json);
+
+    // Validate the input JSON
+    const errors = [];
+    [
+      'repositoryArn',
+      'imageOverrides',
+    ].forEach(prop => {
+      if (!(prop in obj)) {
+        errors.push(`Property ${prop} was expected but not found in ${obj}`);
+      }
+    });
+    if (!(obj.imageOverrides instanceof Object)) {
+      errors.push(`Expected Object for imageOverrides but found ${typeof(obj.imageOverrides)}`);
+    }
+    Object.keys(obj.imageOverrides).forEach(key => {
+      if (!Object.values(Recipes).includes(key as Recipes)) {
+        errors.push(`Key ${key} in imageOverrides is invalid. Must be in: [${Object.values(Recipes)}].`);
+      }
+    });
+
+    if (errors.length > 0) {
+      throw new Error(`Invalid JSON for ECRImageOverrides: ${errors.join('\n')}`);
+    }
+
+    return obj as ECRImageOverrides;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public readonly repositoryArn: string;
+  /**
+   * @inheritdoc
+   */
+  public readonly imageOverrides: DeadlineDockerImageOverrides;
+
+  constructor(props: {repositoryArn: string, imageOverrides: DeadlineDockerImageOverrides}) {
+    this.repositoryArn = props.repositoryArn;
+    this.imageOverrides = props.imageOverrides;
+  }
+}
+
+/**
+ * Properties for {@link ThinkboxDockerImageOverrides}.
+ */
+export interface ThinkboxDockerImageOverridesProps {
+  /**
+   * The {@link RenderQueueImages} override.
+   */
+  readonly renderQueueImages?: RenderQueueImages;
+  /**
+   * The {@link UsageBasedLicensingImages} override.
+   */
+  readonly ublImages?: UsageBasedLicensingImages;
+}
+
+/**
+ * Contains overrides for Thinkbox Docker images used in the RFDK.
+ */
+export class ThinkboxDockerImageOverrides {
+  /**
+   * Creates a {@link ThinkboxDockerImageOverrides} from a JSON string. The JSON string must contain the fields in {@link IECRImageOverrides}.
+   */
+  public static fromJSON(scope: Construct, id: string, json: string): ThinkboxDockerImageOverrides {
+    const overrides: IECRImageOverrides = ECRImageOverrides.fromJSON(json);
+    const repository = Repository.fromRepositoryArn(scope, `${id}Repository`, overrides.repositoryArn);
+
+    return new ThinkboxDockerImageOverrides({
+      renderQueueImages: Recipes.REMOTE_CONNECTION_SERVER in overrides.imageOverrides ?
+        {
+          remoteConnectionServer: ContainerImage.fromEcrRepository(repository, overrides.imageOverrides[Recipes.REMOTE_CONNECTION_SERVER]),
+        } : undefined,
+      ublImages: Recipes.LICENSE_FORWARDER in overrides.imageOverrides ?
+        {
+          licenseForwarder: ContainerImage.fromEcrRepository(repository, overrides.imageOverrides[Recipes.LICENSE_FORWARDER]),
+        } : undefined,
+    });
+  }
+
+  /**
+   * The {@link RenderQueueImages} override.
+   */
+  public readonly renderQueueImages?: RenderQueueImages;
+
+  /**
+   * The {@link UsageBasedLicensingImages} override.
+   */
+  public readonly ublImages?: UsageBasedLicensingImages;
+
+  constructor(props: ThinkboxDockerImageOverridesProps) {
+    this.renderQueueImages = props.renderQueueImages;
+    this.ublImages = props.ublImages;
+  }
+}

--- a/integ/package.json
+++ b/integ/package.json
@@ -72,6 +72,8 @@
   "dependencies": {
     "@aws-cdk/aws-docdb": "1.72.0",
     "@aws-cdk/aws-ec2": "1.72.0",
+    "@aws-cdk/aws-ecr": "1.72.0",
+    "@aws-cdk/aws-ecs": "1.72.0",
     "@aws-cdk/aws-efs": "1.72.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "1.72.0",
     "@aws-cdk/aws-iam": "1.72.0",
@@ -87,6 +89,8 @@
   "peerDependencies": {
     "@aws-cdk/aws-docdb": "1.72.0",
     "@aws-cdk/aws-ec2": "1.72.0",
+    "@aws-cdk/aws-ecr": "1.72.0",
+    "@aws-cdk/aws-ecs": "1.72.0",
     "@aws-cdk/aws-efs": "1.72.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "1.72.0",
     "@aws-cdk/aws-iam": "1.72.0",

--- a/integ/test-config.sh
+++ b/integ/test-config.sh
@@ -16,6 +16,17 @@ export DEADLINE_VERSION
 #   - If set here, the version found in `manifest.json` at this path will override any value supplied for DEADLINE_VERSION
 export DEADLINE_STAGING_PATH
 
+# Override for Deadline Docker images that will be used over the images that can be built via the staged Deadline Docker recipes
+#   - If set, it must be a JSON string like:
+#     {
+#       "repositoryArn": <string>, (The ECR repository ARN)
+#       "imageOverrides": {
+#         <string>: <string>, (key = Deadline Docker recipe name (see ThinkboxManagedDeadlineDockerRecipes in aws-rfdk); value = tag of Docker image to use)
+#         ...
+#       }
+#     }
+export RFDK_DOCKER_IMAGE_OVERRIDES
+
 # EC2 AMIs to use for Deadline workers
 #   - If not set here, the appropriate basic worker AMI for the version of Deadline and region will be pulled from the public directory
 export LINUX_DEADLINE_AMI_ID

--- a/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-recipes.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-recipes.ts
@@ -17,16 +17,16 @@ import {
 /**
  * An enum that is associated with AWS Thinkbox managed recipes that are available in the stage manifest.
  */
-enum ThinkboxManagedDeadlineDockerRecipes {
+export enum ThinkboxManagedDeadlineDockerRecipes {
   /**
    * The Docker Image Asset for the Remote Connection Server.
    */
-  RemoteConnectionServer = 'rcs',
+  REMOTE_CONNECTION_SERVER = 'rcs',
 
   /**
    * The Docker Image Asset for the License Forwarder.
    */
-  LicenseForwarder = 'license-forwarder',
+  LICENSE_FORWARDER = 'license-forwarder',
 }
 
 /**
@@ -106,7 +106,7 @@ export class ThinkboxDockerRecipes extends Construct {
 
     this.version  = props.stage.getVersion(this, 'Version');
 
-    for (const recipe of [ThinkboxManagedDeadlineDockerRecipes.RemoteConnectionServer, ThinkboxManagedDeadlineDockerRecipes.LicenseForwarder]) {
+    for (const recipe of [ThinkboxManagedDeadlineDockerRecipes.REMOTE_CONNECTION_SERVER, ThinkboxManagedDeadlineDockerRecipes.LICENSE_FORWARDER]) {
       if (!props.stage.manifest.recipes[recipe]) {
         throw new Error(`Could not find ${recipe} recipe`);
       }
@@ -115,13 +115,13 @@ export class ThinkboxDockerRecipes extends Construct {
     this.remoteConnectionServer = props.stage.imageFromRecipe(
       this,
       'RemoteConnectionServer',
-      ThinkboxManagedDeadlineDockerRecipes.RemoteConnectionServer.toString(),
+      ThinkboxManagedDeadlineDockerRecipes.REMOTE_CONNECTION_SERVER.toString(),
     );
 
     this.licenseForwarder = props.stage.imageFromRecipe(
       this,
       'LicenseForwarder',
-      ThinkboxManagedDeadlineDockerRecipes.LicenseForwarder.toString(),
+      ThinkboxManagedDeadlineDockerRecipes.LICENSE_FORWARDER.toString(),
     );
 
     this.renderQueueImages = {


### PR DESCRIPTION
Adds options to override Deadline Docker images used in integration tests. This allows us to run integration tests on Docker images that are already built and in an ECR repository.

### Testing
- Built a Docker image for Deadline RCS and pushed it to an ECR repository
- Defined the `RFDK_DOCKER_IMAGE_OVERRIDES` environment variable with the appropriate JSON
- Ran the RFDK integration tests and ensured:
    1. The Docker images specified in the overrides were used over the ones that were built from staged recipes
    1. The integration tests succeeded

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
