### PR TITLE
fix(integ): ignore unbound RUN_TESTS_IN_PARALLEL variable

### DIFF
--- a/integ/components/deadline/common/scripts/bash/deploy-utils.sh
+++ b/integ/components/deadline/common/scripts/bash/deploy-utils.sh
@@ -20,7 +20,7 @@ function deploy_component_stacks () {
   echo "Running $COMPONENT_NAME end-to-end test..."
 
   echo "Deploying test app for $COMPONENT_NAME test suite"
-  if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+  if [ "${RUN_TESTS_IN_PARALLEL-}" = true ]; then
     npx cdk deploy "*" --require-approval=never > "$INTEG_TEMP_DIR/${COMPONENT_NAME}_deploy.txt" 2>&1
   else
     npx cdk deploy "*" --require-approval=never
@@ -36,7 +36,7 @@ function execute_component_test () {
   run_aws_interaction_hook
 
   echo "Running test suite $COMPONENT_NAME..."
-  if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+  if [ "${RUN_TESTS_IN_PARALLEL-}" = true ]; then
     yarn run test "$COMPONENT_NAME.test" --json --outputFile="$INTEG_TEMP_DIR/$COMPONENT_NAME.json" > "$INTEG_TEMP_DIR/${COMPONENT_NAME}.txt" 2>&1
   else
     yarn run test "$COMPONENT_NAME.test" --json --outputFile="$INTEG_TEMP_DIR/$COMPONENT_NAME.json"
@@ -52,7 +52,7 @@ function destroy_component_stacks () {
   run_aws_interaction_hook
 
   echo "Destroying test app $COMPONENT_NAME..."
-  if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+  if [ "${RUN_TESTS_IN_PARALLEL-}" = true ]; then
     npx cdk destroy "*" -f > "$INTEG_TEMP_DIR/${COMPONENT_NAME}_destroy.txt" 2>&1
   else
     npx cdk destroy "*" -f

--- a/integ/scripts/bash/rfdk-integ-e2e.sh
+++ b/integ/scripts/bash/rfdk-integ-e2e.sh
@@ -93,7 +93,7 @@ for COMPONENT in **/cdk.json; do
     if [[ "$COMPONENT_NAME" != _* ]]; then
         # Excecute the e2e test in the component's scripts directory
         cd "$INTEG_ROOT/$COMPONENT_ROOT"
-        if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+        if [ "${RUN_TESTS_IN_PARALLEL-}" = true ]; then
             (../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" || ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" --destroy-only) &
             export ${COMPONENT_NAME}_PID=$!
             COMPONENTS+=(${COMPONENT_NAME})
@@ -104,7 +104,7 @@ for COMPONENT in **/cdk.json; do
     export ${COMPONENT_NAME}_FINISH_TIME=$SECONDS
 done
 
-if [ "${RUN_TESTS_IN_PARALLEL}" = true ]; then
+if [ "${RUN_TESTS_IN_PARALLEL-}" = true ]; then
     while [ "${#COMPONENTS[@]}" -ne 0 ]; do
         ACTIVE_COMPONENTS=()
         for COMPONENT_NAME in ${COMPONENTS[@]}; do


### PR DESCRIPTION
### Problem
When we run integration tests without running `test-config.sh` (in case of auto-bump) variable `RUN_TESTS_IN_PARALLEL` is unbound that leads to crash.

### Testing
Run `yarn e2e-automated` and make sure that tests are running.
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
