### PR TITLE
chore(deps): force netmask version to avoid cve-2021-28918

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
     "ts-jest": "^26.5.4",
     "typescript": "~4.2.3"
   },
+  "resolutions-netmask-comment": "transitive dep from proxy-agent 4.0.1 & pac-resolver 4.1.0, which are transitive deps from CDK. Remove the forced resolution when able.",
+  "resolutions": {
+    "netmask": "^2.0.1",
+    "pac-resolver": "^4.2.0"
+  },
   "workspaces": {
     "packages": [
       "examples/**",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7761,10 +7761,10 @@ nested-error-stacks@^2.0.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-netmask@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
-  integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
+netmask@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.1.tgz#5a5cbdcbb7b6de650870e15e83d3e9553a414cf4"
+  integrity sha512-gB8eG6ubxz67c7O2gaGiyWdRUIbH61q7anjgueDqCC9kvIs/b4CTtCMaQKeJbv1/Y7FT19I4zKwYmjnjInRQsg==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -8405,14 +8405,14 @@ pac-proxy-agent@^4.1.0:
     raw-body "^2.2.0"
     socks-proxy-agent "5"
 
-pac-resolver@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-4.1.0.tgz#4b12e7d096b255a3b84e53f6831f32e9c7e5fe95"
-  integrity sha512-d6lf2IrZJJ7ooVHr7BfwSjRO1yKSJMaiiWYSHcrxSIUtZrCa4KKGwcztdkZ/E9LFleJfjoi1yl+XLR7AX24nbQ==
+pac-resolver@^4.1.0, pac-resolver@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-4.2.0.tgz#b82bcb9992d48166920bc83c7542abb454bd9bdd"
+  integrity sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==
   dependencies:
     degenerator "^2.2.0"
     ip "^1.1.5"
-    netmask "^1.0.6"
+    netmask "^2.0.1"
 
 package-hash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
We transitively get netmask deps from CDK; even with v1.96.0. Force resolution of netmask to 2.0.1. This essentially mimics work that was done upstream in CDK to resolve it in their packaging.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
