### PR TITLE
fix(integ): fix broken CDK app deny-list and error handling

### DIFF
--- a/integ/components/deadline/common/scripts/bash/component_e2e_driver.sh
+++ b/integ/components/deadline/common/scripts/bash/component_e2e_driver.sh
@@ -41,8 +41,6 @@ EOF
 # Clean-up if test failed
 if [[ $test_exit_code -ne 0 ]]
 then
-    # A failed cleanup should propagate to the calling process
-    set -e
     ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" --destroy-only
 fi
 


### PR DESCRIPTION
## Problem

In #427, a bug was introduced due to a last-minute change that was not properly tested. When running the tests, the following output is emitted:

```log
[infrastructure] deployment started
[infrastructure] deployment complete
components/deadline/common/scripts/bash/component_e2e_driver.sh: line 23: ../common/scripts/bash/deploy-utils.sh: No such file or directory
components/deadline/common/scripts/bash/component_e2e_driver.sh: line 24: ensure_component_artifact_dir: command not found
components/deadline/common/scripts/bash/component_e2e_driver.sh: line 28: ../common/scripts/bash/component_e2e.sh: No such file or directory
components/deadline/common/scripts/bash/component_e2e_driver.sh: line 30: /local/home/myusername/workplace/integ_credentials_refresh/integ/.e2etemp/_infrastructure/exitcode: No such file or directory
components/deadline/common/scripts/bash/component_e2e_driver.sh: line 36: /local/home/myusername/workplace/integ_credentials_refresh/integ/.e2etemp/_infrastructure/timings.sh: No such file or directory
components/deadline/common/scripts/bash/component_e2e_driver.sh: line 46: ../common/scripts/bash/component_e2e.sh: No such file or directory
```

After investigating, it appears the last minute change here:

https://github.com/aws/aws-rfdk/pull/427/commits/e9eadf880a6852445fe872ff23363858ee889165#diff-12e3db469e3b9c677d80f1e5b14eb27f8f93e655aa2dd7a59a008b1186cf112cR88

did not work as expected and the CDK app in `integ/components/_infrastructure` was being run as an integration test which was not intended.

## Solution

*   Modified the `egrep` pattern to properly filter out the infrastructure app.
* The error-handling cleanup logic was also modified so that the test results are reported despite any test orchestration failures.

## Testing

*   Ran the `get_component_dirs` bash function in a terminal and confirming that the `_infrastructure` app was not output.
*   Ran the full e2e integration tests ([log](https://gist.githubusercontent.com/jusiskin/c82bcc4bac3c3e914021ceb705e35651/raw/ffeb299879fe0ef3277474c4766a6af831c40387/rfdk-integ.log))

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
