### PR TITLE
test(integ): add test for RCS process owner

### DIFF
--- a/integ/components/deadline/deadline_02_renderQueue/scripts/bastion/testing/RQ-query-rcs-user.sh
+++ b/integ/components/deadline/deadline_02_renderQueue/scripts/bastion/testing/RQ-query-rcs-user.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Script to return the username for the process running the RCS as reported by Deadline
+#
+# Input:
+#   None
+# Output:
+#   Non-zero return code on failure.
+#   Outputs the username of the process that the Deadline RCS is running as
+
+
+set -euo pipefail
+
+DEADLINE="/opt/Thinkbox/Deadline10/bin"
+
+# Fetch repository.ini from the Deadline repo
+$DEADLINE/deadlinecommand -json GetProxyServerInfos | jq -e -r '.result[]|select(.Stat == 1 and .Type == "Remote")|.User'

--- a/integ/components/deadline/deadline_02_renderQueue/test/deadline_02_renderQueue.test.ts
+++ b/integ/components/deadline/deadline_02_renderQueue/test/deadline_02_renderQueue.test.ts
@@ -230,5 +230,32 @@ describe.each(testCases)('Deadline RenderQueue tests (%s)', (_, id) => {
         expect(responseCode).toEqual(0);
       });
     });
+
+    test(`RQ-${id}-5: RCS not running as root`, async () => {
+      /**********************************************************************************************************
+       * TestID:          RQ-5
+       * Description:     Confirm that RCS process is not running as the root user
+       * Input:           The user owning the RCS process as reported by deadlinecommand
+       * Expected result: Response code 0, i.e. the script execution was successful and Deadline accepted the job
+      **********************************************************************************************************/
+      var params = {
+        DocumentName: 'AWS-RunShellScript',
+        Comment: 'Execute Test Script RQ-query-rcs-user.sh',
+        InstanceIds: [bastionId],
+        Parameters: {
+          commands: [
+            'sudo -i',
+            'su - ec2-user >/dev/null',
+            'cd ~ec2-user',
+            './testScripts/RQ-query-rcs-user.sh',
+          ],
+        },
+      };
+      return awaitSsmCommand(bastionId, params).then( response => {
+        const user = response.output;
+        expect(user).not.toHaveLength(0);
+        expect(user).not.toEqual('root');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Problem

The RFDK integration tests does not have any coverage for the owning user of the process that the Deadline RCS runs as within the ECS task container. This means that we have no assurance that RFDK follows the principle of least-privilege with respect to the process permissions within these containers.

## Solution

Add a test that checks the OS user of the RCS process running within the ECS task containers deployed by RFDK's `RenderQueue` construct. The Deadline RCS already reports it's process' user to Deadline's database. This tests relies on:

```
deadlinecommand GetProxyServerInfos
```

which returns this information as reported by the RCS.

## Testing

Ran the integration tests and confirmed that the new test was run and passed:

```
Complete!
Pretest setup runtime: 0m 4s
Infrastructure stack deploy runtime: 4m 1s
Infrastructure stack cleanup runtime: 2m 0s
Results for test component deadline_02_renderQueue:
  -Tests ran: 10
  -Tests passed: 10
  -Tests failed: 0
  -Deploy runtime:     24m 12s
  -Test suite runtime: 0m 57s
  -Cleanup runtime:    16m 18s
Cleaning up folders...
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
