### PR TITLE
chore: configure dependabot to ignore cdk toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       - dependency-name: "constructs"
         versions: ">=3.0.4"
       - dependency-name: "@aws-cdk/*"
+      - dependency-name: "jsii*"
+      - dependency-name: "awslint"
     commit-message:
       prefix: "chore(deps):"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
fixes #215

## Problem

from the issue description:

>   Dependabot creates PRs to automatically update packages that are part of the CDK/JSII toolchain. Our process is to update these dependencies manually when we are updating to use the latest CDK version since we want the tool versions we use to match what is used to produce our target version of CDK.
>
> For this reason, we should configure dependabot to ignore these dependencies.

## Solution

Modified the dependabot configuration to ignore:

*   `jsii*`
*   `awslint`

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
