### PR TITLE
chore: Adds supported Deadline versions to CHANGELOG

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -55,8 +55,17 @@ if [[ $version == "patch" ]]; then
   sed -i "s|$version_header|\1|" ./CHANGELOG.md
 fi
 
-# Add a section to the changelog that state the version of CDK being used
 version_header="# \[$new_version](.*) (.*)"
+
+# Add a section to the changelog that states the supported Deadline versions
+DEADLINE_RELEASE_NOTE_URL="https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html"
+DEADLINE_SUPPORTED_VERSIONS=$(node ./scripts/getSupportedDeadlineVersions.ts)
+MIN_DEADLINE_VERSION=$(echo "$DEADLINE_SUPPORTED_VERSIONS" | grep 'Min' | cut -f 2 -d ' ')
+MAX_DEADLINE_VERSION=$(echo "$DEADLINE_SUPPORTED_VERSIONS" | grep 'Max' | cut -f 2 -d ' ')
+deadline_version_section="\n\n\n### Officially Supported Deadline Versions\n\n* [${MIN_DEADLINE_VERSION} to ${MAX_DEADLINE_VERSION}](${DEADLINE_RELEASE_NOTE_URL})"
+sed -i "s|\($version_header\)|\1$deadline_version_section|" ./CHANGELOG.md
+
+# Add a section to the changelog that state the version of CDK being used
 cdk_version=$(node -p "require('./package.json').devDependencies['aws-cdk']")
 cdk_version_section="\n\n\n### Supported CDK Version\n\n* [$cdk_version](https://github.com/aws/aws-cdk/releases/tag/v$cdk_version)"
 sed -i "s|\($version_header\)|\1$cdk_version_section|" ./CHANGELOG.md

--- a/scripts/getSupportedDeadlineVersions.ts
+++ b/scripts/getSupportedDeadlineVersions.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 // Get the minimum supported version by pulling it from the Version class in
 // RFDK's Deadline submodule.

--- a/scripts/getSupportedDeadlineVersions.ts
+++ b/scripts/getSupportedDeadlineVersions.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+// Get the minimum supported version by pulling it from the Version class in
+// RFDK's Deadline submodule.
+
+const dlmod = require('../packages/aws-rfdk/lib/deadline');
+const minVersion = dlmod.Version.MINIMUM_SUPPORTED_DEADLINE_VERSION.toString();
+
+// Get the maximum supported version by querying the Deadline metadata file that is
+// hosted in S3.
+// Officially, the RFDK supports the latest version of Deadline that had been released
+// when the RFDK version releases.
+const mod = require('../packages/aws-rfdk/lib/core/lambdas/nodejs/lib/version-provider');
+const provider=new mod.VersionProvider();
+
+provider.getVersionUris({ product: mod.Product.deadline, platform: mod.Platform.linux })
+  .then(result => {
+    const version = result.get(mod.Platform.linux);
+    const maxVersion = `${version.MajorVersion}.${version.MinorVersion}.${version.ReleaseVersion}.${version.PatchVersion}`;
+    console.log(`Min: ${minVersion}\nMax: ${maxVersion}`);
+  })
+  .catch(error => {
+    console.error(`ERROR - ${error.message}`);
+    process.exit(1);
+  });


### PR DESCRIPTION
This is modifying the bump script to add the officially supported Deadline versions to the release changelog.

New section to the CHANGELOG looks like:
```
### Officially Supported Deadline Versions

* [10.1.9.2 to 10.1.10.6](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
