### PR TITLE
chore: update copyright dates for 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -214,7 +214,7 @@ limitations under the License.
 ------
 
 ** openssl -- https://www.openssl.org/
-Copyright (c) 1998-2020 The OpenSSL Project
+Copyright (c) 1998-2021 The OpenSSL Project
 Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
 All rights reserved.
 

--- a/integ/LICENSE
+++ b/integ/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/integ/NOTICE
+++ b/integ/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/lambda-layers/LICENSE
+++ b/lambda-layers/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lambda-layers/NOTICE
+++ b/lambda-layers/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/packages/aws-rfdk/LICENSE
+++ b/packages/aws-rfdk/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/aws-rfdk/NOTICE
+++ b/packages/aws-rfdk/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/tools/cdk-build-tools/LICENSE
+++ b/tools/cdk-build-tools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/tools/cdk-build-tools/NOTICE
+++ b/tools/cdk-build-tools/NOTICE
@@ -1,2 +1,2 @@
 AWS Cloud Development Kit (AWS CDK)
-Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/tools/pkglint/LICENSE
+++ b/tools/pkglint/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/tools/pkglint/NOTICE
+++ b/tools/pkglint/NOTICE
@@ -1,2 +1,2 @@
 AWS Cloud Development Kit (AWS CDK)
-Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION

awslint tests check LICENSE and NOTICE for consistency in the current year, but the LICENSE and NOTICE files still have 2020 as the copyright year rather than 2021

RFDK equivalent of https://github.com/aws/aws-cdk/issues/12303

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
