### PR TITLE
fix(integ): supply Repository with EFS access point

### DIFF
--- a/integ/lib/storage-struct.ts
+++ b/integ/lib/storage-struct.ts
@@ -11,7 +11,10 @@ import {
   Vpc,
   SubnetType,
 } from '@aws-cdk/aws-ec2';
-import { FileSystem } from '@aws-cdk/aws-efs';
+import {
+  AccessPoint,
+  FileSystem,
+} from '@aws-cdk/aws-efs';
 import { PrivateHostedZone } from '@aws-cdk/aws-route53';
 import { ISecret } from '@aws-cdk/aws-secretsmanager';
 import {
@@ -114,8 +117,16 @@ export class StorageStruct extends Construct {
         vpc,
         removalPolicy: RemovalPolicy.DESTROY,
       });
+      const accessPoint = new AccessPoint(this, 'AccessPoint', {
+        fileSystem: deadlineEfs,
+        posixUser: {
+          uid: "0",
+          gid: "0",
+        },
+      });
       deadlineMountableEfs = new MountableEfs(this, {
         filesystem: deadlineEfs,
+        accessPoint,
       });
     }
     // If databaseType is MongoDB, a MongoDB instance is created in place of the DocDB

--- a/integ/lib/storage-struct.ts
+++ b/integ/lib/storage-struct.ts
@@ -120,8 +120,8 @@ export class StorageStruct extends Construct {
       const accessPoint = new AccessPoint(this, 'AccessPoint', {
         fileSystem: deadlineEfs,
         posixUser: {
-          uid: "0",
-          gid: "0",
+          uid: '0',
+          gid: '0',
         },
       });
       deadlineMountableEfs = new MountableEfs(this, {


### PR DESCRIPTION
## Problem

In #339 , we added a synthesis-time validation to ensure that an EFS access point is provided when supplying an EFS file-system to the `Repository` construct.

The RFDK integration tests were no updated to provide an access point and are failing with the synthesis-time validation error.

```
Running deadline_01_repository end-to-end test...
Deploying test app for deadline_01_repository test suite
npx: installed 9 in 0.995s
When using EFS with the Repository, you must provide an EFS Access Point
Subprocess exited with error 1
```

## Solution

Modify the `StorageStruct` to provide an EFS access point

## Testing

Modified the integration tests to do a `cdk synth` instead of `cdk deploy` and no longer saw the:

```
When using EFS with the Repository, you must provide an EFS Access Point
```

error message.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
