### PR TITLE
fix(core): move mountable's asset to scope of target

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
@@ -126,7 +126,7 @@ export class MountableBlockVolume implements IMountableLinuxFilesystem {
 
     this.grantRequiredPermissions(target);
 
-    const mountScriptAsset = this.mountAssetSingleton();
+    const mountScriptAsset = this.mountAssetSingleton(target);
     mountScriptAsset.grantRead(target.grantPrincipal);
     const mountScriptZip: string = target.userData.addS3DownloadCommand({
       bucket: mountScriptAsset.bucket,
@@ -189,8 +189,8 @@ export class MountableBlockVolume implements IMountableLinuxFilesystem {
   /**
    * Fetch the Asset singleton for the Volume mounting scripts, or generate it if needed.
    */
-  protected mountAssetSingleton(): Asset {
-    const stack = Stack.of(this.scope);
+  protected mountAssetSingleton(scope: IConstruct): Asset {
+    const stack = Stack.of(scope);
     const uuid = '01ca4aa6-d440-4f83-84d8-80a5a21fd0e3';
     const uniqueId = 'MountableBlockVolumeAsset' + uuid.replace(/[-]/g, '');
     return (stack.node.tryFindChild(uniqueId) as Asset) ?? new Asset(stack, uniqueId, {

--- a/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
@@ -18,6 +18,7 @@ import {
 } from '@aws-cdk/aws-s3-assets';
 import {
   Construct,
+  IConstruct,
   IResolvable,
   Stack,
   isResolvableObject,
@@ -136,7 +137,7 @@ export class MountableEfs implements IMountableLinuxFilesystem {
 
     target.connections.allowTo(this.props.filesystem, this.props.filesystem.connections.defaultPort as Port);
 
-    const mountScriptAsset = this.mountAssetSingleton();
+    const mountScriptAsset = this.mountAssetSingleton(target);
     mountScriptAsset.grantRead(target.grantPrincipal);
     const mountScript: string = target.userData.addS3DownloadCommand({
       bucket: mountScriptAsset.bucket,
@@ -214,8 +215,8 @@ export class MountableEfs implements IMountableLinuxFilesystem {
   /**
    * Fetch the Asset singleton for the EFS mounting scripts, or generate it if needed.
    */
-  protected mountAssetSingleton(): Asset {
-    const stack = Stack.of(this.scope);
+  protected mountAssetSingleton(scope: IConstruct): Asset {
+    const stack = Stack.of(scope);
     const uuid = '2b31c419-5b0b-4bb8-99ad-5b2575b2c06b';
     const uniqueId = 'MountableEfsAsset' + uuid.replace(/[-]/g, '');
     return (stack.node.tryFindChild(uniqueId) as Asset) ?? new Asset(stack, uniqueId, {

--- a/packages/aws-rfdk/lib/core/lib/mountable-filesystem.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-filesystem.ts
@@ -6,6 +6,9 @@
 import {
   IConnectable,
 } from '@aws-cdk/aws-ec2';
+import {
+  IConstruct,
+} from '@aws-cdk/core';
 
 import { IScriptHost } from './script-assets';
 
@@ -14,7 +17,7 @@ import { IScriptHost } from './script-assets';
  * {@link https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ec2.Instance.html|EC2 Instance}
  * or an {@link https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-autoscaling.AutoScalingGroup.html|EC2 Auto Scaling Group}
  */
-export interface IMountingInstance extends IConnectable, IScriptHost {
+export interface IMountingInstance extends IConnectable, IConstruct, IScriptHost {
 }
 
 /**


### PR DESCRIPTION
We're unable to update the mountable's scripts without a full tear-down of all consuming stacks.
This moves the assets to the target's stack instead of the Mountable's stack to avoid exports in
cross-stack usage.

BREAKING CHANGE: Stacks set up like our examples will see an error regarding being unable to
 delete an export in use when deploying a stack update. To bypass, use cdk deploy's -e option
 to deploy each stack upstream of the Mountable's stack before updating the Mountable's stack. e.g.
- cdk deploy -e ComputeTier; cdk deploy -e ServiceTier; cdk deploy -e StorageTier

Fixes: https://github.com/aws/aws-rfdk/issues/368

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
