### PR TITLE
chore: remove legacy lerna field from lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "lerna": "3.15.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "rejectCycles": "true",


### PR DESCRIPTION
The lerna field in lerna.json is no longer needed: https://github.com/lerna/lerna#legacy-fields.

### Testing
Ran `yarn build` and ensured the local install of lerna was used (v4.0.0)
```
$ yarn build
yarn run v1.22.10
$ ./build.sh
=============================================================================================
installing...
[1/4] Resolving packages...
success Already up-to-date.
git-secrets scan ok
=============================================================================================
building...
lerna notice cli v4.0.0
lerna notice filter excluding "all-in-farm**"
lerna info filter [ '!all-in-farm**' ]
lerna info Executing command in 5 packages: "yarn run build+test"
```
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
