### PR TITLE
feat(deadline): add option to the RenderQueue to use cachefilesd

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/service_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/service_tier.py
@@ -171,7 +171,11 @@ class ServiceTier(Stack):
             # TODO - Evaluate deletion protection for your own needs. This is set to false to
             # cleanly remove everything when this stack is destroyed. If you would like to ensure
             # that this resource is not accidentally deleted, you should set this to true.
-            deletion_protection=False
+            deletion_protection=False,
+            # Enable a local transparent filesystem cache of the Repository filesystem to reduce
+            # data traffic from the Repository's filesystem.
+            # For an EFS and NFS filesystem, this requires the 'fsc' mount option.
+            enable_local_file_caching=True,
         )
         self.render_queue.connections.allow_default_port_from(self.bastion)
 

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
@@ -123,7 +123,11 @@ class StorageTier(Stack):
         self.mountable_file_system = MountableEfs(
             self,
             filesystem=file_system,
-            access_point=access_point
+            access_point=access_point,
+            # We have enable_local_file_caching set to True on the RenderQueue in the
+            # Service Tier. EFS requires the 'fsc' mount option to take advantage of
+            # that.
+            extra_mount_options=['fsc']
         )
 
         # The database to connect Deadline to.

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/service-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/service-tier.ts
@@ -193,6 +193,10 @@ export class ServiceTier extends cdk.Stack {
       // cleanly remove everything when this stack is destroyed. If you would like to ensure
       // that this resource is not accidentally deleted, you should set this to true.
       deletionProtection: false,
+      // Enable a local transparent filesystem cache of the Repository filesystem to reduce
+      // data traffic from the Repository's filesystem.
+      // For an EFS and NFS filesystem, this requires the 'fsc' mount option.
+      enableLocalFileCaching: true,
     });
     this.renderQueue.connections.allowDefaultPortFrom(this.bastion);
 

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
@@ -104,6 +104,10 @@ export abstract class StorageTier extends cdk.Stack {
     this.mountableFileSystem = new MountableEfs(this, {
       filesystem: fileSystem,
       accessPoint,
+      // We have enableLocalFilecaching set to 'true' on the RenderQueue in the
+      // Service Tier. EFS requires the 'fsc' mount option to take advantage of
+      // that.
+      extraMountOptions: [ 'fsc' ]
     });
   }
 }

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -334,6 +334,27 @@ export interface RenderQueueProps {
    * @default - new security groups are created
    */
   readonly securityGroups?: RenderQueueSecurityGroups;
+
+  /**
+   * If enabled, then Linux's cachefilesd will be installed and set to running on the
+   * ECS container host for the Deadline Remote Connection Server. This can reduce
+   * the amount of read throughput required for the Repository Filesystem.
+   *
+   * For more information, please see: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-fscache
+   *
+   * Note: If enabling this, then your Repository filesystem may require additional
+   * mount options to take advantage. Not every filesystem's driver supports integration
+   * with cachefilesd. e.g. NFS and Amazon EFS do support it, and require the 'fsc' mount
+   * option be provided.
+   *
+   * Note2: Your ECS container host will require access to port 80 on the regional S3 service
+   * when enabling this option so that it can install cachefilesd. This host is based on
+   * Amazon Linux 2, and the package repository for these systems is hosted on S3 and reached
+   * via port 80.
+   *
+   * @default false
+   */
+  readonly enableLocalFileCaching?: boolean;
 }
 
 /**

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -4,6 +4,9 @@
  */
 
 import {
+  join,
+} from 'path';
+import {
   AutoScalingGroup,
   BlockDeviceVolume,
   UpdateType,
@@ -69,6 +72,7 @@ import {
   ConnectableApplicationEndpoint,
   ImportedAcmCertificate,
   LogGroupFactory,
+  ScriptAsset,
   X509CertificatePem,
   X509CertificatePkcs12,
 } from '../../core';
@@ -336,6 +340,10 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
     this.asg.userData.addCommands(
       'yum install -yq awscli unzip',
     );
+    if (props.enableLocalFileCaching ?? false) {
+      // Has to be done before any filesystems mount.
+      this.enableFilecaching(this.asg);
+    }
 
     const externalPortNumber = RenderQueue.RCS_PROTO_PORTS[externalProtocol];
     const internalPortNumber = RenderQueue.RCS_PROTO_PORTS[internalProtocol];
@@ -568,6 +576,19 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
    */
   public addBackendSecurityGroups(...securityGroups: ISecurityGroup[]): void {
     securityGroups.forEach(securityGroup => this.asg.addSecurityGroup(securityGroup));
+  }
+
+  private enableFilecaching(asg: AutoScalingGroup): void {
+    const script = ScriptAsset.fromPathConvention(this, 'FilecachingScript', {
+      osType: asg.osType,
+      baseName: 'enableCacheFilesd',
+      rootDir: join(__dirname, '..', 'scripts'),
+    });
+    // A comment in userData to make this easier to test.
+    asg.userData.addCommands('# RenderQueue file caching enabled');
+    script.executeOn({
+      host: asg,
+    });
   }
 
   private createTaskDefinition(props: {

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/enableCacheFilesd.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/enableCacheFilesd.sh
@@ -11,7 +11,7 @@ then
   # The yum install can fail if there is no route to the yum repository.
   # Since this is an AL2 instance, that is equivalent to requiring a route to
   # the regional S3 endpoint on port 80.
-  sudo yum install -y cachefilesd || exit 0
+  sudo yum install -y cachefilesd || ( echo 'ERROR -- Failed to install cachefilesd' && exit 0 )
 
   cat << EOF | sudo tee -a /etc/cachefilesd.conf
 # Allow 16k cull table entries

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/enableCacheFilesd.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/enableCacheFilesd.sh
@@ -11,7 +11,7 @@ then
   # The yum install can fail if there is no route to the yum repository.
   # Since this is an AL2 instance, that is equivalent to requiring a route to
   # the regional S3 endpoint on port 80.
-  sudo yum install -y cachefilesd || ( echo 'ERROR -- Failed to install cachefilesd' && exit 0 )
+  sudo yum install -y cachefilesd || echo 'ERROR -- Failed to install cachefilesd' && exit 0
 
   cat << EOF | sudo tee -a /etc/cachefilesd.conf
 # Allow 16k cull table entries

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/enableCacheFilesd.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/enableCacheFilesd.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Script to install and configure cachefilesd onto a Linux host.
+# This script is presently narrowly written for use on the ECS container host
+# instance(s) that are running the Deadline RCS containers in the RenderQueue construct.
+
+set -xeu
+
+if ! test -f /sbin/cachefilesd
+then
+  # The yum install can fail if there is no route to the yum repository.
+  # Since this is an AL2 instance, that is equivalent to requiring a route to
+  # the regional S3 endpoint on port 80.
+  sudo yum install -y cachefilesd || exit 0
+
+  cat << EOF | sudo tee -a /etc/cachefilesd.conf
+# Allow 16k cull table entries
+culltable 14
+EOF
+
+fi
+
+# Make sure cachefilesd is running
+sudo systemctl enable cachefilesd
+sudo systemctl start cachefilesd


### PR DESCRIPTION
Implements: https://github.com/aws/aws-rfdk/issues/366

### Testing

Started up a basic render farm using the RFDK examples, but modified the example to set the `fsc` mount option on the Amazon EFS and enable `cachefilesd` on the RenderQueue.

Used systems manager connection to remote in to the RenderQueue's ECS container host, and then:
1. Verified that cachefilesd is installed and running.
2. Verified that the `/mnt/repo` filesystem was mounted using the EFS helper which in-turn uses the NFSv4 mount driver, and that the `fsc` option was properly set on the NFSv4 mount point.
```bash
[root@ip-10-0-126-223 ~]# mount | grep nfs
sunrpc on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw,relatime)
127.0.0.1:/ on /mnt/repo type nfs4 (rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20312,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,fsc,local_lock=none,addr=127.0.0.1,_netdev)
```
3. Ran a series of full copies of the `/mnt/repo` filesystem (approx 1.3 GB of data) to the local device both with and without cachefilesd running. The image below shows the throughput metrics on the Amazon EFS filesystem through these tests; as expected, the read throughput with cachefilesd is much lower than a full copy once the local cache has been populated.

![RepoCopy](https://user-images.githubusercontent.com/53624638/112866441-6bdfaf80-907f-11eb-9ca3-41c01f5c4ea9.png)

### Performance Testing

Test setup:
1. RFDK Basic all-in application with an added bastion host set up as a Workstation (installed Deadline & DCV). So... single RCS (c5.large), EFS burst-mode filesystem with ~1GB of data (encrypted), DocDB (db.r5.large), Linux-based Worker ASG (t3.medium), and TLS enabled throughout

![summary](https://user-images.githubusercontent.com/53624638/113048881-9fe2cf80-9168-11eb-9fee-a24831c863fd.png)

So, cachefilesd shaves about 30% of metered throughput when starting 200 workers (9.73MB/s -> 6.9MB/s) and 26% of metered throughput when rendering 1k 'sleep 10' jobs (1.9MB/s -> 1.6MB/s). With the standard caveats, of course, about this being a single data point so there will be sizable error bars on those.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
