### PR TITLE
fix(core): Add security group property to HealthMonitor

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -14,6 +14,7 @@ import {
 import {SnsAction} from '@aws-cdk/aws-cloudwatch-actions';
 import {
   IConnectable,
+  ISecurityGroup,
   IVpc,
   Port,
   SubnetSelection,
@@ -211,6 +212,13 @@ export interface HealthMonitorProps {
    * @default: The VPC default strategy
    */
   readonly vpcSubnets?: SubnetSelection;
+
+  /**
+   * Security group for the health monitor. This is security group is associated with the health monitor's load balancer.
+   *
+   * @default: A security group is created
+   */
+  readonly securityGroup?: ISecurityGroup;
 }
 
 /**

--- a/packages/aws-rfdk/lib/core/lib/load-balancer-manager.ts
+++ b/packages/aws-rfdk/lib/core/lib/load-balancer-manager.ts
@@ -200,6 +200,7 @@ export class LoadBalancerFactory {
       internetFacing: false,
       vpcSubnets: healthMonitorProps.vpcSubnets,
       deletionProtection: healthMonitorProps.deletionProtection ?? true,
+      securityGroup: healthMonitorProps.securityGroup,
     });
     // Enabling dropping of invalid HTTP header fields on the load balancer to prevent http smuggling attacks.
     loadBalancer.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true');


### PR DESCRIPTION
### Problem 
The health monitor construct creates a application load balancer. This construct creates a new security group(SG) implicitly if it is not provided in constructor properties. This means, a new SG is always created and ingress and egress rules are added automatically based on the target groups created.

### Solution
Extended `HealthMonitorProps` with new optional property `securityGroup`.
Passing this new property to `ApplicationLoadBalancer` construct.

### Testing
Added unit test.
Deployed fleet with defined security group and tested that:
- instance was raised and running at least 30 minutes
- after terminating launcher on instance it received status `unhealthy`
- new instance was invoked to reach target capacity
- target capacity set to 0 when both instances had status `unhealthy`

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
