### PR TITLE
feat: add ability to use EFS access points

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/app.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/app.py
@@ -101,7 +101,7 @@ def main():
     # ------------------------------
     service_props = service_tier.ServiceTierProps(
         database=storage.database,
-        file_system=storage.file_system,
+        mountable_file_system=storage.mountable_file_system,
         vpc=network.vpc,
         ubl_certs_secret_arn=config.ubl_certificate_secret_arn,
         ubl_licenses=config.ubl_licenses,

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/config.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/config.py
@@ -33,8 +33,8 @@ class AppConfig:
         self.deadline_version: Optional[str] = None
 
         # A map of regions to Deadline Client Linux AMIs. As an example, the Linux Deadline 10.1.13.2 AMI ID
-        # from us-west-2 is filled in. It can be used as-is, added to, or replaced. Ideally the version here
-        #  should match the one used for fetching the render queue and usage based licensing images.
+        # from us-west-2 is filled in. It can be used as-is, added to, or replaced. Ideally the version here should match the version of
+        # Deadline used in any connected Deadline constructs.
         self.deadline_client_linux_ami_map: Mapping[str, str] = {'us-west-2': 'ami-0237f13ce87af168e'}
 
         # A secret (in binary form) in SecretsManager that stores the UBL certificates in a .zip file.

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
@@ -98,7 +98,7 @@ if (config.deployMongoDB) {
 const service = new ServiceTier(app, 'ServiceTier', {
   env,
   database: storage.database,
-  fileSystem: storage.fileSystem,
+  mountableFileSystem: storage.mountableFileSystem,
   vpc: network.vpc,
   deadlineVersion: config.deadlineVersion,
   ublCertsSecretArn: config.ublCertificatesSecretArn,

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/config.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/config.ts
@@ -32,8 +32,8 @@ class AppConfig {
 
   /**
    * A map of regions to Deadline Client Linux AMIs. As an example, the Linux Deadline 10.1.13.2 AMI ID from us-west-2
-   * is filled in. It can be used as-is, added to, or replaced. Ideally the version here should match the one in
-   * package.json used for fetching the render queue and usage based licensing images.
+   * is filled in. It can be used as-is, added to, or replaced. Ideally the version here should match the version of
+   * Deadline used in any connected Deadline constructs.
    */
   public readonly deadlineClientLinuxAmiMap: Record<string, string> = {['us-west-2']: 'ami-0237f13ce87af168e'};
 

--- a/packages/aws-rfdk/README.md
+++ b/packages/aws-rfdk/README.md
@@ -15,3 +15,4 @@ Please see the following sources for additional information:
 * The [RFDK API Documentation](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk-construct-library.html)
 * The [README for the main module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/core/README.md)
 * The [README for the Deadline module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/deadline/README.md)
+* The [RFDK Upgrade Documentation](./docs/upgrade/index.md)

--- a/packages/aws-rfdk/docs/upgrade/index.md
+++ b/packages/aws-rfdk/docs/upgrade/index.md
@@ -1,0 +1,7 @@
+# Upgrading RFDK
+
+This documentation aims to provide information to help planning or troubleshoot issues upgrading RFDK in your CDK
+applications. The documentation is separated by RFDK versions that included potentially breaking changes. If you are
+upgrading to (or beyond) a version listed below, you should consult the the linked upgrade documentation.
+
+*   [`0.27.x`](./upgrading-0.27.md)

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.27.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.27.md
@@ -1,0 +1,272 @@
+# Upgrading to RFDK v0.27.x or Newer
+
+The Deadline container images used for server components (`RenderQueue` and `UsageBasedLicensing` constructs) have
+changed and as a result, [EFS access points][efs_access_points] must now be used to properly mount Deadline's Repository
+file-system. To upgrade without disruption, you must make changes to your CDK application and/or deployed EFS
+file-system.
+
+The upgrade process differs based on your usage pattern of the `Repository` RFDK construct. These usage patterns are
+documented in the following sections. Once you've identified which pattern applies to your CDK applicaiton, review the
+steps and plan your upgrade as documented.
+
+Scenarios:
+
+1.  [Deadline Repository with Implicit EFS File-System](#Deadline-Repository-with-Implicit-EFS-File-System)
+
+    **TypeScript:**
+    ```ts
+    new Repository(scope, 'Repository', {
+        // ...
+        // no "fileSystem" property
+        // ...
+    })
+    ```
+
+    **Python:**
+    ```py
+    Repository(scope, 'Repository',
+        # ...
+        # no "file_system" property
+        # ...
+    )
+    ```
+
+2.  [Deadline Repository with Provided EFS File-System](#Deadline-Repository-with-Provided-EFS-File-System)
+
+    **TypeScript:**
+    ```ts
+    new Repository(scope, 'Repository', {
+        // ...
+        fileSystem: myFileSystem
+        // ...
+    });
+    ```
+
+    **Python:**
+    ```py
+    Repository(scope, 'Repository',
+        # ...
+        file_system=my_file_system,
+        # ...
+    )
+    ```
+
+## Deadline Repository with Implicit EFS File-System
+
+If your app creates a `Repository` instance without a supplied file-system, then the `Repository` construct creates an
+EFS file-system for the Deadline Repository files.
+
+In RFDK 0.27.x, the `Repository` construct's behavior has changed in this scenario. It now creates and uses an EFS
+Access Point. Both the `Repository` and the `RenderQueue` mount the EFS using this new access point. Each EFS access
+point corresponds to a POSIX UID/GID combination. All file operations performed via a mount of the access point assume
+those UID/GIDs. For the above CDK code snippets, when no file-system is supplied to the `Repository` construct, it now
+creates an Access Point with:
+
+*   **UID**: `0`
+*   **GID**: `0`
+
+In effect, this gives the `Repository` and `RenderQueue` unrestricted access to the EFS file-system. This usage pattern
+is intended to abstract and encapsulate the file-system.
+
+**If you intend to share an EFS file-system with other parts of your infrastructure beyond the `Repository` and
+`RenderQueue` constructs**, you should instead create an EFS `FileSystem` construct in your CDK app and supply it to the
+`Repository` construct with a secured EFS Access Point. For examples of this, have a look at the newly updated example
+code for [TypeScript][access_point_ex_ts] and [Python][access_point_ex_py].
+
+**If you only require the file-system to be accessed by the `Repository` and `RenderQueue`**, then no further action is
+required and you can safely upgrade RFDK and deploy without disruption.
+
+## Deadline Repository with Provided EFS File-System
+
+In this scenario, your app creates a `Repository` instance with an explicitly specified file-system. Here are the steps
+to upgrade from pre-0.27.x to 0.27.x and higher:
+
+### Before Upgrading RFDK
+
+1.  Decide UID and GID values that you want to to be used by the `Repository` and `RenderQueue` constructs when
+    accessing EFS file-system for the Deadline Repository.
+    
+    If you do not have any requirement to share the EFS file-system with other agents in your infrastructure, these can
+    both be set to `0`. Note, that this grants the `Repository` and `RenderQueue` unrestricted access to the EFS
+    file-system.
+    
+    If you intend to have the EFS file-system used elsewhere, you must decide on these values based on how you'd like
+    to configure POSIX file ownership and permissions.
+1.  If you've chosen non-zero values, you must perform a manual step to [change ownership of the Deadline Repository
+    files on EFS](#Changing-Ownership-of-Deadline-Repository-Files-on-EFS) to  have these values.
+
+At this point you can upgrade your RFDK package to 0.27.x.
+
+### After Upgrading RFDK
+
+The Deadline containers used by the `RenderQueue` now require an EFS Access Point be used. The `MountableEfs` class in
+RFDK now accepts an optional `accessPoint` (TypeScript) / `access_point` (Python) property. You must
+add an Access Point and specify it when creating the `MountableEfs` that you supply to the `Repository` construct.
+
+This is required for the `Repository` and `RenderQueue` to function properly. Have a look at the newly updated example
+code for [TypeScript][access_point_ex_ts] and [Python][access_point_ex_py]. Use UID and GID values chosen in the
+previous section when specifying the `posixUser` (TypeScript) / `posix_user` (Python) property of the `AccessPoint`.
+
+When upgrading a CDK application that uses RFDK and has been previously deployed, the file-system will contain the
+Deadline Repository files. To simplify the changes to your code, your Access Point can keep its `path` argument set to
+the root of the EFS file-system. Sample code:
+
+**TypeScript:**
+
+```ts
+import { AccessPoint, FileSystem } from '@aws-cdk/aws-efs';
+
+const fileSystem = new FileSystem(scope, 'FileSystem', {
+    // ...
+});
+
+// This access point demonstrates the least-effort migration. It grants the
+// Repository and RenderQueue with root access to the entire EFS file-system.
+// If you intend to use the EFS file-system elsewhere, you should consider
+// restricting this access further.
+new AccessPoint(scope, 'AccessPoint', {
+    fileSystem,
+    path: '/',
+    posixUser: {
+        uid: '0',
+        gid: '0',
+    },
+});
+```
+
+**Python:**
+
+```py
+from aws_cdk.aws_efs import (AccessPoint, FileSystem, PosixUser)
+
+file_system = FileSystem(scope, 'FileSystem',
+    # ...
+)
+
+# This access point demonstrates the least-effort migration. It grants the
+# Repository and RenderQueue with root access to the entire EFS file-system.
+# If you intend to use the EFS file-system elsewhere, you should consider
+# restricting this access further.
+AccessPoint(scope, 'AccessPoint',
+    file_system=file_system,
+    path='/',
+    posix_user=PosixUser(
+        uid='0',
+        gid='0',
+    ),
+)
+```
+
+Alternatively, you can specify the absolute path of the Deadline Repository files (relative to the root of the EFS
+file-system) to restrict the access of the `RenderQueue` and `Repository` to the Deadline Repository directory. This may
+be useful if you intend to share the EFS file-system with other parts of your infrastructure (e.g. render assets, home
+directories, etc...).
+
+To make this work properly, you must also adjust the `repoInstallationPath` of you `Repository` construct. Assuming your
+existing RFDK app had a `Repository` that installs to `/DeadlineRepository` (the RFDK default if not specified) on the
+EFS file-system, you could do the following:
+
+**TypeScript:**
+
+```ts
+import { AccessPoint, FileSystem } from '@aws-cdk/aws-efs';
+import { MountableEfs } from 'aws-rfdk';
+import { Repository } from 'aws-rfdk/deadline';
+
+const fileSystem = new FileSystem(scope, 'FileSystem', {
+    // ...
+});
+
+const accessPoint = new AccessPoint(scope, 'AccessPoint', {
+    fileSystem,
+    // Set this to your existing Deadline Repository path relative to the root of the the EFS file-system
+    path: '/DeadlineRepository',
+    posixUser: {
+        uid: '10000',
+        gid: '10000',
+    },
+});
+
+const mountableFs = new MountableEfs(scope, {
+    fileSystem,
+    accessPoint,
+});
+
+new Repository(scope, 'Repository', {
+    // ...
+    fileSystem: mountableFs,
+    // This path is relative to the EFS Access Point path
+    repositoryInstallationPrefix: "/",
+    // ...
+});
+```
+
+**Python:**
+
+```py
+from aws_cdk.aws_efs import (AccessPoint, FileSystem, PosixUser)
+from aws_rfdk import MountableEfs
+from aws_rfdk.deadline import Repository
+
+file_system = FileSystem(scope, 'FileSystem',
+    # ...
+)
+
+access_point = AccessPoint(scope, 'AccessPoint',
+    file_system=file_system,
+    # Set this to your existing Deadline Repository path relative to the root of the the EFS file-system
+    path='/DeadlineRepository',
+    posix_user=PosixUser(
+        uid='10000',
+        gid='10000',
+    ),
+)
+
+mountable_fs = MountableEfs(scope,
+    file_system=file_system,
+    access_point=access_point,
+)
+
+new Repository(scope, 'Repository',
+    # ...
+    file_system=mountable_fs,
+    # This path is relative to the EFS Access Point path
+    repository_installation_prefix='/',
+    # ...
+)
+```
+
+## Changing Ownership of Deadline Repository Files on EFS
+
+In order to migrate to RFDK 0.27.x and newer, you will first need take a manual step to modify the ownership of the
+files in the Deadline Repository file-system. To do this, you can deploy a bastion that has the EFS file-system mounted
+(see our example [TypeScript][attach_bastion_ts]/[Python][attach_bastion_py] code).
+
+Once you've deployed the bastion, you can use [SSM Session Manager][session_manager] to start a terminal session on the
+bastion. Assuming you've mounted the EFS file-system to `/mnt/efs` (as done in the examples linked above), you must then
+modify the file permissions with:
+
+```sh
+# TODO: replace these values with your EFS mount path and desired UID/GID
+EFS_MOUNT_PATH=/mnt/efs
+TARGET_UID=10000
+TARGET_GID=10000
+
+sudo chown -R "${TARGET_UID}:${TARGET_GID}" "${EFS_MOUNT_PATH}"
+```
+
+---
+
+**NOTE:** This operation will change ownership of files, but a running render farm may create additional files that need
+to be modified as well. It is advised to first deploy a change to destroy/disable any Deadline Workers and services
+(`RenderQueue` or `UsageBasedLicensing` constructs).
+
+---
+
+
+[efs_access_points]: https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html
+[attach_bastion_ts]: https://github.com/aws/aws-rfdk/blob/f96be912c443cbfd1b38a2aed57436c33f033c7c/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/service-tier.ts#L125-L145
+[attach_bastion_py]: https://github.com/aws/aws-rfdk/blob/release/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/service_tier.py#L93-L117
+[session_manager]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html
+[access_point_ex_ts]: https://github.com/aws/aws-rfdk/blob/v0.27.0/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts#L77-L107
+[access_point_ex_py]: https://github.com/aws/aws-rfdk/blob/v0.27.0/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py#L93-L126

--- a/packages/aws-rfdk/lib/core/lib/mount-permissions-helper.ts
+++ b/packages/aws-rfdk/lib/core/lib/mount-permissions-helper.ts
@@ -29,4 +29,21 @@ export class MountPermissionsHelper {
     }
     throw new Error(`Unhandled MountPermission: ${permission}`);
   }
+
+  /**
+   * Convert the given permission into the appropriate list of IAM actions allowed on the EFS FileSystem required for
+   * the mount.
+   *
+   * @param permission The permission to convert. Defaults to {@link MountPermissions.READWRITE} if not defined.
+   */
+  public static toEfsIAMActions(permission?: MountPermissions): string[] {
+    permission = permission ?? MountPermissions.READWRITE;
+    const iamActions = [
+      'elasticfilesystem:ClientMount',
+    ];
+    if (permission === MountPermissions.READWRITE) {
+      iamActions.push('elasticfilesystem:ClientWrite');
+    }
+    return iamActions;
+  }
 }

--- a/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
@@ -11,11 +11,16 @@ import {
 } from '@aws-cdk/aws-ec2';
 import * as efs from '@aws-cdk/aws-efs';
 import {
+  PolicyStatement,
+} from '@aws-cdk/aws-iam';
+import {
   Asset,
 } from '@aws-cdk/aws-s3-assets';
 import {
   Construct,
+  IResolvable,
   Stack,
+  isResolvableObject,
 } from '@aws-cdk/core';
 
 import {
@@ -38,6 +43,19 @@ export interface MountableEfsProps {
   readonly filesystem: efs.IFileSystem;
 
   /**
+   * An optional access point to use for mounting the file-system
+   *
+   * NOTE: Access points are only supported when using the EFS mount helper. The EFS Mount helper comes pre-installed on
+   * Amazon Linux 2. For other Linux distributions, you must have the Amazon EFS client installed on your AMI for this
+   * to work properly. For instructions on installing the Amazon EFS client for other distributions, see:
+   *
+   * https://docs.aws.amazon.com/efs/latest/ug/installing-amazon-efs-utils.html#installing-other-distro
+   *
+   * @default no access point is used
+   */
+  readonly accessPoint?: efs.IAccessPoint;
+
+  /**
    * Extra NFSv4 mount options that will be added to /etc/fstab for the file system.
    * See: {@link https://www.man7.org/linux/man-pages//man5/nfs.5.html}
    *
@@ -53,6 +71,15 @@ export interface MountableEfsProps {
  * This class encapsulates scripting that can be used to mount an Amazon Elastic File System onto
  * an instance.
  *
+ * An optional EFS access point can be specified for mounting the EFS file-system. For more information on using EFS
+ * Access Points, see https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html. For this to work properly, the
+ * EFS mount helper is required. The EFS Mount helper comes pre-installed on Amazon Linux 2. For other Linux
+ * distributions, the host machine must have the Amazon EFS client installed. We advise installing the Amazon EFS Client
+ * when building your AMI. For instructions on installing the Amazon EFS client for other distributions, see
+ * https://docs.aws.amazon.com/efs/latest/ug/installing-amazon-efs-utils.html#installing-other-distro.
+ *
+ * NOTE: Without an EFS access point, the file-system is writeable only by the root user.
+ *
  * Security Considerations
  * ------------------------
  * - Using this construct on an instance will result in that instance dynamically downloading and running scripts
@@ -60,12 +87,22 @@ export interface MountableEfsProps {
  *   bucket to prevent an attacker from modifying the actions performed by these scripts. We strongly recommend that
  *   you either enable Amazon S3 server access logging on your CDK bootstrap bucket, or enable AWS CloudTrail on your
  *   account to assist in post-incident analysis of compromised production environments.
- *
- * @remark The default access point is writeable only by the root user.
- * @todo Add support for specifying an AccessPoint for the EFS filesystem to  enforce user and group information for all file system requests.
  */
 export class MountableEfs implements IMountableLinuxFilesystem {
-  constructor(protected readonly scope: Construct, protected readonly props: MountableEfsProps) {}
+  /**
+   * The underlying EFS filesystem that is mounted
+   */
+  public readonly fileSystem: efs.IFileSystem;
+
+  /**
+   * The optional access point used to mount the EFS file-system
+   */
+  public readonly accessPoint?: efs.IAccessPoint;
+
+  constructor(protected readonly scope: Construct, protected readonly props: MountableEfsProps) {
+    this.fileSystem = props.filesystem;
+    this.accessPoint = props.accessPoint;
+  }
 
   /**
    * @inheritdoc
@@ -73,6 +110,28 @@ export class MountableEfs implements IMountableLinuxFilesystem {
   public mountToLinuxInstance(target: IMountingInstance, mount: LinuxMountPointProps): void {
     if (target.osType !== OperatingSystemType.LINUX) {
       throw new Error('Target instance must be Linux.');
+    }
+
+    if (Construct.isConstruct(target)) {
+      target.node.addDependency(this.props.filesystem.mountTargetsAvailable);
+    }
+
+    if (this.props.accessPoint) {
+      const grantActions = MountPermissionsHelper.toEfsIAMActions(mount?.permissions);
+      if (this.accessPointRequiresClientRootAccess(this.props.accessPoint)) {
+        grantActions.push('elasticfilesystem:ClientRootAccess');
+      }
+      target.grantPrincipal.addToPrincipalPolicy(new PolicyStatement({
+        resources: [
+          (this.props.filesystem.node.defaultChild as efs.CfnFileSystem).attrArn,
+        ],
+        actions: grantActions,
+        conditions: {
+          StringEquals: {
+            'elasticfilesystem:AccessPointArn': this.props.accessPoint.accessPointArn,
+          },
+        },
+      }));
     }
 
     target.connections.allowTo(this.props.filesystem, this.props.filesystem.connections.defaultPort as Port);
@@ -86,8 +145,14 @@ export class MountableEfs implements IMountableLinuxFilesystem {
 
     const mountDir: string = path.posix.normalize(mount.location);
     const mountOptions: string[] = [ MountPermissionsHelper.toLinuxMountOption(mount.permissions) ];
+    if (this.props.accessPoint) {
+      mountOptions.push(
+        'iam',
+        `accesspoint=${this.props.accessPoint.accessPointId}`,
+      );
+    }
     if (this.props.extraMountOptions) {
-      mountOptions.push( ...this.props.extraMountOptions);
+      mountOptions.push(...this.props.extraMountOptions);
     }
     const mountOptionsStr: string = mountOptions.join(',');
 
@@ -99,6 +164,51 @@ export class MountableEfs implements IMountableLinuxFilesystem {
       'popd',
       `rm -f ${mountScript}`,
     );
+  }
+
+  /**
+   * Uses a CDK escape-hatch to fetch the UID/GID of the access point POSIX user.
+   *
+   * @param accessPoint The access point to obtain the POSIX user for
+   */
+  private getAccessPointPosixUser(accessPoint: efs.AccessPoint): efs.PosixUser | IResolvable | undefined {
+    const accessPointResource = accessPoint.node.defaultChild as efs.CfnAccessPoint;
+    return accessPointResource.posixUser;
+  }
+
+  /**
+   * Uses a synthesis-time check to determine whether an access point is setting its UID/GID to 0 (root). Mounting such
+   * an access point requires the `ClientRootAccess` IAM permission.
+   *
+   * If this introspection is possible and the access point is determined to require root access, the method returns
+   * true.
+   *
+   * If there is no information at synthesis-time, the method returns false as a secure default.
+   *
+   * @param accessPoint The access point to introspect
+   */
+  private accessPointRequiresClientRootAccess(accessPoint: efs.IAccessPoint): boolean {
+    if (accessPoint instanceof efs.AccessPoint) {
+      const posixUser = this.getAccessPointPosixUser(accessPoint);
+      // The following code path is cannot be triggered using the L2 construct for EFS Access Points. It currently
+      // accepts a PosixUser struct. We will skip coverage for the time-being.
+      /* istanbul ignore next */
+      if (isResolvableObject(posixUser)) {
+        // We can't know at synthesis time whether this POSIX user is root. Use secure defaults.
+        return false;
+      }
+      if (!posixUser) {
+        // No POSIX user specified we will not grant ClientRootAccess permission to opt on the side of secure defaults.
+        return false;
+      }
+      // We have synthesis-time values for the UID/GID being set in the access point. Return true if either is 0 (root).
+      return Number(posixUser.uid) === 0 || Number(posixUser.gid) === 0;
+    }
+    else {
+      // This code path is for imported or custom-implementations of efs.AccessPoint
+      // We cannot introspect the access point, so we will impose secure defaults and not grant ClientRootAccess.
+      return false;
+    }
   }
 
   /**

--- a/packages/aws-rfdk/lib/core/lib/script-assets.ts
+++ b/packages/aws-rfdk/lib/core/lib/script-assets.ts
@@ -104,8 +104,6 @@ export interface ExecuteScriptProps {
   /**
    * Command-line arguments to invoke the script with.
    *
-   * @remarks
-   *
    * If supplied, these arguments are simply concatenated with a space character between. No shell escaping is done.
    *
    * @default No command-line arguments

--- a/packages/aws-rfdk/lib/core/test/mount-permissions-helper.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mount-permissions-helper.test.ts
@@ -17,3 +17,29 @@ test.each([
 ])('toLinuxMountOption test: %p', (permission, expected) => {
   expect(MountPermissionsHelper.toLinuxMountOption(permission)).toBe(expected);
 });
+
+test.each<[MountPermissions | undefined, string[]]>([
+  [
+    MountPermissions.READONLY,
+    [
+      'elasticfilesystem:ClientMount',
+    ],
+  ],
+  [
+    MountPermissions.READWRITE,
+    [
+      'elasticfilesystem:ClientMount',
+      'elasticfilesystem:ClientWrite',
+    ],
+  ],
+  [
+    undefined,
+    [
+      'elasticfilesystem:ClientMount',
+      'elasticfilesystem:ClientWrite',
+    ],
+  ],
+])('toEfsIAMActions test: %p', (permission, expected) => {
+  expect(MountPermissionsHelper.toEfsIAMActions(permission)).toEqual(expected);
+});
+

--- a/packages/aws-rfdk/lib/core/test/mountable-ebs.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-ebs.test.ts
@@ -270,6 +270,7 @@ describe('Test MountableBlockVolume', () => {
       public readonly osType = instance.osType;
       public readonly userData = instance.userData;
       public readonly grantPrincipal = instance.grantPrincipal;
+      public readonly node = instance.node;
     }
     const fakeTarget = new FakeTarget();
 

--- a/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-recipes.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-recipes.ts
@@ -97,15 +97,19 @@ export class ThinkboxDockerRecipes extends Construct {
   public readonly ublImages: UsageBasedLicensingImages;
 
   /**
+   * The staged recipes
+   */
+  private readonly stage: Stage;
+
+  /**
    * The version of Deadline in the stage directory.
    */
-  public readonly version: IVersion;
+  private versionInstance?: IVersion;
 
   constructor(scope: Construct, id: string, props: ThinkboxDockerRecipesProps) {
     super(scope, id);
 
-    this.version  = props.stage.getVersion(this, 'Version');
-
+    this.stage = props.stage;
     for (const recipe of [ThinkboxManagedDeadlineDockerRecipes.REMOTE_CONNECTION_SERVER, ThinkboxManagedDeadlineDockerRecipes.LICENSE_FORWARDER]) {
       if (!props.stage.manifest.recipes[recipe]) {
         throw new Error(`Could not find ${recipe} recipe`);
@@ -131,5 +135,12 @@ export class ThinkboxDockerRecipes extends Construct {
     this.ublImages = {
       licenseForwarder: ContainerImage.fromDockerImageAsset(this.licenseForwarder),
     };
+  }
+
+  public get version(): IVersion {
+    if (!this.versionInstance) {
+      this.versionInstance = this.stage.getVersion(this, 'Version');
+    }
+    return this.versionInstance;
   }
 }

--- a/packages/aws-rfdk/lib/deadline/test/thinkbox-docker-recipes.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/thinkbox-docker-recipes.test.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 
 import {
   expect as expectCDK,
+  haveResource,
   haveResourceLike,
   stringLike,
 } from '@aws-cdk/assert';
@@ -134,16 +135,30 @@ describe('ThinkboxDockerRecipes', () => {
     expect(actualImage.sourceHash).toEqual(expectedImage.sourceHash);
   });
 
-  test('provides the Deadline version', () => {
-    // WHEN
-    new ThinkboxDockerRecipes(stack, 'Recipes', {
-      stage,
+  describe('.version', () => {
+    test('creates a VersionQuery when referenced', () => {
+      // GIVEN
+      const recipes = new ThinkboxDockerRecipes(stack, 'Recipes', {
+        stage,
+      });
+
+      // WHEN
+      recipes.version;
+
+      expectCDK(stack).to(haveResourceLike('Custom::RFDK_DEADLINE_INSTALLERS', {
+        forceRun: stringLike('*'),
+        versionString: RELEASE_VERSION_STRING,
+      }));
     });
 
-    expectCDK(stack).to(haveResourceLike('Custom::RFDK_DEADLINE_INSTALLERS', {
-      forceRun: stringLike('*'),
-      versionString: RELEASE_VERSION_STRING,
-    }));
+    test('does not create a VersionQuery when not referenced', () => {
+      // GIVEN
+      new ThinkboxDockerRecipes(stack, 'Recipes', {
+        stage,
+      });
+
+      expectCDK(stack).notTo(haveResource('Custom::RFDK_DEADLINE_INSTALLERS'));
+    });
   });
 
   test.each([


### PR DESCRIPTION
## Summary

This change modifies the `MountableEfs` class to accept an optional `accessPoint` property. When specified, the construct will generate user data that mounts the EFS file-system using the access point.

This allows the process accessing the file-system to use a UID/GID different than what UID/GID of the user running the process on the file-system mount.

## Additional Changes

The AWS-all-in-basic examples were modified to use EFS access points.

## Testing

*   Both of the Python and TypeScript examples were tested with Deadline Docker recipes where the container UID/GID would not have POSIX permissions to the EFS without an access point. When using EFS access points, the container is able to read/write to the EFS as expected.
*   Ran the RFDK integration tests on this branch and they all passed

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
