### PR TITLE
feat(deadline): add security group property to ubl

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -329,6 +329,8 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       }],
       updateType: undefined, // Workaround -- See: https://github.com/aws/aws-cdk/issues/11581
       updatePolicy: UpdatePolicy.rollingUpdate(),
+      // addCapacity doesn't specifically take a securityGroup, but it passes on its properties to the ASG it creates,
+      // so this security group will get applied there
       // @ts-ignore
       securityGroup: props.securityGroups?.backend,
     });

--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -12,6 +12,7 @@ import {
   InstanceClass,
   InstanceSize,
   InstanceType,
+  ISecurityGroup,
   IVpc,
   Port,
   SubnetSelection,
@@ -418,6 +419,12 @@ export interface UsageBasedLicensingProps {
    * @default - LogGroup will be created with all properties' default values to the LogGroup: /renderfarm/<construct id>
    */
   readonly logGroupProps?: LogGroupFactoryProps;
+
+  /**
+   * The security group to use for the License Forwarder
+   * @default - A new security group will be created
+   */
+  readonly securityGroup?: ISecurityGroup;
 }
 
 /**
@@ -511,6 +518,10 @@ export class UsageBasedLicensing extends Construct implements IGrantable {
         deviceName: '/dev/xvda',
         volume: BlockDeviceVolume.ebs( 30, {encrypted: true}),
       }],
+      // addCapacity doesn't specifically take a securityGroup, but it passes on its properties to the ASG it creates,
+      // so this security group will get applied there
+      // @ts-ignore
+      securityGroup: props.securityGroup,
     });
 
     const taskDefinition = new TaskDefinition(this, 'TaskDefinition', {

--- a/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
@@ -192,6 +192,25 @@ describe('UsageBasedLicensing', () => {
         ),
       }));
     });
+
+    test('uses the supplied security group', () => {
+      const securityGroup = new SecurityGroup(stack, 'UblSecurityGroup', {
+        vpc,
+      });
+      // WHEN
+      new UsageBasedLicensing(stack, 'UBL', {
+        certificateSecret,
+        images,
+        licenses,
+        renderQueue,
+        vpc,
+        securityGroup,
+      });
+      // THEN
+      expectCDK(stack).to(haveResourceLike('AWS::AutoScaling::LaunchConfiguration', {
+        SecurityGroups: arrayWith(stack.resolve(securityGroup.securityGroupId)),
+      }));
+    });
   });
 
   describe('creates an ECS service', () => {


### PR DESCRIPTION
Fixes #394 

## Notes
This PR adds `securityGroup` as a construct property on the UBL construct to be used by the ASG that gets created to host the container running the license forwarder, similarly to how we accept a `securityGroup` on the RenderQueue construct for the same purpose.

## Testing
A unit test was added to pass a security group into the UBL constructor and confirm that the security group's ID was present in the LaunchConfiguration of the ASG that the UBL construct creates.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
