### PR TITLE
chore(integ): add ability to run integration tests in parallel

### DIFF
--- a/integ/components/deadline/common/scripts/bash/deploy-utils.sh
+++ b/integ/components/deadline/common/scripts/bash/deploy-utils.sh
@@ -20,9 +20,13 @@ function deploy_component_stacks () {
   echo "Running $COMPONENT_NAME end-to-end test..."
 
   echo "Deploying test app for $COMPONENT_NAME test suite"
-  npx cdk deploy "*" --require-approval=never
+  if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+    npx cdk deploy "*" --require-approval=never > "$INTEG_TEMP_DIR/${COMPONENT_NAME}_deploy.txt" 2>&1
+  else
+    npx cdk deploy "*" --require-approval=never
+  fi
   echo "Test app $COMPONENT_NAME deployed."
-
+  
   return 0
 }
 
@@ -32,7 +36,11 @@ function execute_component_test () {
   run_aws_interaction_hook
 
   echo "Running test suite $COMPONENT_NAME..."
-  yarn run test "$COMPONENT_NAME.test" --json --outputFile="./.e2etemp/$COMPONENT_NAME.json"
+  if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+    yarn run test "$COMPONENT_NAME.test" --json --outputFile="$INTEG_TEMP_DIR/$COMPONENT_NAME.json" > "$INTEG_TEMP_DIR/${COMPONENT_NAME}.txt" 2>&1
+  else
+    yarn run test "$COMPONENT_NAME.test" --json --outputFile="$INTEG_TEMP_DIR/$COMPONENT_NAME.json"
+  fi
   echo "Test suite $COMPONENT_NAME complete."
 
   return 0
@@ -44,7 +52,11 @@ function destroy_component_stacks () {
   run_aws_interaction_hook
 
   echo "Destroying test app $COMPONENT_NAME..."
-  npx cdk destroy "*" -f
+  if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+    npx cdk destroy "*" -f > "$INTEG_TEMP_DIR/${COMPONENT_NAME}_destroy.txt" 2>&1
+  else
+    npx cdk destroy "*" -f
+  fi
   rm -f "./cdk.context.json"
   rm -rf "./cdk.out"
   echo "Test app $COMPONENT_NAME destroyed."

--- a/integ/scripts/bash/rfdk-integ-e2e.sh
+++ b/integ/scripts/bash/rfdk-integ-e2e.sh
@@ -94,7 +94,7 @@ for COMPONENT in **/cdk.json; do
         # Excecute the e2e test in the component's scripts directory
         cd "$INTEG_ROOT/$COMPONENT_ROOT"
         if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
-            ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" || ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" --destroy-only &
+            (../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" || ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" --destroy-only) &
             export ${COMPONENT_NAME}_PID=$!
             COMPONENTS+=(${COMPONENT_NAME})
         else
@@ -118,6 +118,9 @@ if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
               fi
               if [ -f "$INTEG_TEMP_DIR/${COMPONENT_NAME}.txt" ]; then
                 cat "$INTEG_TEMP_DIR/${COMPONENT_NAME}.txt"
+              fi
+              if [ -f "$INTEG_TEMP_DIR/${COMPONENT_NAME}_destroy.txt" ]; then
+                cat "$INTEG_TEMP_DIR/${COMPONENT_NAME}_destroy.txt"
               fi
             fi
             export ${COMPONENT_NAME}_FINISH_TIME=$SECONDS

--- a/integ/scripts/bash/rfdk-integ-e2e.sh
+++ b/integ/scripts/bash/rfdk-integ-e2e.sh
@@ -37,6 +37,7 @@ fi
 
 # Create temp directory
 export INTEG_TEMP_DIR="$INTEG_ROOT/.e2etemp"
+rm -rf $INTEG_TEMP_DIR
 mkdir -p $INTEG_TEMP_DIR
 
 # Stage deadline from script
@@ -76,6 +77,7 @@ $BASH_SCRIPTS/deploy-infrastructure.sh || cleanup_on_failure
 export INFRASTRUCTURE_DEPLOY_FINISH_TIME=$SECONDS
 
 # Pull the top level directory for each cdk app in the components directory
+COMPONENTS=()
 for COMPONENT in **/cdk.json; do
     # In case the yarn install was done inside this integ package, there are some example cdk.json files in the aws-cdk
     # package we want to avoid.
@@ -90,10 +92,46 @@ for COMPONENT in **/cdk.json; do
     export ${COMPONENT_NAME}_START_TIME=$SECONDS
     if [[ "$COMPONENT_NAME" != _* ]]; then
         # Excecute the e2e test in the component's scripts directory
-        cd "$INTEG_ROOT/$COMPONENT_ROOT" && ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" || cleanup_on_failure
+        cd "$INTEG_ROOT/$COMPONENT_ROOT"
+        if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+            ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" || ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" --destroy-only &
+            export ${COMPONENT_NAME}_PID=$!
+            COMPONENTS+=(${COMPONENT_NAME})
+        else
+            ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" || cleanup_on_failure
+        fi
     fi
     export ${COMPONENT_NAME}_FINISH_TIME=$SECONDS
 done
+
+if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+    while [ "${#COMPONENTS[@]}" -ne 0 ]; do
+        ACTIVE_COMPONENTS=()
+        for COMPONENT_NAME in ${COMPONENTS[@]}; do
+            PID=$(eval echo \"\$${COMPONENT_NAME}_PID\")
+            if ps -p "$PID" > /dev/null; then
+              ACTIVE_COMPONENTS+=(${COMPONENT_NAME})
+            else
+              echo "Test app $COMPONENT_NAME finished."
+              if [ -f "$INTEG_TEMP_DIR/${COMPONENT_NAME}_deploy.txt" ]; then
+                cat "$INTEG_TEMP_DIR/${COMPONENT_NAME}_deploy.txt"
+              fi
+              if [ -f "$INTEG_TEMP_DIR/${COMPONENT_NAME}.txt" ]; then
+                cat "$INTEG_TEMP_DIR/${COMPONENT_NAME}.txt"
+              fi
+            fi
+            export ${COMPONENT_NAME}_FINISH_TIME=$SECONDS
+        done
+        if [ "${#ACTIVE_COMPONENTS[@]}" -ne 0 ]; then
+          COMPONENTS=(${ACTIVE_COMPONENTS[@]})
+        else
+          COMPONENTS=()
+        fi
+        sleep 1
+    done
+
+    wait
+fi
 
 # Mark infrastructure destroy start time
 export INFRASTRUCTURE_DESTROY_START_TIME=$SECONDS

--- a/integ/test-config.sh
+++ b/integ/test-config.sh
@@ -37,3 +37,6 @@ export SKIP_deadline_01_repository_TEST
 export SKIP_deadline_02_renderQueue_TEST
 export SKIP_deadline_03_workerFleetHttp_TEST
 export SKIP_deadline_04_workerFleetHttps_TEST
+
+# All test suites will be run in parallel
+export RUN_TESTS_IN_PARALLEL

--- a/integ/test-config.sh
+++ b/integ/test-config.sh
@@ -39,4 +39,4 @@ export SKIP_deadline_03_workerFleetHttp_TEST
 export SKIP_deadline_04_workerFleetHttps_TEST
 
 # All test suites will be run in parallel
-export RUN_TESTS_IN_PARALLEL
+export RUN_TESTS_IN_PARALLEL=false


### PR DESCRIPTION
## Problem
Currently we only have possibility to run integration tests consistently that takes a lot of time

## Solution
Integration test will be running in separate processes.

## Testing
For testing were run integration tests.
Verified that all tests passed and result displayed properly.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
