### PR TITLE
fix(integ): Support last changes in Deadline 10.1.11

### DIFF
--- a/integ/components/deadline/deadline_03_workerFleetHttp/test/deadline_03_workerFleetHttp.test.ts
+++ b/integ/components/deadline/deadline_03_workerFleetHttp/test/deadline_03_workerFleetHttp.test.ts
@@ -123,7 +123,8 @@ describe.each(testCases)('Deadline WorkerFleet tests (%s)', (_, id) => {
       };
       return awaitSsmCommand(bastionId, params).then( response => {
         var responseOutput = response.output;
-        expect(responseOutput).toMatch(/testpool\ntestgroup\ntestregion/);
+        // Starting Deadline 10.1.11 regions that wasn't added do not apply to worker and returned as unrecognized.
+        expect(responseOutput).toMatch(/testpool\ntestgroup\n(?:unrecognized|testregion)/);
       });
     });
 

--- a/integ/components/deadline/deadline_04_workerFleetHttps/test/deadline_04_workerFleetHttps.test.ts
+++ b/integ/components/deadline/deadline_04_workerFleetHttps/test/deadline_04_workerFleetHttps.test.ts
@@ -175,7 +175,8 @@ describe.each(testCases)('Deadline WorkerFleetHttps tests (%s)', (_, id) => {
       };
       return awaitSsmCommand(bastionId, params).then( response => {
         var responseOutput = response.output;
-        expect(responseOutput).toMatch(/testpool\ntestgroup\ntestregion/);
+        // Starting Deadline 10.1.11 regions that wasn't added do not apply to worker and returned as unrecognized.
+        expect(responseOutput).toMatch(/testpool\ntestgroup\n(?:unrecognized|testregion)/);
       });
     });
 

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
@@ -81,7 +81,7 @@ for file in /var/lib/Thinkbox/Deadline10/slaves/*
 do
   file="${file##*/}"
   workerSuffix="${file%%.*}"
-  if [ -z "$workerSuffix" ]; then
+  if [[ -z "$workerSuffix" || "$workerSuffix" = "*" ]]; then
     WORKER_NAMES+=( "$WORKER_NAME_PREFIX" )
   else
     WORKER_NAMES+=( "$WORKER_NAME_PREFIX"-$workerSuffix )
@@ -115,10 +115,13 @@ fi
 
 # Restart service, if it exists, else restart application
 if service --status-all | grep -q 'Deadline 10 Launcher'; then
-  service deadline10launcher restart
+  service deadline10launcher stop
+  sudo killall -w deadlineworker || true
+  service deadline10launcher start
 else
   DEADLINE_LAUNCHER="$DEADLINE_PATH/deadlinelauncher"
   "$DEADLINE_LAUNCHER" -shutdownall
+  sudo killall -w deadlineworker || true
   "$DEADLINE_LAUNCHER"
 fi
 

--- a/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorker.ps1
+++ b/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorker.ps1
@@ -70,6 +70,10 @@ Foreach-Object {
         $WORKER_NAMES+="$WORKER_NAME_PREFIX-$workerConfigName"
     }
 }
+if ( $WORKER_NAMES.count -eq 0 )
+{
+    $WORKER_NAMES+=$WORKER_NAME_PREFIX
+}
 
 $WORKER_NAMES_CSV=$WORKER_NAMES -join ","
 
@@ -99,10 +103,13 @@ if($WORKER_POOLS) {
 
 $serviceName="deadline10launcherservice"
 If (Get-Service $serviceName -ErrorAction SilentlyContinue) {
-    Restart-Service $serviceName
+    Stop-Service $serviceName
+    taskkill /f /fi "IMAGENAME eq deadlineworker.exe"
+    Start-Service $serviceName
 } Else {
     $DEADLINE_LAUNCHER = $DEADLINE_PATH + '/deadlinelauncher.exe'
     & $DEADLINE_LAUNCHER -shutdownall | Out-Default
+    taskkill /f /fi "IMAGENAME eq deadlineworker.exe"
     & $DEADLINE_LAUNCHER
 }
 

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -16,14 +16,14 @@ export { CWA_ASSET_LINUX, CWA_ASSET_WINDOWS, linuxDownloadRunScriptBoilerplate, 
 
 // configureWorker.sh
 export const CONFIG_WORKER_ASSET_LINUX = {
-  Bucket: 'AssetParameterscfbac966c059b6d160d9fe1be830ff2b4e3b3e8583d44c5e6a9ef3cc617cae52S3BucketEC9648BD',
-  Key: 'AssetParameterscfbac966c059b6d160d9fe1be830ff2b4e3b3e8583d44c5e6a9ef3cc617cae52S3VersionKey14E8A825',
+  Bucket: 'AssetParameterse90d5322c2b7457e7dbbacdfc3a350aa501f6a63b939475977f2464abb268b73S3Bucket1840D7FB',
+  Key: 'AssetParameterse90d5322c2b7457e7dbbacdfc3a350aa501f6a63b939475977f2464abb268b73S3VersionKey7BA1309D',
 };
 
 // configureWorker.ps1
 export const CONFIG_WORKER_ASSET_WINDOWS = {
-  Bucket: 'AssetParametersb78a6a7981377c750b127331abdcbd9f1ab312242da73512424611e965eea4c1S3BucketFDCB6ECC',
-  Key: 'AssetParametersb78a6a7981377c750b127331abdcbd9f1ab312242da73512424611e965eea4c1S3VersionKey20AFBF6B',
+  Bucket: 'AssetParametersb1df82abec8605ca7a4666803d27eafda3bd66a9db0e5366d61cdf3d184af8b2S3BucketD9C14531',
+  Key: 'AssetParametersb1df82abec8605ca7a4666803d27eafda3bd66a9db0e5366d61cdf3d184af8b2S3VersionKey40FA52FC',
 };
 
 // installDeadlineRepository.sh


### PR DESCRIPTION
## Problem
The last Deadline 10.1.11 brings some changes that make RFDK integration tests fail.
1) New AMIs have worker autostart is off that lead to unable to configure pools and groups
2) Restarting `DeadlineLauncher` right after start leads to worker continue without last changes in `deadline.ini`
3) New region validation does not allow to set reqion that wasn't previosly added in network configuration.

## Solution
1) If worker was not found was added default worker to the list.
2) After stop deadline launcher was added command to kill deadline worker process.
3) Were changed tests to expect `unrecognized` region instead of `testregion`

## Testing
For testing were ran integration tests and make sure that all tests passed.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
