### PR TITLE
fix(core): PadEfsStorage lambdas need to depend on filesystem

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/pad-efs-storage.ts
+++ b/packages/aws-rfdk/lib/core/lib/pad-efs-storage.ts
@@ -205,6 +205,10 @@ export class PadEfsStorage extends Construct {
       memorySize: 128,
       ...lambdaProps,
     });
+    // Implicit reference should have been fine, but the lambda is unable to mount the filesystem if
+    // executed before the filesystem has been fully formed. We shouldn't have the lambda created until
+    // after the EFS is created.
+    diskUsage.node.addDependency(props.accessPoint);
 
     const doPadding = new LambdaFunction(this, 'PadFilesystem', {
       description: 'Used by RFDK PadEfsStorage to add or remove numbered 1GB files in an EFS access point',
@@ -216,7 +220,10 @@ export class PadEfsStorage extends Construct {
       memorySize: 256,
       ...lambdaProps,
     });
-
+    // Implicit reference should have been fine, but the lambda is unable to mount the filesystem if
+    // executed before the filesystem has been fully formed. We shouldn't have the lambda created until
+    // after the EFS is created.
+    doPadding.node.addDependency(props.accessPoint);
 
     // Build the step function's state machine.
     const fail = new Fail(this, 'Fail');

--- a/packages/aws-rfdk/lib/core/test/pad-efs-storage.test.ts
+++ b/packages/aws-rfdk/lib/core/test/pad-efs-storage.test.ts
@@ -7,6 +7,7 @@ import {
   arrayWith,
   expect as cdkExpect,
   haveResourceLike,
+  ResourcePart,
 } from '@aws-cdk/assert';
 import {
   SecurityGroup,
@@ -21,6 +22,7 @@ import {
 } from '@aws-cdk/aws-lambda';
 import {
   App,
+  CfnElement,
   Size,
   Stack,
 } from '@aws-cdk/core';
@@ -69,49 +71,55 @@ describe('Test PadEfsStorage', () => {
 
     // THEN
     cdkExpect(stack).to(haveResourceLike('AWS::Lambda::Function', {
-      FileSystemConfigs: [
-        {
-          Arn: stack.resolve(accessPoint.accessPointArn),
-          LocalMountPath: '/mnt/efs',
-        },
-      ],
-      Handler: 'pad-efs-storage.getDiskUsage',
-      Runtime: 'nodejs14.x',
-      Timeout: 300,
-      VpcConfig: {
-        SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],
-        SubnetIds: [
+      Properties: {
+        FileSystemConfigs: [
           {
-            Ref: 'VpcPrivateSubnet1Subnet536B997A',
-          },
-          {
-            Ref: 'VpcPrivateSubnet2Subnet3788AAA1',
+            Arn: stack.resolve(accessPoint.accessPointArn),
+            LocalMountPath: '/mnt/efs',
           },
         ],
+        Handler: 'pad-efs-storage.getDiskUsage',
+        Runtime: 'nodejs14.x',
+        Timeout: 300,
+        VpcConfig: {
+          SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],
+          SubnetIds: [
+            {
+              Ref: 'VpcPrivateSubnet1Subnet536B997A',
+            },
+            {
+              Ref: 'VpcPrivateSubnet2Subnet3788AAA1',
+            },
+          ],
+        },
       },
-    }));
+      DependsOn: arrayWith(stack.getLogicalId(accessPoint.node.defaultChild as CfnElement)),
+    }, ResourcePart.CompleteDefinition));
     cdkExpect(stack).to(haveResourceLike('AWS::Lambda::Function', {
-      FileSystemConfigs: [
-        {
-          Arn: stack.resolve(accessPoint.accessPointArn),
-          LocalMountPath: '/mnt/efs',
-        },
-      ],
-      Handler: 'pad-efs-storage.padFilesystem',
-      Runtime: 'nodejs14.x',
-      Timeout: 900,
-      VpcConfig: {
-        SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],
-        SubnetIds: [
+      Properties: {
+        FileSystemConfigs: [
           {
-            Ref: 'VpcPrivateSubnet1Subnet536B997A',
-          },
-          {
-            Ref: 'VpcPrivateSubnet2Subnet3788AAA1',
+            Arn: stack.resolve(accessPoint.accessPointArn),
+            LocalMountPath: '/mnt/efs',
           },
         ],
+        Handler: 'pad-efs-storage.padFilesystem',
+        Runtime: 'nodejs14.x',
+        Timeout: 900,
+        VpcConfig: {
+          SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],
+          SubnetIds: [
+            {
+              Ref: 'VpcPrivateSubnet1Subnet536B997A',
+            },
+            {
+              Ref: 'VpcPrivateSubnet2Subnet3788AAA1',
+            },
+          ],
+        },
       },
-    }));
+      DependsOn: arrayWith(stack.getLogicalId(accessPoint.node.defaultChild as CfnElement)),
+    }, ResourcePart.CompleteDefinition));
 
     const lambdaRetryCatch = {
       Retry: [


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-rfdk/issues/375

### Testing

* Clean deploy of all-in example's StorageTier.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
