### PR TITLE
fix(examples): make alarm email optional and add README instructions

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
@@ -118,12 +118,17 @@ These instructions assume that your working directory is `examples/deadline/All-
     # To accept the MongoDB SSPL, change from USER_REJECTS_SSPL to USER_ACCEPTS_SSPL
     self.accept_sspl_license: MongoDbSsplLicenseAcceptance = MongoDbSsplLicenseAcceptance.USER_REJECTS_SSPL
     ```
-14. Deploy all the stacks in the sample app:
+14. Optionally configure alarm notifications. If you choose to configure alarms, change the value of the `alarm_email_address` variable in `package/config.py` to the desired email address to receive alarm notifications:
+
+    ```python
+    self.alarm_email_address: Optional[str] = 'username@yourdomain.com'
+    ```
+15. Deploy all the stacks in the sample app:
 
     ```bash
     cdk deploy "*"
     ```
-15. Once you are finished with the sample app, you can tear it down by running:
+16. Once you are finished with the sample app, you can tear it down by running:
 
     ```bash
     cdk destroy "*"

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
@@ -82,7 +82,8 @@ class StorageTierProps(StackProps):
     # The VPC to deploy resources into.
     vpc: IVpc
 
-    # Email address to send alerts to when CloudWatch Alarms breach.
+    # Email address to send alerts to when CloudWatch Alarms breach. If not specified, no alarms or alerts will be
+    # deployed.
     alarm_email: Optional[str]
 
 

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
@@ -114,7 +114,12 @@ These instructions assume that your working directory is `examples/deadline/All-
     // To accept the MongoDB SSPL, change from USER_REJECTS_SSPL to USER_ACCEPTS_SSPL
     public readonly acceptSsplLicense: MongoDbSsplLicenseAcceptance = MongoDbSsplLicenseAcceptance.USER_REJECTS_SSPL;
     ```
-13. Build the `aws-rfdk` package, and then build the sample app. There is some magic in the way yarn workspaces and lerna packages work that will link the built `aws-rfdk` from the base directory as the dependency to be used in the example's directory:
+13. Optionally configure alarm notifications. If you choose to configure alarms, change the value of the `alarmEmailAddress` variable in `bin/config.ts` to the desired email address to receive alarm notifications:
+
+    ```ts
+    public readonly alarmEmailAddress?: string = 'username@yourdomain.com';
+    ```
+14. Build the `aws-rfdk` package, and then build the sample app. There is some magic in the way yarn workspaces and lerna packages work that will link the built `aws-rfdk` from the base directory as the dependency to be used in the example's directory:
     ```bash
     # Navigate to the root directory of the RFDK repository (assumes you started in the example's directory)
     pushd ../../../..
@@ -127,12 +132,12 @@ These instructions assume that your working directory is `examples/deadline/All-
     # Run the example's build
     yarn build
     ```
-14. Deploy all the stacks in the sample app:
+15. Deploy all the stacks in the sample app:
 
     ```
     cdk deploy "*"
     ```
-15. Once you are finished with the sample app, you can tear it down by running:
+16. Once you are finished with the sample app, you can tear it down by running:
 
     ```
     cdk destroy "*"

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
@@ -62,8 +62,10 @@ export interface StorageTierProps extends cdk.StackProps {
 
   /**
    * Email address to send alerts to when CloudWatch Alarms breach.
+   *
+   * @default No alarms or alerts will be deployed
    */
-  readonly alarmEmail: string;
+  readonly alarmEmail?: string;
 }
 
 /**


### PR DESCRIPTION
## Problem

#373 added code in the AWS-All-in-Basic example to allow configuring an email address to which operational alarm notifications are sent. The intention was to have this optional and when not specified, no alarms would be configured. In the TypeScript version of the example, this was not made optional and anyone using it would need to  modify the code. This new configuration setting was not documented in the `README.md` files.

## Solution

*   Made the property optional in the TypeScript example
*   Added a step to both the Python and TypeScript `README.md` to optionally populate this configuration setting

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
