### PR TITLE
chore: removed redundant packages field in lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,13 +2,6 @@
   "lerna": "3.15.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "packages": [
-    "examples/**",
-    "lambda-layers/",
-    "packages/aws-rfdk/*",
-    "tools/*",
-    "integ/"
-  ],
   "rejectCycles": "true",
   "version": "0.19.0"
 }


### PR DESCRIPTION
### Summary
Our `lerna.json` file has a `packages` field, but since we're using yarn workspaces, lerna will use the value in `workspaces.packages` in `package.json` instead.

### Testing
Ran the following commands and ensured lerna works as expected for all workspaces:
- `yarn build`
- `yarn clean`
- `yarn package`
- `yarn release`
- `./bump.sh`
- `./pack.sh`
- `scripts/fix-peer-deps.sh`
- `scripts/generate-aggregate-tsconfig.sh`
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
