### PR TITLE
chore(docs): change relative links to markdown files to fully qualified links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 Contributions to the RFDK are encouraged. If you want to fix a problem, or want to enhance the library in any way, then
 we are happy to accept your contribution. Information on contributing to the RFDK can be found
-[in CONTRIBUTING.md](https://github.com/aws/aws-rfdk/blob/mainline/CONTRIBUTING.md).
+[in CONTRIBUTING.md](https://github.com/aws/aws-rfdk/blob/release/CONTRIBUTING.md).
 
 ## Code of Conduct
 

--- a/packages/aws-rfdk/README.md
+++ b/packages/aws-rfdk/README.md
@@ -13,6 +13,6 @@ via AWS CloudFormation by the CDK toolkit. The parameters of an object’s creat
 Please see the following sources for additional information:
 * The [RFDK Developer Guide](https://docs.aws.amazon.com/rfdk/latest/guide/what-is-rfdk.html)
 * The [RFDK API Documentation](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk-construct-library.html)
-* The [README for the main module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/core/README.md)
-* The [README for the Deadline module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/deadline/README.md)
-* The [RFDK Upgrade Documentation](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/upgrade/index.md)
+* The [README for the main module](https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/lib/core/README.md)
+* The [README for the Deadline module](https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/lib/deadline/README.md)
+* The [RFDK Upgrade Documentation](https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/docs/upgrade/index.md)

--- a/packages/aws-rfdk/README.md
+++ b/packages/aws-rfdk/README.md
@@ -15,4 +15,4 @@ Please see the following sources for additional information:
 * The [RFDK API Documentation](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk-construct-library.html)
 * The [README for the main module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/core/README.md)
 * The [README for the Deadline module](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/deadline/README.md)
-* The [RFDK Upgrade Documentation](./docs/upgrade/index.md)
+* The [RFDK Upgrade Documentation](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/upgrade/index.md)

--- a/packages/aws-rfdk/docs/upgrade/index.md
+++ b/packages/aws-rfdk/docs/upgrade/index.md
@@ -4,4 +4,4 @@ This documentation aims to provide information to help planning or troubleshoot 
 applications. The documentation is separated by RFDK versions that included potentially breaking changes. If you are
 upgrading to (or beyond) a version listed below, you should consult the the linked upgrade documentation.
 
-*   [`0.27.x`](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/upgrade/upgrading-0.27.md)
+*   [`0.27.x`](./upgrading-0.27.md)

--- a/packages/aws-rfdk/docs/upgrade/index.md
+++ b/packages/aws-rfdk/docs/upgrade/index.md
@@ -4,4 +4,4 @@ This documentation aims to provide information to help planning or troubleshoot 
 applications. The documentation is separated by RFDK versions that included potentially breaking changes. If you are
 upgrading to (or beyond) a version listed below, you should consult the the linked upgrade documentation.
 
-*   [`0.27.x`](./upgrading-0.27.md)
+*   [`0.27.x`](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/upgrade/upgrading-0.27.md)

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -317,11 +317,11 @@ const fleet = new SpotEventPluginFleet(this, 'SpotEventPluginFleet', {
 
 ## Stage
 
-A stage is a directory that conforms to a [conventional structure](../../docs/DockerImageRecipes.md#stage-directory-convention) that RFDK requires to deploy Deadline. This directory contains the Docker image recipes that RFDK uses to build Docker images.
+A stage is a directory that conforms to a [conventional structure](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/DockerImageRecipes.md#stage-directory-convention) that RFDK requires to deploy Deadline. This directory contains the Docker image recipes that RFDK uses to build Docker images.
 
 ### Staging Docker Recipes
 
-Docker image recipes required by various constructs in Deadline (e.g. `RenderQueue`, `UsageBasedLicensing`, etc.) must be staged to a local directory that RFDK can consume. For information on what a Docker image recipe is and how it should be organized, see [Docker Image Recipes](../../docs/DockerImageRecipes.md). You can either stage your own recipes or use ones provided by AWS Thinkbox via `ThinkboxDockerRecipes`.
+Docker image recipes required by various constructs in Deadline (e.g. `RenderQueue`, `UsageBasedLicensing`, etc.) must be staged to a local directory that RFDK can consume. For information on what a Docker image recipe is and how it should be organized, see [Docker Image Recipes](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/DockerImageRecipes.md). You can either stage your own recipes or use ones provided by AWS Thinkbox via `ThinkboxDockerRecipes`.
 
 #### Using Thinkbox Docker Recipes
 
@@ -528,7 +528,7 @@ The `WorkerInstanceFleet` uses Elastic Load Balancing (ELB) health checks with i
 1. **EC2 Status Checks** - Amazon EC2 identifies any hardware or software issues on instances. If a status check fails for an instance, it will be replaced. For more information, see [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html).
 2. **Load Balancer Health Checks** - Load balancers send periodic pings to instances in the `AutoScalingGroup`. If a ping to an instance fails, the instance is considered unhealthy. For more information, see [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-elb-healthcheck.html).
 
-EC2 status checks are great for detecting lower level issues with instances and automatically replacing them. If you also want to detect any issues with Deadline on your instances, you can do this by setting up a health monitoring options on the `WorkerInstanceFleet` along with a `HealthMonitor` (see [`aws-rfdk`](../core/README.md)). The `HealthMonitor` will ensure that your `WorkerInstanceFleet` remains healthy by checking that a minimum number of hosts are healthy for a given grace period. If the fleet is found to be unhealthy, its capacity will set to 0, meaning that all instances will be terminated. This is a precaution to save on costs in the case of a misconfigured render farm.
+EC2 status checks are great for detecting lower level issues with instances and automatically replacing them. If you also want to detect any issues with Deadline on your instances, you can do this by setting up a health monitoring options on the `WorkerInstanceFleet` along with a `HealthMonitor` (see [`aws-rfdk`](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/core/README.md)). The `HealthMonitor` will ensure that your `WorkerInstanceFleet` remains healthy by checking that a minimum number of hosts are healthy for a given grace period. If the fleet is found to be unhealthy, its capacity will set to 0, meaning that all instances will be terminated. This is a precaution to save on costs in the case of a misconfigured render farm.
 
 Below is an example of setting up health monitoring in a `WorkerInstanceFleet`.
 ```ts

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -317,11 +317,11 @@ const fleet = new SpotEventPluginFleet(this, 'SpotEventPluginFleet', {
 
 ## Stage
 
-A stage is a directory that conforms to a [conventional structure](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/DockerImageRecipes.md#stage-directory-convention) that RFDK requires to deploy Deadline. This directory contains the Docker image recipes that RFDK uses to build Docker images.
+A stage is a directory that conforms to a [conventional structure](https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/docs/DockerImageRecipes.md#stage-directory-convention) that RFDK requires to deploy Deadline. This directory contains the Docker image recipes that RFDK uses to build Docker images.
 
 ### Staging Docker Recipes
 
-Docker image recipes required by various constructs in Deadline (e.g. `RenderQueue`, `UsageBasedLicensing`, etc.) must be staged to a local directory that RFDK can consume. For information on what a Docker image recipe is and how it should be organized, see [Docker Image Recipes](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/docs/DockerImageRecipes.md). You can either stage your own recipes or use ones provided by AWS Thinkbox via `ThinkboxDockerRecipes`.
+Docker image recipes required by various constructs in Deadline (e.g. `RenderQueue`, `UsageBasedLicensing`, etc.) must be staged to a local directory that RFDK can consume. For information on what a Docker image recipe is and how it should be organized, see [Docker Image Recipes](https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/docs/DockerImageRecipes.md). You can either stage your own recipes or use ones provided by AWS Thinkbox via `ThinkboxDockerRecipes`.
 
 #### Using Thinkbox Docker Recipes
 
@@ -528,7 +528,7 @@ The `WorkerInstanceFleet` uses Elastic Load Balancing (ELB) health checks with i
 1. **EC2 Status Checks** - Amazon EC2 identifies any hardware or software issues on instances. If a status check fails for an instance, it will be replaced. For more information, see [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html).
 2. **Load Balancer Health Checks** - Load balancers send periodic pings to instances in the `AutoScalingGroup`. If a ping to an instance fails, the instance is considered unhealthy. For more information, see [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-elb-healthcheck.html).
 
-EC2 status checks are great for detecting lower level issues with instances and automatically replacing them. If you also want to detect any issues with Deadline on your instances, you can do this by setting up a health monitoring options on the `WorkerInstanceFleet` along with a `HealthMonitor` (see [`aws-rfdk`](https://github.com/aws/aws-rfdk/blob/mainline/packages/aws-rfdk/lib/core/README.md)). The `HealthMonitor` will ensure that your `WorkerInstanceFleet` remains healthy by checking that a minimum number of hosts are healthy for a given grace period. If the fleet is found to be unhealthy, its capacity will set to 0, meaning that all instances will be terminated. This is a precaution to save on costs in the case of a misconfigured render farm.
+EC2 status checks are great for detecting lower level issues with instances and automatically replacing them. If you also want to detect any issues with Deadline on your instances, you can do this by configuring health monitoring options on the `WorkerInstanceFleet` along with a `HealthMonitor` (see [aws-rfdk](https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/lib/core/README.md)). The `HealthMonitor` will ensure that your `WorkerInstanceFleet` remains healthy by checking that a minimum number of hosts are healthy for a given grace period. If the fleet is found to be unhealthy, its capacity will set to 0, meaning that all instances will be terminated. This is a precaution to save on costs in the case of a misconfigured render farm.
 
 Below is an example of setting up health monitoring in a `WorkerInstanceFleet`.
 ```ts


### PR DESCRIPTION
Relative links to our markdown files don't translate properly when rendered in our [API docs](https://docs.aws.amazon.com/rfdk/api/latest/) and result in broken links. This PR changes all relative paths to fully qualified URLs.

### Testing
Built the API docs and verified the links are no longer broken.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
