### PR TITLE
fix(integ): capture exit codes of parallel tests

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,13 @@
     "@aws-cdk/region-info" "1.94.1"
     constructs "^3.2.0"
 
+"@aws-cdk/aws-imagebuilder@1.94.1":
+  version "1.94.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-imagebuilder/-/aws-imagebuilder-1.94.1.tgz#9166c733b46d24dbc033081c2a96a426dec05d31"
+  integrity sha512-7Y6T8BFawnv7rWEwR4Dh3Lm/R8f7gfBlubMwwLRHNyCAXkW4XDnV2ZftLwE83IwsWLcNU80p5E/ZqK+Q6+j/+A==
+  dependencies:
+    "@aws-cdk/core" "1.94.1"
+
 "@aws-cdk/aws-kinesis@1.94.1":
   version "1.94.1"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.94.1.tgz#1eddde067229f9ee77297deca094ed7dd1d408a1"
@@ -3907,6 +3914,11 @@ crc32-stream@^4.0.1:
   dependencies:
     crc-32 "^1.2.0"
     readable-stream "^3.4.0"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^4:
   version "4.0.2"
@@ -10224,6 +10236,18 @@ ts-node@^8.0.2:
   integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
   dependencies:
     arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.17"


### PR DESCRIPTION
### Notes
Fixed the parallel integration test code to capture the exit code of each integration test and have the script finish with exit code 0 if all tests succeeded, otherwise its exit code is 1.

### Testing
- To verify the exit code logic works correctly, I commented out any calls that deployed/destroyed CF stacks, and replaced the calls to `component_e2e.sh` to a script `runCode.sh` that returns a random exit code:
```bash
#!/bin/bash

sleep $((RANDOM % 3))
exit_code=$((RANDOM % 2))
exit $exit_code
```
The replaced code looked like:
```bash
# ( (../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME"; exit_code=$?; echo $exit_code > "$INTEG_TEMP_DIR/${COMPONENT_NAME}_exitcode"; exit $exit_code) \
# || ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" --destroy-only) &
( (~/tmp/runCode.sh; exit_code=$?; echo $exit_code > "$INTEG_TEMP_DIR/${COMPONENT_NAME}_exitcode"; exit $exit_code) \
|| echo "Failed") &
```
I ran the integ tests with `RUN_TESTS_IN_PARALLEL=true` and verified the script captured all exit codes and exited with the appropriate code.
**Success Case Output**
```
[jericht@dev-dsk-jericht-2a-f8c9ce54 integ]$ yarn run e2e
yarn run v1.22.10
$ ./scripts/bash/rfdk-integ-e2e.sh
Loading config...
Setting test variables...
Starting RFDK-integ end-to-end tests
Test app deadline_03_workerFleetHttp finished with exit code 0
Test app deadline_04_workerFleetHttps finished with exit code 0
Test app deadline_01_repository finished with exit code 0
Test app deadline_02_renderQueue finished with exit code 0
Complete!
Cleaning up folders...
Exiting...
Done in 3.86s.
[jericht@dev-dsk-jericht-2a-f8c9ce54 integ]$ echo $?
0
```

**Failure Case Output**
```
[jericht@dev-dsk-jericht-2a-f8c9ce54 integ]$ yarn run e2e
yarn run v1.22.10
$ ./scripts/bash/rfdk-integ-e2e.sh
Loading config...
Setting test variables...
Starting RFDK-integ end-to-end tests
Failed
Failed
Test app deadline_01_repository finished with exit code 1
Test app deadline_02_renderQueue finished with exit code 0
Test app deadline_03_workerFleetHttp finished with exit code 0
Test app deadline_04_workerFleetHttps finished with exit code 1
Complete!
Cleaning up folders...
Exiting...
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[jericht@dev-dsk-jericht-2a-f8c9ce54 integ]$ echo $?
1
```
- Ran the script as-is in parallel mode and ensured it still works as expected

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
