### PR TITLE
feat(core): add ability to resolve mount targets using EFS API

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
@@ -188,7 +188,7 @@ export class MountableEfs implements IMountableLinuxFilesystem {
       'TMPDIR=$(mktemp -d)',
       'pushd "$TMPDIR"',
       `unzip ${mountScript}`,
-      `bash ./mountEfs.sh ${this.props.filesystem.fileSystemId} ${mountDir} ${mountOptionsStr} ${resolveMountTargetDnsWithApi}`,
+      `bash ./mountEfs.sh ${this.props.filesystem.fileSystemId} ${mountDir} ${resolveMountTargetDnsWithApi} ${mountOptionsStr}`,
       'popd',
       `rm -f ${mountScript}`,
     );

--- a/packages/aws-rfdk/lib/core/scripts/bash/metadataUtilities.sh
+++ b/packages/aws-rfdk/lib/core/scripts/bash/metadataUtilities.sh
@@ -68,3 +68,10 @@ function get_region() {
     #  into: us-west-2
     echo $IDENTITY_DOC | tr ',' '\n' | tr -d '[",{}]' | grep 'region' | awk '{print $3}'
 }
+
+function get_availability_zone() {
+    # Get the availability zone that this instance is running within (ex: us-west-2b)
+    # Usage: $0 <token>
+    TOKEN=$1
+    curl -H "X-aws-ec2-metadata-token: $TOKEN" -v 'http://169.254.169.254/latest/meta-data/placement/availability-zone' 2> /dev/null
+}

--- a/packages/aws-rfdk/lib/core/scripts/bash/mountEfs.sh
+++ b/packages/aws-rfdk/lib/core/scripts/bash/mountEfs.sh
@@ -42,7 +42,7 @@ MOUNT_PATH=$2
 RESOLVE_MOUNTPOINT_IP_VIA_API=$3
 MOUNT_OPTIONS="${4:-}"
 
-sudo mkdir -p "${MOUNT_PATH}"
+mkdir -p "${MOUNT_PATH}"
 
 AMAZON_EFS_PACKAGE="amazon-efs-utils"
 if which yum
@@ -55,12 +55,12 @@ else
 fi
 
 function use_amazon_efs_mount() {
-  test -f "/sbin/mount.efs" || sudo "${PACKAGE_MANAGER}" install -y "${AMAZON_EFS_PACKAGE}"
+  test -f "/sbin/mount.efs" || "${PACKAGE_MANAGER}" install -y "${AMAZON_EFS_PACKAGE}"
   return $?
 }
 
 function use_nfs_mount() {
-  test -f "/sbin/mount.nfs4" || sudo "${PACKAGE_MANAGER}" install -y "${NFS_UTILS_PACKAGE}"
+  test -f "/sbin/mount.nfs4" || "${PACKAGE_MANAGER}" install -y "${NFS_UTILS_PACKAGE}"
   return $?
 }
 
@@ -117,7 +117,7 @@ then
   # jq is used to query the JSON API response
   if ! where jq > /dev/null 2>&1
   then
-    sudo "${PACKAGE_MANAGER}" install -y jq
+    "${PACKAGE_MANAGER}" install -y jq
   fi
 
   # Get access point ID if available, otherwise file system ID
@@ -143,16 +143,16 @@ fi
 if test $(tail -c 1 /etc/fstab | wc -l) -eq 0
 then
   # Newline was missing, so add one.
-  echo "" | sudo tee -a /etc/fstab
+  echo "" | tee -a /etc/fstab
 fi
 
 if use_amazon_efs_mount
 then
-  echo "${FILESYSTEM_ID}:/ ${MOUNT_PATH} efs defaults,tls,_netdev,${MOUNT_OPTIONS}" | sudo tee -a /etc/fstab
+  echo "${FILESYSTEM_ID}:/ ${MOUNT_PATH} efs defaults,tls,_netdev,${MOUNT_OPTIONS}" | tee -a /etc/fstab
   MOUNT_TYPE=efs
 elif use_nfs_mount
 then
-  echo "${FILESYSTEM_ID}.efs.${AWS_REGION}.amazonaws.com:/ ${MOUNT_PATH} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev,${MOUNT_OPTIONS} 0 0" | sudo tee -a /etc/fstab
+  echo "${FILESYSTEM_ID}.efs.${AWS_REGION}.amazonaws.com:/ ${MOUNT_PATH} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev,${MOUNT_OPTIONS} 0 0" | tee -a /etc/fstab
   MOUNT_TYPE=nfs4
 else
   echo "Could not find suitable mount helper to mount the Elastic File System: ${FILESYSTEM_ID}"
@@ -164,7 +164,7 @@ fi
 # only if unable to mount it after that.
 TRIES=0
 MAX_TRIES=20
-while test ${TRIES} -lt ${MAX_TRIES} && ! sudo mount -a -t ${MOUNT_TYPE}
+while test ${TRIES} -lt ${MAX_TRIES} && ! mount -a -t ${MOUNT_TYPE}
 do
   let TRIES=TRIES+1
   sleep 2

--- a/packages/aws-rfdk/lib/core/scripts/bash/mountEfs.sh
+++ b/packages/aws-rfdk/lib/core/scripts/bash/mountEfs.sh
@@ -20,7 +20,7 @@
 
 set -xeu
 
-if test $# -lt 2
+if test $# -lt 3
 then
   echo "Usage: $0 FILE_SYSTEM_ID MOUNT_PATH RESOLVE_MOUNT_POINT_USING_API [MOUNT_OPTIONS]"
   exit 1

--- a/packages/aws-rfdk/lib/core/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/core/test/asset-constants.ts
@@ -19,7 +19,7 @@ export const CWA_ASSET_WINDOWS = {
 
 // mountEbsBlockVolume.sh + metadataUtilities.sh + ec2-certificates.crt
 export const MOUNT_EBS_SCRIPT_LINUX = {
-  Bucket: stringLike('AssetParameters*S3BucketD23CD539'),
+  Bucket: stringLike('AssetParameters*S3BucketD3D2B3C1'),
 };
 
 export const INSTALL_MONGODB_3_6_SCRIPT_LINUX = {

--- a/packages/aws-rfdk/lib/core/test/mountable-efs.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-efs.test.ts
@@ -286,4 +286,60 @@ describe('Test MountableEFS', () => {
     expect(matches).toHaveLength(2);
     expect(matches[0]).toBe(matches[1]);
   });
+
+  describe('resolves mount target using API', () => {
+    describe.each<[string, () => efs.AccessPoint | undefined]>([
+      ['with access point', () => {
+
+        return new efs.AccessPoint(stack, 'AccessPoint', {
+          fileSystem: efsFS,
+          posixUser: {
+            gid: '1',
+            uid: '1',
+          },
+        });
+      }],
+      ['without access point', () => undefined],
+    ])('%s', (_, getAccessPoint) => {
+      let accessPoint: efs.AccessPoint | undefined;
+
+      beforeEach(() => {
+        // GIVEN
+        accessPoint = getAccessPoint();
+        const mountable = new MountableEfs(efsFS, {
+          filesystem: efsFS,
+          accessPoint,
+          resolveMountTargetDnsWithApi: true,
+        });
+
+        // WHEN
+        mountable.mountToLinuxInstance(instance, {
+          location: '/mnt/efs',
+        });
+      });
+
+      test('grants DescribeMountTargets permission', () => {
+        const expectedResources = [
+          stack.resolve((efsFS.node.defaultChild as efs.CfnFileSystem).attrArn),
+        ];
+        if (accessPoint) {
+          expectedResources.push(stack.resolve(accessPoint?.accessPointArn));
+        }
+        cdkExpect(stack).to(haveResourceLike('AWS::IAM::Policy', {
+          PolicyDocument: objectLike({
+            Statement: arrayWith(
+              {
+                Action: 'elasticfilesystem:DescribeMountTargets',
+                Effect: 'Allow',
+                Resource: expectedResources.length == 1 ? expectedResources[0] : expectedResources,
+              },
+            ),
+          }),
+          Roles: arrayWith(
+            stack.resolve((instance.role.node.defaultChild as CfnResource).ref),
+          ),
+        }));
+      });
+    });
+  });
 });

--- a/packages/aws-rfdk/lib/core/test/mountable-efs.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-efs.test.ts
@@ -92,7 +92,7 @@ describe('Test MountableEFS', () => {
     expect(userData).toMatch(new RegExp(escapeTokenRegex(s3Copy)));
     expect(userData).toMatch(new RegExp(escapeTokenRegex('unzip /tmp/${Token[TOKEN.\\d+]}${Token[TOKEN.\\d+]}')));
     // Make sure we execute the script with the correct args
-    expect(userData).toMatch(new RegExp(escapeTokenRegex('bash ./mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 rw')));
+    expect(userData).toMatch(new RegExp(escapeTokenRegex('bash ./mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 false rw')));
   });
 
   test('assert Linux-only', () => {
@@ -129,7 +129,7 @@ describe('Test MountableEFS', () => {
     const userData = instance.userData.render();
 
     // THEN
-    expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 r')));
+    expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 false r')));
   });
 
   describe.each<[MountPermissions | undefined]>([
@@ -206,7 +206,7 @@ describe('Test MountableEFS', () => {
             expect.arrayContaining([
               expect.stringMatching(new RegExp('(\\n|^)bash \\./mountEfs.sh $')),
               stack.resolve(efsFS.fileSystemId),
-              ` ${mountPath} ${expectedMountMode},iam,accesspoint=`,
+              ` ${mountPath} false ${expectedMountMode},iam,accesspoint=`,
               stack.resolve(accessPoint.accessPointId),
               expect.stringMatching(/^\n/),
             ]),
@@ -257,7 +257,7 @@ describe('Test MountableEFS', () => {
     const userData = instance.userData.render();
 
     // THEN
-    expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 rw,option1,option2')));
+    expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 false rw,option1,option2')));
   });
 
   test('asset is singleton', () => {

--- a/packages/aws-rfdk/lib/deadline/test/repository.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/repository.test.ts
@@ -432,7 +432,7 @@ test('repository mounts repository filesystem', () => {
   const userData = (repo.node.defaultChild as AutoScalingGroup).userData.render();
 
   // THEN
-  expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 rw')));
+  expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/efs/fs1 false rw')));
 });
 
 test.each([
@@ -939,7 +939,7 @@ test('repository configure client instance', () => {
 
   // THEN
   // white-box testing. If we mount the filesystem, then we've called: setupDirectConnect()
-  expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/repository rw')));
+  expect(userData).toMatch(new RegExp(escapeTokenRegex('mountEfs.sh ${Token[TOKEN.\\d+]} /mnt/repository false rw')));
 
   // Make sure we added the DB connection args
   expect(userData).toMatch(/.*export -f configure_deadline_database.*/);


### PR DESCRIPTION
Resolves #391

Taken from that issue:

> The RFDK code to mount EFS file-systems on an instance assumes that the instance belongs to a VPC with Amazon-supplied DNS (see [VPC DNS documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html)). When a VPC is configured to disable the Amazon-supplied DNS resolver, then the DNS names used by both the EFS mount helper and the NFS mounting code cannot be resolved and the mount will fail with an error showing up in the `cloud-init` log file, such as:

> ```
> [   32.413572] cloud-init[3739]: Failed to resolve "fs-a1b2c3d4.efs.us-west-2.amazonaws.com" - check that your file system ID is correct.
> ```

## Solution

The DNS names in the error message above correspond to [EFS mount  targets](https://docs.aws.amazon.com/efs/latest/ug/manage-fs-access.html). These provide the endpoints that serve the networked file-system traffic. EFS automatically adds DNS entries into your VPC's Amazon-supplied Route 53 resolver, but when this feature is disabled, those names cannot be resolved using DNS.

Fortunately, the IP address of each mount target can be obtained by calling the EFS [`DescribeMountTargets` API](https://docs.aws.amazon.com/efs/latest/ug/API_DescribeMountTargets.html).

Added an optional boolean flag when EFS mounting script that will perform this lookup and bake the IP address into the host machine's `/etc/hosts` file to bypass DNS lookups. Using this looks like:

**TypeScript:**

```ts
new MountableEfs(scope, {
  // ...
  resolveMountTargetDnsWithApi: true,
});
```

**Python:**

```py
MountableEfs(scope,
  # ...
  resolve_mount_target_dns_with_api=True,
)
```

## Testing

Modified the `All-In-AWS-Infrastructure-Basic` example, enabling the above flag. Connected to the mounting instances using SSM Session Manager and confirmed:

*   The `/etc/hosts` file contains an entry for the mount target:

        10.0.71.79 fs-a1b2c1d2.efs.us-west-2.amazonaws.com # Added by RFDK

*   The EFS file-system driver establishes a connection to the specified IP address:

    ```sh
    $ sudo netstat -alnp | grep 10.0.71.79
    tcp        0      0 10.0.0.13:55102         10.0.71.79:2049         ESTABLISHED 2306/stunnel
    ```

*   Deployment succeeds
*   Am able to connect to the farm, submit a job, view successful render logs (requires proper EFS mounting on the `RenderQueue`)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
