### PR TITLE
feat(deadline): add custom user data commands to Worker instance startup

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/compute_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/compute_tier.py
@@ -17,15 +17,20 @@ from aws_cdk.aws_ec2 import (
     IVpc,
     Port
 )
+from aws_cdk.aws_s3_assets import (
+  Asset
+)
 
 from aws_rfdk import (
     HealthMonitor,
 )
 from aws_rfdk.deadline import (
+    InstanceUserDataProvider,
     IRenderQueue,
     WorkerInstanceFleet,
 )
 
+import os
 
 @dataclass
 class ComputeTierProps(StackProps):
@@ -43,6 +48,30 @@ class ComputeTierProps(StackProps):
     # The bastion host to  allow connection to Worker nodes.
     bastion: Optional[BastionHostLinux] = None
 
+class UserDataProvider(InstanceUserDataProvider):
+    def __init__(self, scope: Construct, stack_id: str):
+        super().__init__(scope, stack_id)
+        self.test_script=Asset(scope, "SampleAsset",
+            path=os.path.join(os.getcwd(), "..", "scripts", "configure_worker.sh")
+        )
+
+    def pre_cloud_watch_agent(self, host) -> None:
+        host.user_data.add_commands("echo preCloudWatchAgent")
+
+    def pre_render_queue_configuration(self, host) -> None:
+        host.user_data.add_commands("echo preRenderQueueConfiguration")
+
+    def pre_worker_configuration(self, host) -> None:
+        host.user_data.add_commands("echo preWorkerConfiguration")
+
+    def post_worker_launch(self, host) -> None:
+        host.user_data.add_commands("echo postWorkerLaunch")
+        self.test_script.grant_read(host)
+        local_path = host.user_data.add_s3_download_command(
+            bucket=self.test_script.bucket,
+            bucket_key=self.test_script.s3_object_key
+        )
+        host.user_data.add_execute_file_command(file_path=local_path)
 
 class ComputeTier(Stack):
     """
@@ -78,6 +107,7 @@ class ComputeTier(Stack):
             worker_machine_image=props.worker_machine_image,
             health_monitor=self.health_monitor,
             key_name=props.key_pair_name,
+            user_data_provider=UserDataProvider(self, 'UserDataProvider')
         )
 
         if props.bastion:

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/scripts/configure_worker.sh
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/scripts/configure_worker.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# This script is only here to illustrate how to add custom user data when using our WorkerInstanceFleet and WorkerInstanceConfiguration constructs
+mkdir test_dir 

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -319,3 +319,23 @@ const workerFleet = new WorkerInstanceFleet(stack, 'WorkerFleet', {
   }
 });
 ```
+
+### User data scripts for the Worker configuration
+
+You have possibility to run user data scripts at various points during the Worker configuration lifecycle.
+
+To do this, subclass `InstanceUserDataProvider` and override desired methods:
+```ts
+class UserDataProvider extends InstanceUserDataProvider {
+  preCloudWatchAgent(host: IHost): void {
+    host.userData.addCommands('echo preCloudWatchAgent');
+  }
+}
+const fleet = new WorkerInstanceFleet(stack, 'WorkerFleet', {
+  vpc,
+  renderQueue,
+  workerMachineImage: /* ... */,
+  userDataProvider: new UserDataProvider(stack, 'UserDataProvider'),
+});
+
+```

--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -55,6 +55,7 @@ import {
 } from './render-queue';
 import { Version } from './version';
 import {
+  IInstanceUserDataProvider,
   WorkerInstanceConfiguration,
   WorkerSettings,
 } from './worker-configuration';
@@ -189,6 +190,12 @@ export interface WorkerInstanceFleetProps extends WorkerSettings {
    * @default The default devices of the provided ami will be used.
    */
   readonly blockDevices?: BlockDevice[];
+
+  /**
+   * An optional provider of user data commands to be injected at various points during the Worker configuration lifecycle.
+   * You can provide a subclass of InstanceUserDataProvider with the methods overridden as desired.
+   */
+  readonly userDataProvider?: IInstanceUserDataProvider;
 }
 
 /**
@@ -449,6 +456,7 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
       },
       renderQueue: props.renderQueue,
       workerSettings: props,
+      userDataProvider: props.userDataProvider,
     });
 
     // Updating the user data with successful cfn-signal commands.

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -47,8 +47,3 @@ export const RQ_CONNECTION_ASSET = {
   Bucket: 'AssetParameters89a29e05a2a88ec4d4a02e847e3c3c9461d0154b326492f4cad655d4ca0bda98S3BucketC22E185C',
   Key: 'AssetParameters89a29e05a2a88ec4d4a02e847e3c3c9461d0154b326492f4cad655d4ca0bda98S3VersionKey0833D670',
 };
-
-export const VERSION_QUERY_ASSET = {
-  Bucket: stringLike('AssetParameters*S3Bucket6ABF873D'),
-  Key: stringLike('AssetParameters*S3VersionKey5A5FE29C'),
-};

--- a/packages/aws-rfdk/lib/deadline/test/version-query.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/version-query.test.ts
@@ -18,8 +18,6 @@ import {
   VersionQuery,
 } from '../lib';
 
-import { VERSION_QUERY_ASSET } from './asset-constants';
-
 test('VersionQuery constructor full version', () => {
   const app = new App();
   const stack = new Stack(app, 'Stack');
@@ -57,44 +55,6 @@ test('VersionQuery constructor full version', () => {
     ],
   }));
   expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
-    Code: {
-      S3Bucket: {
-        Ref: VERSION_QUERY_ASSET.Bucket,
-      },
-      S3Key: {
-        'Fn::Join': [
-          '',
-          [
-            {
-              'Fn::Select': [
-                0,
-                {
-                  'Fn::Split': [
-                    '||',
-                    {
-                      Ref: VERSION_QUERY_ASSET.Key,
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              'Fn::Select': [
-                1,
-                {
-                  'Fn::Split': [
-                    '||',
-                    {
-                      Ref: VERSION_QUERY_ASSET.Key,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        ],
-      },
-    },
     Handler: 'version-provider.handler',
     Role: {
       'Fn::GetAtt': [


### PR DESCRIPTION
## Problem
Users do not have possibility to run user data scripts before worker configured and run by RFDK configuration script.
Was created issue with request to add this functional: [Worker nodes and UserData](https://github.com/aws/aws-rfdk/issues/191)

## Solution
Was chosen solution that allows user to create class with methods that add user data scripts in all stages of worker configuration.
Was added interface `IInstanceUserDataProvider` and class `InstanceUserDataProvider` with three methods.
Every method can be overridden by user and has possibility to modify worker user data.
Were added examples for this functionality for Python and Typescript.

## Testing
Was added integration tests that cover 100% of new functionality.
Were deployed Python and Typescript examples and verified that all expected code was added to userdata and example script was copied to worker instance and run.

Was removed validation S3Bucket in version query test because these values are changed periodically.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
