### PR TITLE
feat(deadline): add security group configuration for Repository and RenderQueue

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
@@ -286,6 +286,12 @@ export interface IMongoDb extends IConnectable, IConstruct {
    * The version of MongoDB that is running on this instance.
    */
   readonly version: MongoDbVersion;
+
+  /**
+   * Adds security groups to the database.
+   * @param securityGroups The security groups to add.
+   */
+  addSecurityGroup(...securityGroups: ISecurityGroup[]): void;
 }
 
 /**
@@ -485,6 +491,13 @@ export class MongoDbInstance extends Construct implements IMongoDb, IGrantable {
 
     // Tag deployed resources with RFDK meta-data
     tagConstruct(this);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public addSecurityGroup(...securityGroups: ISecurityGroup[]): void {
+    securityGroups?.forEach(securityGroup => this.server.autoscalingGroup.addSecurityGroup(securityGroup));
   }
 
   /**

--- a/packages/aws-rfdk/lib/core/test/mongodb-instance.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-instance.test.ts
@@ -724,6 +724,31 @@ describe('Test MongoDbInstance', () => {
     }));
   });
 
+  test('adds security group', () => {
+    // GIVEN
+    const securityGroup = new SecurityGroup(stack, 'NewSecurityGroup', {
+      vpc,
+    });
+    const instance = new MongoDbInstance(stack, 'MongoDbInstance', {
+      mongoDb: {
+        version,
+        dnsZone,
+        hostname,
+        serverCertificate: serverCert,
+        userSsplAcceptance,
+      },
+      vpc,
+    });
+
+    // WHEN
+    instance.addSecurityGroup(securityGroup);
+
+    // THEN
+    cdkExpect(stack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+      SecurityGroups: arrayWith(stack.resolve(securityGroup.securityGroupId)),
+    }));
+  });
+
   testConstructTags({
     constructName: 'MongoDbInstance',
     createConstruct: () => {

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -213,9 +213,9 @@ export interface RenderQueueAccessLogProps {
 }
 
 /**
- * Options for security groups of the Render Queue.
+ * Security groups of the Render Queue.
  */
-export interface RenderQueueSecurityGroupsOptions {
+export interface RenderQueueSecurityGroups {
   /**
    * The security group for the backend components of the Render Queue, which consists of the AutoScalingGroup for the Deadline RCS.
    */
@@ -329,9 +329,11 @@ export interface RenderQueueProps {
   readonly deletionProtection?: boolean;
 
   /**
-   * Options to add additional security groups to the Render Queue.
+   * Security groups to use for the Render Queue.
+   *
+   * @default - new security groups are created
    */
-  readonly securityGroupsOptions?: RenderQueueSecurityGroupsOptions;
+  readonly securityGroups?: RenderQueueSecurityGroups;
 }
 
 /**

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -8,6 +8,7 @@ import {
 } from '@aws-cdk/aws-certificatemanager';
 import {
   InstanceType,
+  ISecurityGroup,
   IVpc,
   SubnetSelection,
 } from '@aws-cdk/aws-ec2';
@@ -212,6 +213,20 @@ export interface RenderQueueAccessLogProps {
 }
 
 /**
+ * Options for security groups of the Render Queue.
+ */
+export interface RenderQueueSecurityGroupsOptions {
+  /**
+   * The security group for the backend components of the Render Queue, which consists of the AutoScalingGroup for the Deadline RCS.
+   */
+  readonly backend?: ISecurityGroup;
+  /**
+   * The security group for the frontend of the Render Queue, which is its load balancer.
+   */
+  readonly frontend?: ISecurityGroup;
+}
+
+/**
  * Properties for the Render Queue
  */
 export interface RenderQueueProps {
@@ -312,6 +327,11 @@ export interface RenderQueueProps {
    * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection
    */
   readonly deletionProtection?: boolean;
+
+  /**
+   * Options to add additional security groups to the Render Queue.
+   */
+  readonly securityGroupsOptions?: RenderQueueSecurityGroupsOptions;
 }
 
 /**

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -306,7 +306,7 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       }],
       updateType: UpdateType.ROLLING_UPDATE,
       // @ts-ignore
-      securityGroup: props.securityGroupsOptions?.backend,
+      securityGroup: props.securityGroups?.backend,
     });
 
     /**
@@ -350,7 +350,7 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       vpcSubnets: props.vpcSubnetsAlb ?? { subnetType: SubnetType.PRIVATE, onePerAz: true },
       internetFacing: false,
       deletionProtection: props.deletionProtection ?? true,
-      securityGroup: props.securityGroupsOptions?.frontend,
+      securityGroup: props.securityGroups?.frontend,
     });
 
     this.pattern = new ApplicationLoadBalancedEc2Service(this, 'AlbEc2ServicePattern', {

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -24,6 +24,7 @@ import {
   InstanceClass,
   InstanceSize,
   InstanceType,
+  ISecurityGroup,
   IVpc,
   OperatingSystemType,
   SubnetSelection,
@@ -243,6 +244,26 @@ export interface RepositoryRemovalPolicies {
 }
 
 /**
+ * Options for the security groups of the Repository.
+ */
+export interface RepositorySecurityGroupsOptions {
+  /**
+   * The security group for the filesystem of the Repository. This is ignored if the Repository is not creating
+   * its own Amazon Elastic File System (EFS) because one was given.
+   */
+  readonly fileSystem?: ISecurityGroup;
+  /**
+   * The security group for the database of the Repository. This is ignored if the Repository is not creating
+   * its own DocumentDB database because one was given.
+   */
+  readonly database?: ISecurityGroup;
+  /**
+   * The security group for the AutoScalingGroup of the instance that runs the Deadline Repository installer.
+   */
+  readonly installer?: ISecurityGroup;
+}
+
+/**
  * Properties for the Deadline repository
  */
 export interface RepositoryProps {
@@ -339,6 +360,11 @@ export interface RepositoryProps {
    * @default Duration.days(15) for the database
    */
   readonly backupOptions?: RepositoryBackupOptions;
+
+  /**
+   * Options to add additional security groups to the Repository.
+   */
+  readonly securityGroupsOptions?: RepositorySecurityGroupsOptions;
 }
 
 /**
@@ -437,6 +463,12 @@ export class Repository extends Construct implements IRepository {
   public readonly fileSystem: IMountableLinuxFilesystem;
 
   /**
+   * The underlying Amazon Elastic File System (EFS) used by the Repository.
+   * This is only defined if this Repository created its own filesystem, otherwise it will be `undefined`.
+   */
+  public readonly efs?: EfsFileSystem;
+
+  /**
    * The autoscaling group for this repository's installer-running instance.
    */
   private readonly installerGroup: AutoScalingGroup;
@@ -456,17 +488,24 @@ export class Repository extends Construct implements IRepository {
 
     this.version = props.version;
 
-    // Set up the Filesystem and Database components of the repository
-    this.fileSystem = props.fileSystem ?? new MountableEfs(this, {
-      filesystem: new EfsFileSystem(this, 'FileSystem', {
+    // Set up the Filesystem of the repository
+    if (props.fileSystem !== undefined) {
+      this.fileSystem = props.fileSystem;
+    } else {
+      this.efs = new EfsFileSystem(this, 'FileSystem', {
         vpc: props.vpc,
         vpcSubnets: props.vpcSubnets ?? { subnetType: SubnetType.PRIVATE },
         encrypted: true,
         lifecyclePolicy: EfsLifecyclePolicy.AFTER_14_DAYS,
         removalPolicy: props.removalPolicy?.filesystem ?? RemovalPolicy.RETAIN,
-      }),
-    });
+        securityGroup: props.securityGroupsOptions?.fileSystem,
+      });
+      this.fileSystem = new MountableEfs(this, {
+        filesystem: this.efs,
+      });
+    }
 
+    // Set up the Database of the repository
     if (props.database) {
       this.databaseConnection = props.database;
       if (props.databaseAuditLogging !== undefined){
@@ -498,6 +537,7 @@ export class Repository extends Construct implements IRepository {
           instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
           vpc: props.vpc,
           vpcSubnets: props.vpcSubnets ?? { subnetType: SubnetType.PRIVATE, onePerAz: true },
+          securityGroup: props.securityGroupsOptions?.database,
         },
         instances,
         backup: {
@@ -550,6 +590,7 @@ export class Repository extends Construct implements IRepository {
       resourceSignalTimeout: (props.repositoryInstallationTimeout || Duration.minutes(15)),
       updateType: UpdateType.REPLACING_UPDATE,
       replacingUpdateMinSuccessfulInstancesPercent: 100,
+      securityGroup: props.securityGroupsOptions?.installer,
     });
     this.node.defaultChild = this.installerGroup;
     // Ensure the DB is serving before we try to connect to it.

--- a/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
@@ -315,7 +315,7 @@ describe('DocumentDB', () => {
   });
 
   // This test can be removed once the following CDK PR is merged:
-  // TODO: make PR
+  // https://github.com/aws/aws-cdk/pull/13290
   test('adds warning annotation when a security group cannot be added due to implementation changes in DatabaseCluster', () => {
     // GIVEN
     if (!database.node.tryRemoveChild('Resource')) {

--- a/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
@@ -11,9 +11,12 @@ import {
 } from '@aws-cdk/assert';
 import {
   DatabaseCluster,
+  Endpoint,
+  IDatabaseCluster,
 } from '@aws-cdk/aws-docdb';
 import {
   AmazonLinuxGeneration,
+  Connections,
   Instance,
   InstanceClass,
   InstanceSize,
@@ -31,11 +34,17 @@ import {
 import {
   PrivateHostedZone,
 } from '@aws-cdk/aws-route53';
-import { Secret } from '@aws-cdk/aws-secretsmanager';
 import {
+  Secret,
+  SecretAttachmentTargetProps,
+} from '@aws-cdk/aws-secretsmanager';
+import {
+  Construct,
   Duration,
+  ResourceEnvironment,
   Stack,
 } from '@aws-cdk/core';
+import * as sinon from 'sinon';
 
 import {
   IMongoDb,
@@ -262,6 +271,70 @@ describe('DocumentDB', () => {
     expect(() => {
       connection.addConnectionDBArgs(instance);
     }).toThrowError('Connecting to the Deadline Database is currently only supported for Linux.');
+  });
+
+  test('adds warning annotation when a security group cannot be added due to unsupported IDatabaseCluster implementation', () => {
+    // GIVEN
+    class FakeDatabaseCluster extends Construct implements IDatabaseCluster {
+      public readonly clusterIdentifier: string = '';
+      public readonly instanceIdentifiers: string[] = [];
+      public readonly clusterEndpoint: Endpoint = new Endpoint('address', 123);
+      public readonly clusterReadEndpoint: Endpoint = new Endpoint('readAddress', 123);
+      public readonly instanceEndpoints: Endpoint[] = [];
+      public readonly securityGroupId: string = '';
+      public readonly connections: Connections = new Connections();
+
+      public readonly stack: Stack;
+      public readonly env: ResourceEnvironment;
+
+      constructor(scope: Construct, id: string) {
+        super(scope, id);
+        this.stack = Stack.of(scope);
+        this.env = {account: this.stack.account, region: this.stack.region};
+      }
+
+      asSecretAttachmentTarget(): SecretAttachmentTargetProps {
+        throw new Error('Method not implemented.');
+      }
+    }
+    const fakeDatabase = new FakeDatabaseCluster(stack, 'FakeDatabase');
+    const securityGroup = new SecurityGroup(stack, 'NewSecurityGroup', { vpc });
+    const connection = DatabaseConnection.forDocDB({database: fakeDatabase, login: database.secret!});
+
+    // WHEN
+    connection.addSecurityGroup(securityGroup);
+
+    // THEN
+    expect(fakeDatabase.node.metadata).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'aws:cdk:warning',
+        data: expect.stringMatching(new RegExp(`Failed to add the following security groups to ${fakeDatabase.node.id}: .*\\. ` +
+        'The \\"database\\" property passed to this class is not an instance of AWS CDK\'s DocumentDB cluster construct.')),
+      }),
+    ]));
+  });
+
+  // This test can be removed once the following CDK PR is merged:
+  // TODO: make PR
+  test('adds warning annotation when a security group cannot be added due to implementation changes in DatabaseCluster', () => {
+    // GIVEN
+    if (!database.node.tryRemoveChild('Resource')) {
+      throw new Error('The internal implementation of AWS CDK\'s DocumentDB cluster construct has changed. The addSecurityGroup method needs to be updated.');
+    }
+    const securityGroup = new SecurityGroup(stack, 'NewSecurityGroup', { vpc });
+    const connection = DatabaseConnection.forDocDB({database, login: database.secret!});
+
+    // WHEN
+    connection.addSecurityGroup(securityGroup);
+
+    // THEN
+    expect(database.node.metadata).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'aws:cdk:warning',
+        data: expect.stringMatching(new RegExp(`Failed to add the following security groups to ${database.node.id}: .*\\. ` +
+        'The internal implementation of AWS CDK\'s DocumentDB cluster construct has changed.')),
+      }),
+    ]));
   });
 
 });
@@ -615,5 +688,20 @@ describe('MongoDB', () => {
     expect(() => {
       connection.addConnectionDBArgs(instance);
     }).toThrowError('Connecting to the Deadline Database is currently only supported for Linux.');
+  });
+
+  test('adds security group', () => {
+    // GIVEN
+    const dbSpy = sinon.spy(database, 'addSecurityGroup');
+    const connection = DatabaseConnection.forMongoDbInstance({database, clientCertificate: clientCert});
+    const securityGroup = new SecurityGroup(stack, 'NewSecurityGroup', {
+      vpc,
+    });
+
+    // WHEN
+    connection.addSecurityGroup(securityGroup);
+
+    // THEN
+    expect(dbSpy.calledOnce).toBeTruthy();
   });
 });

--- a/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
@@ -67,7 +67,7 @@ import {
   RenderQueue,
   RenderQueueImages,
   RenderQueueProps,
-  RenderQueueSecurityGroupsOptions,
+  RenderQueueSecurityGroups,
   Repository,
   VersionQuery,
 } from '../lib';
@@ -2286,7 +2286,7 @@ describe('RenderQueue', () => {
 
     test('adds security groups on construction', () => {
       // GIVEN
-      const securityGroupsOptions: RenderQueueSecurityGroupsOptions = {
+      const securityGroups: RenderQueueSecurityGroups = {
         backend: backendSecurityGroup,
         frontend: frontendSecurityGroup,
       };
@@ -2297,11 +2297,11 @@ describe('RenderQueue', () => {
         repository,
         version: renderQueueVersion,
         vpc,
-        securityGroupsOptions,
+        securityGroups,
       });
 
       // THEN
-      assertSecurityGroupsWereAdded(securityGroupsOptions);
+      assertSecurityGroupsWereAdded(securityGroups);
     });
 
     test('adds backend security groups post-construction', () => {
@@ -2374,7 +2374,7 @@ describe('RenderQueue', () => {
       }));
     });
 
-    function assertSecurityGroupsWereAdded(securityGroups: RenderQueueSecurityGroupsOptions) {
+    function assertSecurityGroupsWereAdded(securityGroups: RenderQueueSecurityGroups) {
       if (securityGroups.backend !== undefined) {
         expectCDK(stack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
           SecurityGroups: arrayWith(stack.resolve(securityGroups.backend.securityGroupId)),


### PR DESCRIPTION
Fixes https://github.com/aws/aws-rfdk/issues/307

### Changes
- `RenderQueue`: Add `addSecurityGroups` method that adds security groups to the `AutoScalingGroup`, `LoadBalancer`, or both.
- `Repository`: Add `addSecurityGroup` method that adds security groups to the `DatabaseConnection`.
- `DatabaseConnection`
    - DocDB: Adds security groups to the `CfnDBCluster`.
    - MongoDB: Adds security groups to the MongoDB server.
- `MongoDbInstance`: Added an `addSecurityGroup` method to add security groups to the `AutoScalingGroup` of the `StaticPrivateIpServer`.

### Testing
- Added unit tests
- Manual end-to-end tests by modifying the All-In-AWS-Infrastructure-Basic typescript sample app
    - Added a new `SecurityGroup` in `StorageTier` and added it to the `Repository` construct in the `ServiceTier`.
    - Added a new `SecurityGroup` in `ServiceTier` and added it to the `RenderQueue` construct in the `ServiceTier`.
    - Verified that the new security groups get added to the correct resources:
        - `Repository` (DocDB): Added to the DocDB Cluster
        - `Repository` (MongoDB): Added to the AutoScalingGroup
        - `RenderQueue`: Added to the AutoScalingGroup and LoadBalancer
    - Test cases
        1. DocDB repository, pass security groups into constructors
        2. DocDB repository, use `addSecurityGroup(s)` methods to add security groups
        3. MongoDB repository, pass security groups into constructors
        4. MongoDB repository, use `addSecurityGroup(s)` methods to add security groups

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
