### PR TITLE
fix(deadline): Windows WorkerInstanceFleets with Deadline 10.1.14 installed fail deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-node@v2.1.5
       with:
         node-version: ${{ matrix.node-version }}
+    - run: npm install --global yarn
     - run: yarn global add typescript
-    - run: yarn install --frozen-lockfile
-    - run: ./build.sh
+    - run: yarn build
     - run: ./pack.sh

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -361,4 +361,11 @@ export interface InstanceConnectOptions {
    * The Instance/UserData which will directly connect to the Repository
    */
   readonly host: IHost;
+
+  /**
+   * Whether or not to start or restart the Deadline Launcher after configuring the connection.
+   *
+   * @default true
+   */
+  readonly restartLauncher?: boolean;
 }

--- a/packages/aws-rfdk/lib/deadline/lib/worker-configuration.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-configuration.ts
@@ -221,7 +221,14 @@ export class WorkerInstanceConfiguration extends Construct {
       );
     }
     props.userDataProvider?.preRenderQueueConfiguration(props.worker);
-    props.renderQueue?.configureClientInstance({ host: props.worker });
+    props.renderQueue?.configureClientInstance({
+      host: props.worker,
+      // Don't restart the Deadline Launcher service after configuring the connection to the Render Queue. We need to
+      // restart it later anyways, and the Windows service for the Deadline Launcher can get locked in the "stopping"
+      // state if you attempt to stop or restart it while it is still restarting. This can cause the user data execution
+      // to get locked waiting for the service to finish stopping/restarting.
+      restartLauncher: false,
+    });
     props.userDataProvider?.preWorkerConfiguration(props.worker);
 
     this.listenerPort = props.workerSettings?.listenerPort ?? WorkerInstanceConfiguration.DEFAULT_LISTENER_PORT;

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
@@ -133,7 +133,7 @@ else
   DEADLINE_LAUNCHER="$DEADLINE_PATH/deadlinelauncher"
   "$DEADLINE_LAUNCHER" -shutdownall
   sudo killall -w deadlineworker || true
-  "$DEADLINE_LAUNCHER"
+  "$DEADLINE_LAUNCHER" -nogui
 fi
 
 echo "Script completed successfully."

--- a/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorker.ps1
+++ b/packages/aws-rfdk/lib/deadline/scripts/powershell/configureWorker.ps1
@@ -127,7 +127,7 @@ If (Get-Service $serviceName -ErrorAction SilentlyContinue) {
     $DEADLINE_LAUNCHER = $DEADLINE_PATH + '/deadlinelauncher.exe'
     & $DEADLINE_LAUNCHER -shutdownall | Out-Default
     taskkill /f /fi "IMAGENAME eq deadlineworker.exe"
-    & $DEADLINE_LAUNCHER
+    & $DEADLINE_LAUNCHER -nogui
 }
 
 Write-Host "Script completed successfully."

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -18,8 +18,8 @@ export {
 
 // configureWorker.sh
 export const CONFIG_WORKER_ASSET_LINUX = {
-  Bucket: 'AssetParameters21c2af3bc1d4fd78061765b059dcc8e32568828e5cf479b08115489651491c8fS3BucketF10C60A7',
-  Key: 'AssetParameters21c2af3bc1d4fd78061765b059dcc8e32568828e5cf479b08115489651491c8fS3VersionKey7FDCC89A',
+  Bucket: 'AssetParameters1cfdffe73bb016717ba1f43d64fe528af27b3784f524a97bb36533a6e6d057ffS3Bucket9FBDD688',
+  Key: 'AssetParameters1cfdffe73bb016717ba1f43d64fe528af27b3784f524a97bb36533a6e6d057ffS3VersionKey02A3157B',
 };
 
 // configureWorker.ps1
@@ -29,8 +29,8 @@ export const CONFIG_WORKER_ASSET_WINDOWS = {
 };
 
 export const CONFIG_WORKER_PORT_ASSET_WINDOWS = {
-  Bucket: 'AssetParameters0b4fe3ffb7177773bb2781f92b37d9b01b3bd37ee60ea1715c0ad407f141005dS3BucketE7B32C3E',
-  Key: 'AssetParameters0b4fe3ffb7177773bb2781f92b37d9b01b3bd37ee60ea1715c0ad407f141005dS3VersionKey843794E3',
+  Bucket: 'AssetParameters3227efc256da3ae31791b7c80e1532cac975116846f179f118a20843e0c2ee80S3Bucket6583BE37',
+  Key: 'AssetParameters3227efc256da3ae31791b7c80e1532cac975116846f179f118a20843e0c2ee80S3VersionKey6C80977B',
 };
 
 // installDeadlineRepository.sh

--- a/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
@@ -1227,7 +1227,7 @@ describe('RenderQueue', () => {
               '  Restart-Service "deadline10launcherservice"\n' +
               '} Else {\n' +
               '  & "$DEADLINE_PATH/deadlinelauncher.exe" -shutdownall 2>&1\n' +
-              '  & "$DEADLINE_PATH/deadlinelauncher.exe" 2>&1\n' +
+              '  & "$DEADLINE_PATH/deadlinelauncher.exe" -nogui 2>&1\n' +
               '}</powershell>',
             ],
           ],
@@ -1635,7 +1635,7 @@ describe('RenderQueue', () => {
               '  Restart-Service "deadline10launcherservice"\n' +
               '} Else {\n' +
               '  & "$DEADLINE_PATH/deadlinelauncher.exe" -shutdownall 2>&1\n' +
-              '  & "$DEADLINE_PATH/deadlinelauncher.exe" 2>&1\n' +
+              '  & "$DEADLINE_PATH/deadlinelauncher.exe" -nogui 2>&1\n' +
               '}</powershell>',
             ],
           ],

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -721,9 +721,6 @@ test('default worker fleet is created correctly custom subnet values', () => {
           ],
         },
         '\"\n' +
-        'if service --status-all | grep -q "Deadline 10 Launcher"; then\n' +
-        '  service deadline10launcher restart\n' +
-        'fi\n' +
         "mkdir -p $(dirname '/tmp/",
         {
           'Fn::Select': [
@@ -1214,9 +1211,6 @@ test('default worker fleet is created correctly with groups, pools and region', 
         ],
       },
       '\"\n' +
-      'if service --status-all | grep -q "Deadline 10 Launcher"; then\n' +
-      '  service deadline10launcher restart\n' +
-      'fi\n' +
       "mkdir -p $(dirname '/tmp/",
       {
         'Fn::Select': [


### PR DESCRIPTION
## Problem

Primarily #353, but also fixes #312.

>   The `WorkerInstanceFleet` construct fails to deploy its ASG instances when configured to deploy Windows AMIs with Deadline 10.1.14.x.

The real issue is a Deadline bug where stopping or restarting the launcher Windows service while it's still starting up can get stuck. The windows service gets stuck in a `stopping` state and the only way to unlock the service is to kill the process.

RFDK restarts the launcher twice when configuring workers in relatively quick succession. There is a race condition between restarting the service the first time and the second restart. Once Deadline 10.1.14 was available to RFDK, the race became more probable to fail. The result is that the user data generated by RFDK to configure Windows workers never completes to send the CloudFormation signal and deployments fail.

## Solution

Modified the `RenderQueueConnection` sub-classes to accept an optional `restartLauncher` property. The default was made true to preserve backwards-compatible behavior when this API is called directly. When called by `WorkerInstanceConfiguration`, this flag is set to `false` because it needs to restart the Deadline Launcher again later after configuring the remote command listener ports. By reducing the number of launcher service restarts to one, we avoid the race condition.

## Testing

Ran the integration tests using this branch and they now all pass.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
