### PR TITLE
chore(deadline): adding retries for http requests and timeouts for custom resources

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -424,6 +424,7 @@ export class ConfigureSpotEventPlugin extends Construct {
 
     const region = Construct.isConstruct(props.renderQueue) ? Stack.of(props.renderQueue).region : Stack.of(this).region;
 
+    const timeoutMins = 15;
     const configurator = new LambdaFunction(this, 'Configurator', {
       vpc: props.vpc,
       vpcSubnets: props.vpcSubnets ?? { subnetType: SubnetType.PRIVATE },
@@ -432,10 +433,11 @@ export class ConfigureSpotEventPlugin extends Construct {
       }),
       environment: {
         DEBUG: 'false',
+        LAMBDA_TIMEOUT_MINS: timeoutMins.toString(),
       },
       runtime: Runtime.NODEJS_12_X,
       handler: 'configure-spot-event-plugin.configureSEP',
-      timeout: Duration.minutes(15),
+      timeout: Duration.minutes(timeoutMins),
       logRetention: RetentionDays.ONE_WEEK,
     });
 

--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -435,7 +435,7 @@ export class ConfigureSpotEventPlugin extends Construct {
       },
       runtime: Runtime.NODEJS_12_X,
       handler: 'configure-spot-event-plugin.configureSEP',
-      timeout: Duration.minutes(2),
+      timeout: Duration.minutes(15),
       logRetention: RetentionDays.ONE_WEEK,
     });
 

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/handler.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/handler.ts
@@ -101,12 +101,11 @@ export class SEPConfiguratorResource extends SimpleCustomResource {
   }
 
   private async spotEventPluginClient(connection: ConnectionOptions): Promise<SpotEventPluginClient> {
-    // The maximum Lambda execution time is 15 mins.
-    // There will be less retries, because we quit Lambda earlier before the timeout (see simple-resource implementation).
-    // Otherwise, it will hang up.
-    const EXECUTION_TIME_MINUTES = 15;
+    // The calculation of retries is approximate. The real number of retries will be smaller,
+    // because we quit Lambda before the timeout (see SimpleCustomResource implementation).
+    const lambdaTimeoutMins = parseInt(process.env.LAMBDA_TIMEOUT_MINS || '15'); // The maximum Lambda execution time is 15 mins.
     const MS_IN_A_MINUTE = 60000;
-    const timeRemaining = EXECUTION_TIME_MINUTES * MS_IN_A_MINUTE;
+    const timeRemaining = lambdaTimeoutMins * MS_IN_A_MINUTE;
     const retryWaitMs = 10000;
     const retries = Math.floor(timeRemaining / retryWaitMs);
 

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/aws-lambda/types.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/aws-lambda/types.ts
@@ -13,4 +13,5 @@
 export interface LambdaContext {
   readonly logGroupName: string;
   readonly logStreamName: string;
+  getRemainingTimeInMillis?(): number;
 }

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/aws-lambda/types.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/aws-lambda/types.ts
@@ -13,5 +13,5 @@
 export interface LambdaContext {
   readonly logGroupName: string;
   readonly logStreamName: string;
-  getRemainingTimeInMillis?(): number;
+  getRemainingTimeInMillis(): number;
 }

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/deadline-client/deadline-client.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/deadline-client/deadline-client.ts
@@ -54,7 +54,7 @@ export interface DeadlineClientProps {
   readonly tls?: TLSProps;
 
   /**
-   * The number of retries if received status code 503 Service Temporarily unavailable.
+   * The number of retries if received status code 500 or higher.
    * @default 3
    */
   readonly retries?: number;

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/deadline-client/deadline-client.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/deadline-client/deadline-client.ts
@@ -185,7 +185,7 @@ export class DeadlineClient {
     } catch(exception) {
       const { statusCode, statusMessage } = exception;
       if (statusCode !== undefined && statusMessage !== undefined) {
-        if (statusCode === 503 && retriesLeft > 0) {
+        if (statusCode >= 500 && retriesLeft > 0) {
           console.log(`Request failed with ${statusCode}: ${statusMessage}. Will retry after ${retryDelayMs} ms.`);
           console.log(`Retries left: ${retriesLeft}`);
           const delay = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/packages/aws-rfdk/lib/lambdas/nodejs/pad-efs-storage/test/handlers.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/pad-efs-storage/test/handlers.test.ts
@@ -128,6 +128,7 @@ describe('Testing getDiskUsage behavior', () => {
     {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -138,6 +139,7 @@ describe('Testing getDiskUsage behavior', () => {
     {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -153,6 +155,7 @@ describe('Testing getDiskUsage behavior', () => {
     {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -176,6 +179,7 @@ describe('Testing getDiskUsage behavior', () => {
     {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     });
 
     // THEN
@@ -203,6 +207,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -213,6 +218,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -222,6 +228,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -232,6 +239,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -247,6 +255,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     })).rejects.toThrow();
   });
 
@@ -266,6 +275,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     });
 
     // THEN
@@ -291,6 +301,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     });
 
     // WHEN
@@ -302,6 +313,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     });
 
     // THEN
@@ -328,6 +340,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     });
 
     // WHEN
@@ -339,6 +352,7 @@ describe('Testing padFilesystem macro behavior', () => {
     }, {
       logGroupName: '',
       logStreamName: '',
+      getRemainingTimeInMillis: () => 1000,
     });
 
     // THEN


### PR DESCRIPTION
This PR fixes 2 potential issues in RFDK:
1. SEP configuration uses HTTP/HTTPS requests to connect to the RenderQueue. We only send one request, so in case of a failure, the stack will be rolled back. This PR adds possibility to retry the requests in case of `503 Service Temporarily Unavailable error` and other `5xx` errors.
2. Our `SimpleCustomResource implementation` doesn't handle Lambda timeouts properly. When Lambda runs out of time, the execution is stopped without sending a failure signal to the CloudFormation. This causes the deployment to hang for a long time (1 hour) before indicating the error. With the changes from this PR, we will always stop the execution earlier then Lambda times out, so the signal will be always sent to the CloudFormation.
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
