### PR TITLE
chore: pull amazonlinux Docker image from ECR

### DIFF
--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -16,11 +16,36 @@ SCRIPT_DIR=$(dirname $0)
 SCRIPT_DIR=$(readlink -f $SCRIPT_DIR)
 ROOT_DIR=$(readlink -f "${SCRIPT_DIR}/..")
 
+# Determine the ECR region we want to use
+set +e
+# First attempt to use the EC2 instance meta-data to determine the region
+ECR_REGION="$(curl -fs http://169.254.169.254/latest/meta-data/placement/region)"
+if [ "$?" -ne 0 ]; then
+    # Not running on EC2, so get region from AWS CLI configuration
+    ECR_REGION="$(aws configure get region)"
+    if [ "$?" -ne 0 || -z "${ECR_REGION}" ]; then
+        echo "ERROR: Could not determine region"
+        exit 1
+    fi
+fi
+set -e
+
 # Ensure that the docker daemon is running in the background
 # These commands are currently being done here instead of in buildspec due to the following issue: https://github.com/awslabs/aws-delivlib/issues/448
 # These commands come from the Codebuild sample for running docker on a custom image: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files
 docker info || nohup /usr/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &
 timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
+
+# Pull amazonlinux image locally from ECR. This is done to avoid pulling from DockerHub both for egress and rate
+# limiting.
+PULL_AL_FROM_ECR_ARGS=(
+    # Region of ECR repo
+    "${ECR_REGION}"
+    # Image versions to pull
+    "latest" # required for building and publishing lambda layers
+    "2"      # required for building Deadline docker images for running integration tests
+)
+/bin/bash ${SCRIPT_DIR}/pull_amazonlinux_from_ecr.sh "${PULL_AL_FROM_ECR_ARGS[@]}"
 
 # Build and publish lambda layers
 /bin/bash ${SCRIPT_DIR}/publish-all-lambda-layers.sh

--- a/scripts/pull_amazonlinux_from_ecr.sh
+++ b/scripts/pull_amazonlinux_from_ecr.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Fetches the amazonlinux Docker image from the official regional ECR and tags
+# it as-if it were fetched from DockerHub. This avoids any egress to the
+# internet when pulling images from AWS and also can be used to avoid DockerHub
+# rate limits.
+#
+# This assumes that the AWS CLI is configured to use AWS credentials with
+# sufficient access to query and pull images from the amazon linux ECR.
+#
+# For more information, see:
+# https://docs.aws.amazon.com/AmazonECR/latest/userguide/amazon_linux_container_image.html
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonelasticcontainerregistry.html
+#
+# USAGE
+#
+#   pull_amazonlinux_from_ecr.sh REGION [VERSION ...]
+#
+# ARGUMENTS
+#
+#   REGION
+#     The AWS region of the ECR repository to pull from
+#
+#   VERSION
+#     One or more Docker version tags to pull. If not specified, the "latest"
+#     tag will be pulled
+#
+# EXAMPLES
+#
+#   # Pulls the "latest" version from the us-east-1 ECR repo
+#   pull_amazonlinux_from_ecr.sh us-east-1
+#
+#   # Pulls the "amazonlinux:2" from the us-west-2 ECR repo
+#   pull_amazonlinux_from_ecr.sh us-west-2 2
+
+
+set -euo pipefail
+
+# The AWS account that contains the regional amazonlinux ECRs
+AWS_AL_ACCOUNT_ID=137112412989
+
+if [ "$#" -lt 1 ]; then
+    echo "ERROR: No region specified"
+    exit 1
+fi
+
+# Extract the AWS region from the first argument
+AWS_REGION="$1"; shift
+
+# Remaining arguments are the image version tags. If not specified, "latest" is
+# used.
+if [ "$#" -gt 0 ]; then
+    TAG_VERSIONS=( "$@" )
+else
+    TAG_VERSIONS=( "latest" )
+fi
+
+# Compute the ECR URI for the specified region
+AWS_AL_URI="${AWS_AL_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazonlinux"
+aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${AWS_AL_URI}"
+
+for TAG_VERSION in "${TAG_VERSIONS[@]}"; do
+    echo "Pulling amazonlinux:${TAG_VERSION}..."
+    docker pull "${AWS_AL_URI}:${TAG_VERSION}"
+    echo "Tagging amazonlinux:${TAG_VERSION}..."
+    docker tag "${AWS_AL_URI}:${TAG_VERSION}" "amazonlinux:${TAG_VERSION}"
+    echo "done"
+done


### PR DESCRIPTION
## Problem

Beginning November 2 2020, DockerHub began [rate-limiting unauthenticated image pulls](https://docs.docker.com/docker-hub/download-rate-limit/).

Part of the RFDK release automation involves building and publishing lambda layers for use in RFDK constructs. This step uses Docker and currently pulls `amazonlinux` Docker image from DockerHub. This does not authenticate with DockerHub before pulling images. As a result, when we run the release automation, we see the following error:

```
Step 1/4 : FROM amazonlinux
time="2020-11-09T19:54:55.633791062Z" level=error msg="Not continuing with pull after error: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

## Solution

Created a new script in `scripts/pull_amazonlinux_from_ecr.sh` that pulls Amazon Linux Docker images directly from the official AWS ECR repositories [using commands derived from these instructions](https://docs.aws.amazon.com/AmazonECR/latest/userguide/amazon_linux_container_image.html) and then tags them as-if they were pulled from DockerHub.

Modified `scripts/prep_release.sh`, which is the entry-point of our release bump automation to call `scripts/pull_amazonlinux_from_ecr.sh` before building and publishing the lambda layers.

## Testing

The `scripts/pull_amazonlinux_from_ecr.sh` was written to detect the EC2 region for the ECR pull from the instance meta-data. This will work from our pipeline. It has fallback logic to obtain the region from the AWS CLI for developer use. Tested using this code path and ran:

```sh
bash scripts/prep_release.sh
```

from my branch. Confirmed that it successfully pulled and tagged images from ECR succeeded and the lambda layers were published to my AWS account.

Launched an on-demand EC2 instance and manually ran the commands in the code-path that queries the EC2 instance meta-data. Confirmed the meta-data commands and error-handling works as expected.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
