### PR TITLE
fix(deadline): lock down DocDC engine to version 3.6.0

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
@@ -130,6 +130,7 @@ class StorageTierDocDB(StorageTier):
             # It is recommended that when creating your render farm you use at least 2 instances for redundancy.
             instances=1,
             master_user=Login(username='adminuser'),
+            engine_version='3.6.0',
             backup=BackupProps(
                 # We recommend setting the retention of your backups to 15 days
                 # for security reasons. The default retention is just one day.

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
@@ -116,6 +116,7 @@ export class StorageTierDocDB extends StorageTier {
       masterUser: {
         username: 'adminuser',
       },
+      engineVersion: '3.6.0',
       backup: {
         // We recommend setting the retention of your backups to 15 days
         // for security reasons. The default retention is just one day.

--- a/integ/lib/storage-struct.ts
+++ b/integ/lib/storage-struct.ts
@@ -95,6 +95,7 @@ export class StorageStruct extends Construct {
         masterUser: {
           username: 'DocDBUser',
         },
+        engineVersion: '3.6.0',
         backup: {
           retention: Duration.days(15),
         },

--- a/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
@@ -82,6 +82,7 @@ export interface MongoDbInstanceConnectionOptions {
 export abstract class DatabaseConnection {
   /**
    * Creates a DatabaseConnection which allows Deadline to connect to Amazon DocumentDB.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
    *
    * Resources Deployed
    * ------------------------
@@ -93,6 +94,7 @@ export abstract class DatabaseConnection {
 
   /**
    * Creates a DatabaseConnection which allows Deadline to connect to MongoDB.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
    *
    * Resources Deployed
    * ------------------------
@@ -273,10 +275,7 @@ class DocDBDatabaseConnection extends DatabaseConnection {
     // checking the value of the engineVersion property of that object.
     if (this.props.database.node.defaultChild) {
       const cluster = this.props.database.node.defaultChild! as CfnDBCluster;
-      if (cluster.engineVersion === '3.6.0') {
-        return true;
-      }
-      return false;
+      return cluster.engineVersion?.startsWith('3.6') ?? false;
     }
 
     return true; // No information, assume it's compatible.

--- a/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
@@ -44,7 +44,8 @@ import {
 export interface DocDBConnectionOptions {
 
   /**
-   * The Document DB Cluster this connection is for
+   * The Document DB Cluster this connection is for.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
    */
   readonly database: IDatabaseCluster;
 
@@ -61,6 +62,7 @@ export interface DocDBConnectionOptions {
 export interface MongoDbInstanceConnectionOptions {
   /**
    * The MongoDB database to connect to.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
    */
   readonly database: IMongoDb;
 

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -490,6 +490,7 @@ export class Repository extends Construct implements IRepository {
       const instances = props.documentDbInstanceCount ?? Repository.DEFAULT_NUM_DOCDB_INSTANCES;
       const dbCluster = new DatabaseCluster(this, 'DocumentDatabase', {
         masterUser: {username: 'DocDBUser'},
+        engineVersion: '3.6.0',
         instanceProps: {
           instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
           vpc: props.vpc,

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -288,6 +288,7 @@ export interface RepositoryProps {
 
   /**
    * Specify the database where the deadline schema needs to be initialized.
+   * Note that Deadline supports only databases that are compatible with MongoDB 3.6.
    *
    * @default A Document DB Cluster will be created with a single db.r5.large instance.
    */


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-rfdk/issues/229

## Testing

Did a quick deploy of the Deadline Repository & RCS. Verified it deployed successfully, and the DocDB engine version was correct. Also changed the engine version to 4.0.0 and did the same to verify that it changed there too.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
