### PR TITLE
feat(deadline): add ability to import repository settings

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -43,6 +43,9 @@ import {
   PolicyStatement,
 } from '@aws-cdk/aws-iam';
 import {
+  Asset,
+} from '@aws-cdk/aws-s3-assets';
+import {
   Annotations,
   Construct,
   Duration,
@@ -376,6 +379,12 @@ export interface RepositoryProps {
    * Options to add additional security groups to the Repository.
    */
   readonly securityGroupsOptions?: RepositorySecurityGroupsOptions;
+
+  /**
+   * The Deadline Repository settings file to import.
+   * @see https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/repository-settings-importer-exporter.html
+   */
+  readonly repositorySettings?: Asset;
 }
 
 /**
@@ -657,6 +666,7 @@ export class Repository extends Construct implements IRepository {
       this.installerGroup,
       repositoryInstallationPath,
       props.version,
+      props.repositorySettings,
     );
 
     this.configureSelfTermination();
@@ -887,7 +897,8 @@ export class Repository extends Construct implements IRepository {
   private configureRepositoryInstallerScript(
     installerGroup: AutoScalingGroup,
     installPath: string,
-    version: IVersion) {
+    version: IVersion,
+    settings?: Asset) {
     const installerScriptAsset = ScriptAsset.fromPathConvention(this, 'DeadlineRepositoryInstallerScript', {
       osType: installerGroup.osType,
       baseName: 'installDeadlineRepository',
@@ -902,13 +913,23 @@ export class Repository extends Construct implements IRepository {
 
     version.linuxInstallers.repository.s3Bucket.grantRead(installerGroup, version.linuxInstallers.repository.objectKey);
 
+    const installerArgs = [
+      `"s3://${version.linuxInstallers.repository.s3Bucket.bucketName}/${version.linuxInstallers.repository.objectKey}"`,
+      `"${installPath}"`,
+      version.linuxFullVersionString(),
+    ];
+
+    if (settings) {
+      const repositorySettingsFilePath = installerGroup.userData.addS3DownloadCommand({
+        bucket: settings.bucket,
+        bucketKey: settings.s3ObjectKey,
+      });
+      installerArgs.push(repositorySettingsFilePath);
+    }
+
     installerScriptAsset.executeOn({
       host: installerGroup,
-      args: [
-        `"s3://${version.linuxInstallers.repository.s3Bucket.bucketName}/${version.linuxInstallers.repository.objectKey}"`,
-        `"${installPath}"`,
-        version.linuxFullVersionString(),
-      ],
+      args: installerArgs,
     });
   }
 }

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -383,6 +383,8 @@ export interface RepositoryProps {
   /**
    * The Deadline Repository settings file to import.
    * @see https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/repository-settings-importer-exporter.html
+   *
+   * @default Repository settings are not imported.
    */
   readonly repositorySettings?: Asset;
 }
@@ -898,7 +900,8 @@ export class Repository extends Construct implements IRepository {
     installerGroup: AutoScalingGroup,
     installPath: string,
     version: IVersion,
-    settings?: Asset) {
+    settings?: Asset,
+  ) {
     const installerScriptAsset = ScriptAsset.fromPathConvention(this, 'DeadlineRepositoryInstallerScript', {
       osType: installerGroup.osType,
       baseName: 'installDeadlineRepository',

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/installDeadlineRepository.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/installDeadlineRepository.sh
@@ -75,7 +75,8 @@ for key in "${!INSTALLER_DB_ARGS[@]}"; do INSTALLER_DB_ARGS_STRING=$INSTALLER_DB
 REPOSITORY_SETTINGS_ARG_STRING=''
 if [ ! -z "$DEADLINE_REPOSITORY_SETTINGS_FILE" ]; then
   if [ ! -f "$DEADLINE_REPOSITORY_SETTINGS_FILE" ]; then
-    echo "WARNING: Repository settings file was specified but is not a file: $DEADLINE_REPOSITORY_SETTINGS_FILE. Repository settings will not be imported."
+    echo "ERROR: Repository settings file was specified but is not a file: $DEADLINE_REPOSITORY_SETTINGS_FILE."
+    exit 1
   else
     REPOSITORY_SETTINGS_ARG_STRING="--importrepositorysettings true --repositorysettingsimportoperation append --repositorysettingsimportfile \"$DEADLINE_REPOSITORY_SETTINGS_FILE\""
   fi

--- a/packages/aws-rfdk/lib/deadline/test/repository.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/repository.test.ts
@@ -35,6 +35,7 @@ import {
   FileSystem as EfsFileSystem,
 } from '@aws-cdk/aws-efs';
 import { Bucket } from '@aws-cdk/aws-s3';
+import { Asset } from '@aws-cdk/aws-s3-assets';
 import {
   App,
   CfnElement,
@@ -1204,4 +1205,22 @@ test('throws an error if supplied a MountableEfs with no Access Point', () => {
 
   // THEN
   expect(when).toThrow('When using EFS with the Repository, you must provide an EFS Access Point');
+});
+
+test('imports repository settings', () => {
+  // GIVEN
+  const repositorySettings = new Asset(stack, 'RepositorySettingsAsset', {
+    path: __filename,
+  });
+
+  // WHEN
+  const repository = new Repository(stack, 'Repository', {
+    vpc,
+    version,
+    repositorySettings,
+  });
+
+  // THEN
+  const installerGroup = repository.node.tryFindChild('Installer') as AutoScalingGroup;
+  expect(installerGroup.userData.render()).toContain(`aws s3 cp '${repositorySettings.s3ObjectUrl}'`);
 });


### PR DESCRIPTION
Partial fix for https://github.com/aws/aws-rfdk/issues/397

### Notes
Adds ability to import Deadline Repository settings with a repository settings file (see https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/repository-settings-importer-exporter.html)

### Testing
Creating a JSON file that conformed to the repository settings importer format with a region and a path mapping rule. Modified the example app to use the file in the `Repository` construct and deployed it. Verified that:
- The Repository installer group succeeds in importing the settings with the Repository installer.
- Ran the `ExportRepositorySettings` Deadline command from the `RenderQueue` container and verified the settings I imported were in the output
Also deployed without the settings and verified the installer still succeeds.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
