### PR TITLE
chore(integ): add SSMInstancePolicy aspect

### DIFF
--- a/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
+++ b/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { App, Stack } from '@aws-cdk/core';
+import { App, Stack, Aspects } from '@aws-cdk/core';
 import {
   Stage,
   ThinkboxDockerRecipes,
 } from 'aws-rfdk/deadline';
 
+import { SSMInstancePolicyAspect } from '../../../../lib/ssm-policy-aspect';
 import { DatabaseType, StorageStruct } from '../../../../lib/storage-struct';
 import { RepositoryTestingTier } from '../lib/repository-testing-tier';
 
@@ -46,3 +47,6 @@ const structs: Array<StorageStruct> = [
 ];
 
 new RepositoryTestingTier(app, 'RFDKInteg-DL-TestingTier' + integStackTag, { env, integStackTag, structs });
+
+// Adds IAM Policy to Instance and ASG Roles
+Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
+++ b/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { App, Stack } from '@aws-cdk/core';
+import { App, Stack, Aspects } from '@aws-cdk/core';
 import {
   Stage,
   ThinkboxDockerRecipes,
 } from 'aws-rfdk/deadline';
 
 import { RenderStruct } from '../../../../lib/render-struct';
+import { SSMInstancePolicyAspect } from '../../../../lib/ssm-policy-aspect';
 import { DatabaseType, StorageStruct } from '../../../../lib/storage-struct';
 import { RenderQueueTestingTier } from '../lib/renderQueue-testing-tier';
 
@@ -57,3 +58,6 @@ const structs: Array<RenderStruct> = [
 ];
 
 new RenderQueueTestingTier(app, 'RFDKInteg-RQ-TestingTier' + integStackTag, { env, integStackTag, structs });
+
+// Adds IAM Policy to Instance and ASG Roles
+Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_03_workerFleetHttp/bin/deadline_03_workerFleetHttp.ts
+++ b/integ/components/deadline/deadline_03_workerFleetHttp/bin/deadline_03_workerFleetHttp.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { App, Stack } from '@aws-cdk/core';
+import { App, Stack, Aspects } from '@aws-cdk/core';
 import {
   Stage,
   ThinkboxDockerRecipes,
 } from 'aws-rfdk/deadline';
 
 import { RenderStruct } from '../../../../lib/render-struct';
+import { SSMInstancePolicyAspect } from '../../../../lib/ssm-policy-aspect';
 import { DatabaseType, StorageStruct } from '../../../../lib/storage-struct';
 import { WorkerStruct } from '../../../../lib/worker-struct';
 import { WorkerFleetTestingTier } from '../lib/workerFleetHttp-testing-tier';
@@ -61,3 +62,6 @@ oss.forEach( (os, index) => {
 });
 
 new WorkerFleetTestingTier(app, 'RFDKInteg-WF-TestingTier' + integStackTag, {env, integStackTag, structs});
+
+// Adds IAM Policy to Instance and ASG Roles
+Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_04_workerFleetHttps/bin/deadline_04_workerFleetHttps.ts
+++ b/integ/components/deadline/deadline_04_workerFleetHttps/bin/deadline_04_workerFleetHttps.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { App, Stack } from '@aws-cdk/core';
+import { App, Stack, Aspects } from '@aws-cdk/core';
 import {
   Stage,
   ThinkboxDockerRecipes,
 } from 'aws-rfdk/deadline';
 
 import { RenderStruct } from '../../../../lib/render-struct';
+import { SSMInstancePolicyAspect } from '../../../../lib/ssm-policy-aspect';
 import { DatabaseType, StorageStruct } from '../../../../lib/storage-struct';
 import { WorkerStruct } from '../../../../lib/worker-struct';
 import { WorkerFleetTestingTier } from '../lib/workerFleetHttps-testing-tier';
@@ -61,3 +62,6 @@ oss.forEach( (os, index) => {
 });
 
 new WorkerFleetTestingTier(app, 'RFDKInteg-WFS-TestingTier' + integStackTag, {env, integStackTag, structs});
+
+// Adds IAM Policy to Instance and ASG Roles
+Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/lib/ssm-policy-aspect.ts
+++ b/integ/lib/ssm-policy-aspect.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AutoScalingGroup } from '@aws-cdk/aws-autoscaling';
+import { Instance } from '@aws-cdk/aws-ec2';
+import { ManagedPolicy } from '@aws-cdk/aws-iam';
+import * as cdk from '@aws-cdk/core';
+
+export class SSMInstancePolicyAspect implements cdk.IAspect {
+  private static readonly SSM_POLICY = ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore');
+  public visit(node: cdk.IConstruct): void {
+    if (node instanceof Instance || node instanceof AutoScalingGroup) {
+      node.role.addManagedPolicy(SSMInstancePolicyAspect.SSM_POLICY);
+    }
+  }
+}

--- a/integ/package.json
+++ b/integ/package.json
@@ -74,6 +74,7 @@
     "@aws-cdk/aws-docdb": "1.99.0",
     "@aws-cdk/aws-ec2": "1.99.0",
     "@aws-cdk/aws-ecr": "1.99.0",
+    "@aws-cdk/aws-autoscaling": "1.99.0",
     "@aws-cdk/aws-ecs": "1.99.0",
     "@aws-cdk/aws-efs": "1.99.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "1.99.0",


### PR DESCRIPTION
### Problem

The ```AmazonSSMManagedInstanceCore``` needs to be added to all instances launched by integration.

### Solution

Added an [Aspect](https://docs.aws.amazon.com/cdk/latest/guide/aspects.html) to add the ```AmazonSSMManagedInstanceCore``` to all Instances and ASG roles of an application. Implemented the Aspect in each of the integration apps.

### Testing

* Confirmed the ```AmazonSSMManagedInstanceCore``` policy is applied to all instances launched by an end-to-end test. 
* Confirmed that the end-to-end test completed successfully:

```
Complete!
Pretest setup runtime: 0m 1s
Infrastructure stack deploy runtime: 2m 53s
Infrastructure stack cleanup runtime: 2m 6s
Results for test component deadline_01_repository:
  -Tests ran: 21
  -Tests passed: 21
  -Tests failed: 0
  -Deploy runtime:     26m 28s
  -Test suite runtime: 0m 29s
  -Cleanup runtime:    12m 54s
Results for test component deadline_02_renderQueue:
  -Tests ran: 10
  -Tests passed: 10
  -Tests failed: 0
  -Deploy runtime:     25m 10s
  -Test suite runtime: 1m 5s
  -Cleanup runtime:    15m 22s
Results for test component deadline_03_workerFleetHttp:
  -Tests ran: 8
  -Tests passed: 8
  -Tests failed: 0
  -Deploy runtime:     56m 48s
  -Test suite runtime: 1m 50s
  -Cleanup runtime:    35m 25s
Results for test component deadline_04_workerFleetHttps:
  -Tests ran: 8
  -Tests passed: 8
  -Tests failed: 0
  -Deploy runtime:     59m 20s
  -Test suite runtime: 1m 56s
  -Cleanup runtime:    35m 32s
``` 

Thanks to @jusiskin for the Aspect implementation code.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
