### PR TITLE
feat(deadline): add ability to horizontally scale the RenderQueue

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -77,8 +77,8 @@ export interface RenderQueueSizeConstraints {
    * If this is set to a number, every deployment will reset the number of RCS processes
    * to this number. It is recommended to leave this value undefined.
    *
-   * Currently, the Deadline RCS does not properly support being horizontally scaled behind a load-balancer. For this
-   * reason, the desired number of processes can only be set to 1 currently.
+   * Deadline versions earlier than 10.1.10 do not support being horizontally scaled behind a load-balancer.
+   * For these versions of Deadline, the desired number of processes can only be set to 1.
    *
    * @default The min size.
    */
@@ -87,14 +87,27 @@ export interface RenderQueueSizeConstraints {
   /**
    * Minimum number of Deadline RCS processes that will serve RenderQueue requests.
    *
-   * Currently, the Deadline RCS does not properly support being horizontally scaled behind a load-balancer. For this
-   * reason, the minimum can be at most one, otherwise an error is thrown.
+   * Deadline versions earlier than 10.1.10 do not support being horizontally scaled behind a load-balancer.
+   * For these versions of Deadline, the minimum number of processes can only be set to 1, otherwise an error is thrown.
    *
-   * The minimum that this can value be set to is 1.
+   * The minimum that this value can be set to is 1.
    *
    * @default 1
    */
   readonly min?: number;
+
+  /**
+   * Maximum number of Deadline RCS processes that will serve RenderQueue requests.
+   *
+   * Deadline versions earlier than 10.1.10 do not support being horizontally scaled behind a load-balancer.
+   * For these versions of Deadline, the maximum number of processes can only be set to 1, otherwise an error is thrown.
+   *
+   * The minimum that this value can be set to is 1.
+   * This value cannot be less than `min` or `desired`.
+   *
+   * @default 1
+   */
+  readonly max?: number;
 }
 
 /**
@@ -283,7 +296,7 @@ export interface RenderQueueProps {
    * Constraints on the number of Deadline RCS processes that can be run as part of this
    * RenderQueue.
    *
-   * @default Allow no more and no less than one Deadline RCS to be running.
+   * @default Allow no less than one Deadline RCS to be running.
    */
   readonly renderQueueSize?: RenderQueueSizeConstraints;
 


### PR DESCRIPTION
## Problem
Since Deadline 10.1.10 we have possibility to create multiple RCS machines.

## Solution
Removing limitation of maximum instances for RCS if version greater than 10.1.9.

## Testing
 - Was creating farm with two RCS instances (set parameter `desired` in `RenderQueue` construct to 2
 - Verified that two RCS instances appeared in `Connection servers` panel
 - Increasing number of workers to 200 and run 2000 task, after that verified that both instances were used.
 - Increasing number of desired instances to 7 and verified that after deploying changed code were created 7 RCS instances and all appeared on `Connection servers` panel
 - Decreasing number of desired instances to 3 and verified that only 3 RCS instances were running after deployment.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
