### PR TITLE
chore(lambdas): add retry logic to ACM certificate importer

### DIFF
--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/backoff-generator.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/backoff-generator.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Properties for BackoffGenerator.
+ */
+export interface BackoffGeneratorProps {
+  /**
+   * The base duration, in milliseconds, used to calculate exponential backoff.
+   *
+   * For example, when not using jitter, the backoff time per attempt will be calculated as:
+   * 1. `base` * 2^0
+   * 2. `base` * 2^1
+   * 3. `base` * 2^2, etc.
+   *
+   * @default 200 milliseconds
+   */
+  readonly base?: number;
+
+  /**
+   * The maximum amount of time, in milliseconds, allowed between backoffs.
+   * @default Number.MAX_SAFE_INTEGER
+   */
+  readonly maxIntervalMs?: number;
+
+  /**
+   * The divisor used to calculate the portion backoff time that will be subject to jitter.
+   * Higher values indicate lower jitters (backoff times will differ by a smaller amount).
+   *
+   * For example, given a calculated `backoff` value, applying jitter would look like:
+   * ```
+   * backoffJitter = (backoff - backoff / jitterDivisor) + jitter(backoff / jitterDivisor)
+   * ```
+   * @default 1 - The entire backoff time is subject to jitter (i.e. "full jitter")
+   */
+  readonly jitterDivisor?: number;
+
+  /**
+   * The maximum amount of time, in milliseconds, to backoff before quitting.
+   * @default No limit on how long this object can backoff for
+   */
+  readonly maxBackoffTimeMs?: number;
+
+  /**
+   * The maximum number of times to backoff before quitting.
+   * @default No limit on how many times this object can backoff
+   */
+  readonly maxAttempts?: number;
+}
+
+/**
+ * Class to handle sleeping with exponential backoff.
+ *
+ * Reference: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+ */
+export class BackoffGenerator
+{
+  /**
+   * Calculates the number of milliseconds to sleep based on the attempt count.
+   * @param b The base value for the calculation.
+   * @param attempt The attempt count.
+   * @param maxIntervalMs The maximum interval between backoffs, in milliseconds.
+   * @returns The number of milliseconds to sleep.
+   */
+  private static calculateSleepMs(b: number, attempt: number, maxIntervalMs: number): number {
+    return Math.min(b * Math.pow(2, attempt), maxIntervalMs, Number.MAX_SAFE_INTEGER);
+  }
+
+  private readonly base: number;
+  private readonly maxIntervalMs: number;
+  private readonly jitterDivisor: number;
+  private readonly maxBackoffTimeMs: number | undefined;
+  private readonly maxAttempts: number | undefined;
+
+  private sleepTime: number = 0;
+  private attempt: number = 0;
+
+  constructor(props?: BackoffGeneratorProps)
+  {
+    this.maxBackoffTimeMs = props?.maxBackoffTimeMs;
+    this.maxAttempts = props?.maxAttempts;
+    this.base = props?.base ?? 200;
+    this.maxIntervalMs = props?.maxIntervalMs ?? Number.MAX_SAFE_INTEGER;
+
+    this.jitterDivisor = props?.jitterDivisor ?? 1;
+    if (this.jitterDivisor <= 0) {
+      throw new Error(`jitterDivisor must be a postive integer, got: ${this.jitterDivisor}`);
+    }
+
+    // Initialize internal counters
+    this.restart();
+  }
+
+  /**
+   * Restarts the internal counters used by this class.
+   */
+  public restart(): void {
+    this.sleepTime = 0;
+    this.attempt = 0;
+  }
+
+  /**
+   * Sleeps for an exponentially increasing time depending on how many times this class has backed off.
+   */
+  public async backoff(): Promise<void> {
+    const interval = BackoffGenerator.calculateSleepMs(this.base, this.attempt, this.maxIntervalMs);
+
+    await sleep(interval);
+    this.sleepTime += interval;
+    this.attempt++;
+  }
+
+  /**
+   * Sleeps for an exponentially increasing time (with jitter) depending on how many times this class has backed off.
+   */
+  public async backoffJitter(): Promise<void> {
+    const interval = BackoffGenerator.calculateSleepMs(this.base, this.attempt, this.maxIntervalMs);
+    const intervalJitter = (interval - interval / this.jitterDivisor) + (Math.floor(interval / this.jitterDivisor * Math.random()));
+
+    await sleep(intervalJitter);
+    this.sleepTime += intervalJitter;
+    this.attempt++;
+  }
+
+  /**
+   * Returns true if either the maximum number of attempts or maximum time span has been reached.
+   * If neither are specified, this will always return true.
+   */
+  public shouldContinue(): boolean {
+    return ( this.maxAttempts === undefined || this.attempt < this.maxAttempts ) &&
+           ( this.maxBackoffTimeMs === undefined || this.sleepTime < this.maxBackoffTimeMs );
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(res => setTimeout(res, ms));
+}

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/backoff-generator.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/backoff-generator.ts
@@ -117,14 +117,13 @@ export class BackoffGenerator
       interval = (interval - interval / this.jitterDivisor) + (Math.floor(interval / this.jitterDivisor * Math.random()));
     }
 
-    const shouldContinue = this.shouldContinue();
-    if (force || shouldContinue) {
+    if (force || this.shouldContinue()) {
       await sleep(interval);
       this.cumulativeBackoffTimeMs += interval;
       this.attempt++;
     }
 
-    return shouldContinue;
+    return this.shouldContinue();
   }
 
   /**

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/index.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './backoff-generator';

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/test/backoff-generator.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/backoff-generator/test/backoff-generator.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as sinon from 'sinon';
+import { BackoffGenerator } from '../backoff-generator';
+
+describe('BackoffGenerator', () => {
+  const base = 100;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('throws when jitterDivisor is invalid', () => {
+    // GIVEN
+    const jitterDivisor = 0;
+
+    // WHEN
+    expect(() => new BackoffGenerator({
+      jitterDivisor,
+    }))
+
+    // THEN
+      .toThrow(`jitterDivisor must be a postive integer, got: ${jitterDivisor}`);
+  });
+
+  test('stops when max attempts is reached', async () => {
+    // GIVEN
+    const maxAttempts = 2;
+    const backoffGenerator = new BackoffGenerator({
+      base,
+      maxAttempts,
+    });
+
+    // WHEN
+    for (let i = 0; i < maxAttempts; i++) {
+      const promise = backoffGenerator.backoff();
+      jest.advanceTimersByTime(base * Math.pow(2, i));
+      await promise;
+    }
+
+    // THEN
+    expect(backoffGenerator.shouldContinue()).toBe(false);
+  });
+
+  test('stops when timeout is reached', async () => {
+    // GIVEN
+    const backoffGenerator = new BackoffGenerator({
+      base,
+      maxBackoffTimeMs: base,
+    });
+
+    // WHEN
+    const promise = backoffGenerator.backoff();
+    jest.advanceTimersByTime(base);
+    await promise;
+
+    // THEN
+    expect(backoffGenerator.shouldContinue()).toBe(false);
+  });
+
+  test('respects max interval between backoffs', async () => {
+    // GIVEN
+    const maxIntervalMs = base / 2;
+    const backoffGenerator = new BackoffGenerator({
+      base,
+      maxIntervalMs,
+    });
+
+    // WHEN
+    const promise = backoffGenerator.backoff();
+    jest.advanceTimersByTime(maxIntervalMs);
+    await promise;
+
+    // THEN
+    expect(maxIntervalMs).toBeLessThan(base);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), maxIntervalMs);
+  });
+
+  test('restarts', async () => {
+    // GIVEN
+    const backoffGenerator = new BackoffGenerator({
+      base,
+      maxAttempts: 1,
+    });
+    // This reaches maxAttempts, shouldContinue() will return false
+    const promise = backoffGenerator.backoff();
+    jest.advanceTimersByTime(base);
+    await promise;
+
+    // WHEN
+    backoffGenerator.restart();
+
+    // THEN
+    expect(backoffGenerator.shouldContinue()).toBe(true);
+  });
+
+  describe.each([
+    0,
+    0.25,
+    0.5,
+    0.75,
+    1,
+  ])('jitter (factor %d)', (factor: number) => {
+    let randomStub: sinon.SinonStub;
+    beforeAll(() => {
+      randomStub = sinon.stub(Math, 'random').returns(factor);
+    });
+
+    afterAll(() => {
+      randomStub.restore();
+    });
+
+    test('applies full jitter', async () => {
+      // GIVEN
+      const backoffGenerator = new BackoffGenerator({
+        base,
+        jitterDivisor: 1,
+      });
+      const interval = base * factor;
+
+      // WHEN
+      const promise = backoffGenerator.backoffJitter();
+      jest.advanceTimersByTime(interval);
+      await promise;
+
+      // THEN
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), interval);
+    });
+
+    test('correctly calculates jitter with divisor', async () => {
+      // GIVEN
+      const jitterDivisor = 4;
+      const backoffGenerator = new BackoffGenerator({
+        base,
+        jitterDivisor,
+      });
+      const interval = (base - base / jitterDivisor) + Math.floor(base / jitterDivisor * factor);
+
+      // WHEN
+      const promise = backoffGenerator.backoffJitter();
+      jest.advanceTimersByTime(interval);
+      await promise;
+
+      // THEN
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), interval);
+    });
+  });
+});

--- a/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/acm-handlers.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/acm-handlers.ts
@@ -39,6 +39,7 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
     this.secretsManagerClient = secretsManagerClient;
   }
 
+  /* istanbul ignore next */
   public validateInput(data: object): boolean {
     return implementsIAcmImportCertProps(data);
   }
@@ -199,17 +200,18 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
       maxAttempts,
     });
 
+    let retry = false;
     do {
       try {
         return await this.acmClient.importCertificate(importCertRequest).promise();
       } catch (e) {
         console.warn(`Could not import certificate: ${e}`);
-        await backoffGenerator.backoff();
-        if (backoffGenerator.shouldContinue()) {
+        retry = await backoffGenerator.backoff();
+        if (retry) {
           console.log('Retrying...');
         }
       }
-    } while (backoffGenerator.shouldContinue());
+    } while (retry);
 
     throw new Error(`Failed to import certificate ${importCertRequest.CertificateArn ?? ''} after ${maxAttempts} attempts.`);
   }
@@ -227,6 +229,7 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
 /**
  * The handler used to import an X.509 certificate to ACM from a Secret
  */
+/* istanbul ignore next */
 export async function importCert(event: CfnRequestEvent, context: LambdaContext): Promise<string> {
   const handler = new AcmCertificateImporter(
     new ACM({ apiVersion: ACM_VERSION }),

--- a/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/acm-handlers.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/acm-handlers.ts
@@ -10,6 +10,7 @@ import * as crypto from 'crypto';
 import { ACM, DynamoDB, SecretsManager } from 'aws-sdk';
 
 import { LambdaContext } from '../lib/aws-lambda';
+import { BackoffGenerator } from '../lib/backoff-generator';
 import { CfnRequestEvent, DynamoBackedCustomResource } from '../lib/custom-resource';
 import { CompositeStringIndexTable } from '../lib/dynamodb';
 import { Certificate } from '../lib/x509-certs';
@@ -18,10 +19,6 @@ import {
   IAcmImportCertProps,
   implementsIAcmImportCertProps,
 } from './types';
-
-const defaultSleep = function(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-};
 
 const ACM_VERSION = '2015-12-08';
 const DYNAMODB_VERSION = '2012-08-10';
@@ -84,9 +81,14 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
     const maxAttempts = 10;
     for (const [key, resource] of Object.entries(resources)) {
       const arn: string = resource.ARN;
-
       let inUseByResources = [];
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const backoffGenerator = new BackoffGenerator({
+        base: 200,
+        jitterDivisor: 4,
+        maxAttempts,
+      });
+
+      do {
         const { Certificate: cert } = await this.acmClient.describeCertificate({
           CertificateArn: arn,
         }).promise();
@@ -94,15 +96,11 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
         inUseByResources = cert!.InUseBy || [];
 
         if (inUseByResources.length) {
-          // Exponential backoff with jitter based on 200ms base
-          // component of backoff fixed to ensure minimum total wait time on
-          // slow targets.
-          const base = Math.pow(2, attempt);
-          await defaultSleep(Math.random() * base * 50 + base * 150);
+          await backoffGenerator.backoffJitter();
         } else {
           break;
         }
-      }
+      } while (backoffGenerator.shouldContinue());
 
       if (inUseByResources.length) {
         throw new Error(`Response from describeCertificate did not contain an empty InUseBy list after ${maxAttempts} attempts.`);
@@ -156,7 +154,7 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
           PrivateKey: args.key,
           Tags: args.tags,
         };
-        await this.acmClient.importCertificate(importCertRequest).promise();
+        await this.importCertificate(importCertRequest);
       } else {
         throw Error(`Database entry ${existingItem.ARN} could not be found in ACM.`);
       }
@@ -168,7 +166,7 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
         Tags: args.tags,
       };
 
-      const resp = await this.acmClient.importCertificate(importCertRequest).promise();
+      const resp = await this.importCertificate(importCertRequest);
 
       if (!resp.CertificateArn) {
         throw new Error(`CertificateArn was not properly populated after attempt to import ${args.cert}`);
@@ -186,6 +184,31 @@ export class AcmCertificateImporter extends DynamoBackedCustomResource {
     }
 
     return certificateArn;
+  }
+
+  private async importCertificate(importCertRequest: ACM.ImportCertificateRequest) {
+    // ACM cert imports are limited to 1 per second (see https://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html#api-rate-limits)
+    // We need to backoff & retry in the event that two imports happen in the same second
+    const maxAttempts = 10;
+    const backoffGenerator = new BackoffGenerator({
+      base: 200,
+      jitterDivisor: 4,
+      maxAttempts,
+    });
+
+    do {
+      try {
+        return await this.acmClient.importCertificate(importCertRequest).promise();
+      } catch (e) {
+        console.warn(`Could not import certificate: ${e}`);
+        await backoffGenerator.backoffJitter();
+        if (backoffGenerator.shouldContinue()) {
+          console.log('Retrying...');
+        }
+      }
+    } while (backoffGenerator.shouldContinue());
+
+    throw new Error(`Failed to import certificate ${importCertRequest.CertificateArn ?? ''} after ${maxAttempts} attempts.`);
   }
 
   private async getSecretString(SecretId: string): Promise<string> {

--- a/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/test/acm-handlers.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/test/acm-handlers.test.ts
@@ -182,6 +182,7 @@ describe('AcmCertificateImporter', () => {
           .resolves.toEqual({ CertificateArn: certArn });
         expect(getItemStub.calledOnce).toBe(true);
         expect(getCertificateFake.calledOnce).toBe(true);
+        // Verify that we import the existing certificate to support replacing/updating of it (e.g. to rotate certs)
         expect(importCertificateFake.calledOnce).toBe(true);
       });
     });

--- a/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/test/acm-handlers.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/test/acm-handlers.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as AWS from 'aws-sdk';
+import * as AWSMock from 'aws-sdk-mock';
+import * as sinon from 'sinon';
+import { BackoffGenerator } from '../../lib/backoff-generator';
+import { CompositeStringIndexTable } from '../../lib/dynamodb';
+import { Certificate } from '../../lib/x509-certs';
+import { AcmCertificateImporter } from '../acm-handlers';
+import { IAcmImportCertProps } from '../types';
+
+describe('AcmCertificateImporter', () => {
+  const physicalId = 'physicalId';
+  const certArn = 'certArn';
+  const oldEnv = process.env;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    jest.spyOn(global.console, 'log').mockImplementation(() => {});
+    jest.spyOn(global.console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    process.env.DATABASE = 'database';
+    AWSMock.setSDKInstance(AWS);
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    sinon.restore();
+    AWSMock.restore();
+  });
+
+  describe('doCreate', () => {
+    const doCreateProps: IAcmImportCertProps = {
+      Tags: [],
+      X509CertificatePem: {
+        Cert: 'cert',
+        CertChain: 'certChain',
+        Key: 'key',
+        Passphrase: 'passphrase',
+      },
+    };
+
+    beforeEach(() => {
+      sinon.stub(Certificate, 'decryptKey').returns(new Promise((res, _rej) => res('key')));
+
+      // Mock out the API call in getSecretString
+      AWSMock.mock('SecretsManager', 'getSecretValue', sinon.fake.resolves({ SecretString: 'secret' }));
+    });
+
+    test('throws when a secret does not have SecretString', async () => {
+      // GIVEN
+      const getSecretValueFake = sinon.fake.resolves({});
+      AWSMock.remock('SecretsManager', 'getSecretValue', getSecretValueFake);
+
+      const importer = new TestAcmCertificateImporter({
+        acm: new AWS.ACM(),
+        dynamoDb: new AWS.DynamoDB(),
+        secretsManager: new AWS.SecretsManager(),
+        resourceTableOverride: new MockCompositeStringIndexTable(),
+      });
+
+      // WHEN
+      let error = undefined;
+      try {
+        await importer.doCreate(physicalId, doCreateProps);
+      } catch(e) {
+        error = e;
+      }
+
+      // THEN
+      expect(error).toBeDefined();
+      expect(error.message).toMatch(/Secret .* did not contain a SecretString as expected/);
+      expect(getSecretValueFake.calledOnce).toBe(true);
+    });
+
+    test('retries importing certificate', async () => {
+      // GIVEN
+      const resourceTable = new MockCompositeStringIndexTable();
+      const getItemStub = sinon.stub(resourceTable, 'getItem').resolves(undefined);
+      const putItemStub = sinon.stub(resourceTable, 'putItem').resolves(true);
+
+      const importCertificateStub = sinon.stub()
+        .onFirstCall().rejects('Rate exceeded')
+        .onSecondCall().rejects('Rate exceeded')
+        .onThirdCall().resolves({ CertificateArn: certArn });
+      AWSMock.mock('ACM', 'importCertificate', importCertificateStub);
+
+      const backoffJitterStub = sinon.stub(BackoffGenerator.prototype, 'backoffJitter').resolves();
+      const shouldContinueStub = sinon.stub(BackoffGenerator.prototype, 'shouldContinue').returns(true);
+
+      const importer = new TestAcmCertificateImporter({
+        acm: new AWS.ACM(),
+        dynamoDb: new AWS.DynamoDB(),
+        secretsManager: new AWS.SecretsManager(),
+        resourceTableOverride: resourceTable,
+      });
+
+      // WHEN
+      await expect(importer.doCreate(physicalId, doCreateProps))
+
+      // THEN
+        .resolves.toEqual({ CertificateArn: certArn });
+      expect(getItemStub.calledOnce).toBe(true);
+      expect(putItemStub.calledOnce).toBe(true);
+      expect(importCertificateStub.calledThrice).toBe(true);
+      expect(backoffJitterStub.callCount).toEqual(2);
+      // An additional check is made before logging "Retrying..."
+      expect(shouldContinueStub.callCount).toEqual(4);
+    });
+
+    describe('existing', () => {
+      test('throws if item ARN is missing', async () => {
+        // GIVEN
+        const resourceTable = new MockCompositeStringIndexTable();
+        const getItemStub = sinon.stub(resourceTable, 'getItem').resolves({});
+
+        const importer = new TestAcmCertificateImporter({
+          acm: new AWS.ACM(),
+          dynamoDb: new AWS.DynamoDB(),
+          secretsManager: new AWS.SecretsManager(),
+          resourceTableOverride: resourceTable,
+        });
+
+        // WHEN
+        await expect(importer.doCreate(physicalId, doCreateProps))
+
+        // THEN
+          .rejects.toEqual(new Error("Database Item missing 'ARN' attribute"));
+        expect(getItemStub.calledOnce).toBe(true);
+      });
+
+      test('throws if certificate not found in ACM', async () => {
+        // GIVEN
+        const resourceTable = new MockCompositeStringIndexTable();
+        const getItemStub = sinon.stub(resourceTable, 'getItem').resolves({ ARN: certArn });
+
+        const getCertificateFake = sinon.fake.resolves({});
+        AWSMock.mock('ACM', 'getCertificate', getCertificateFake);
+
+        const importer = new TestAcmCertificateImporter({
+          acm: new AWS.ACM(),
+          dynamoDb: new AWS.DynamoDB(),
+          secretsManager: new AWS.SecretsManager(),
+          resourceTableOverride: resourceTable,
+        });
+
+        // WHEN
+        await expect(importer.doCreate(physicalId, doCreateProps))
+
+        // THEN
+          .rejects.toEqual(new Error(`Database entry ${certArn} could not be found in ACM.`));
+        expect(getItemStub.calledOnce).toBe(true);
+        expect(getCertificateFake.calledOnce).toBe(true);
+      });
+
+      test('imports certificate', async () => {
+        // GIVEN
+        const resourceTable = new MockCompositeStringIndexTable();
+        const getItemStub = sinon.stub(resourceTable, 'getItem').resolves({ ARN: certArn });
+
+        const getCertificateFake = sinon.fake.resolves({ Certificate: 'cert' });
+        AWSMock.mock('ACM', 'getCertificate', getCertificateFake);
+
+        const importCertificateFake = sinon.fake.resolves({});
+        AWSMock.mock('ACM', 'importCertificate', importCertificateFake);
+
+        const importer = new TestAcmCertificateImporter({
+          acm: new AWS.ACM(),
+          dynamoDb: new AWS.DynamoDB(),
+          secretsManager: new AWS.SecretsManager(),
+          resourceTableOverride: resourceTable,
+        });
+
+        // WHEN
+        await expect(importer.doCreate(physicalId, doCreateProps))
+
+        // THEN
+          .resolves.toEqual({ CertificateArn: certArn });
+        expect(getItemStub.calledOnce).toBe(true);
+        expect(getCertificateFake.calledOnce).toBe(true);
+        expect(importCertificateFake.calledOnce).toBe(true);
+      });
+    });
+
+    describe('new', () => {
+      test('throws if CertificateArn not populated', async () => {
+        // GIVEN
+        const resourceTable = new MockCompositeStringIndexTable();
+        const getItemStub = sinon.stub(resourceTable, 'getItem').resolves(undefined);
+
+        const importCertificateFake = sinon.fake.resolves({});
+        AWSMock.mock('ACM', 'importCertificate', importCertificateFake);
+
+        const importer = new TestAcmCertificateImporter({
+          acm: new AWS.ACM(),
+          dynamoDb: new AWS.DynamoDB(),
+          secretsManager: new AWS.SecretsManager(),
+          resourceTableOverride: resourceTable,
+        });
+
+        // WHEN
+        let error = undefined;
+        try {
+          await importer.doCreate(physicalId, doCreateProps);
+        } catch (e) {
+          error = e;
+        }
+
+        // THEN
+        expect(error).toBeDefined();
+        expect(error.message).toMatch(/CertificateArn was not properly populated after attempt to import .*$/);
+        expect(getItemStub.calledOnce).toBe(true);
+        expect(importCertificateFake.calledOnce).toBe(true);
+      });
+
+      test('imports certificate', async () => {
+        // GIVEN
+        const resourceTable = new MockCompositeStringIndexTable();
+        const getItemStub = sinon.stub(resourceTable, 'getItem').resolves(undefined);
+        const putItemStub = sinon.stub(resourceTable, 'putItem').resolves(true);
+
+        const importCertificateFake = sinon.fake.resolves({ CertificateArn: certArn });
+        AWSMock.mock('ACM', 'importCertificate', importCertificateFake);
+
+        const importer = new TestAcmCertificateImporter({
+          acm: new AWS.ACM(),
+          dynamoDb: new AWS.DynamoDB(),
+          secretsManager: new AWS.SecretsManager(),
+          resourceTableOverride: resourceTable,
+        });
+
+        // WHEN
+        await expect(importer.doCreate(physicalId, doCreateProps))
+
+        // THEN
+          .resolves.toEqual({ CertificateArn: certArn });
+        expect(getItemStub.calledOnce).toBe(true);
+        expect(putItemStub.calledOnce).toBe(true);
+        expect(importCertificateFake.calledOnce).toBe(true);
+      });
+    });
+  });
+
+  describe('doDelete', () => {
+
+    test('throws if describeCertificate is in use after max attempts', async () => {
+      // GIVEN
+      const resourceTable = new MockCompositeStringIndexTable();
+      const queryStub = sinon.stub(resourceTable, 'query').resolves({
+        key: { ARN: certArn },
+      });
+
+      const describeCertificateFake = sinon.fake.resolves({ Certificate: { InUseBy: ['something'] } });
+      AWSMock.mock('ACM', 'describeCertificate', describeCertificateFake);
+
+      // This is hardcoded in the code being tested
+      const maxAttempts = 10;
+      const backoffJitterStub = sinon.stub(BackoffGenerator.prototype, 'backoffJitter').resolves();
+      const shouldContinueStub = sinon.stub(BackoffGenerator.prototype, 'shouldContinue')
+        .returns(true)
+        .onCall(maxAttempts - 1).returns(false);
+
+      const importer = new TestAcmCertificateImporter({
+        acm: new AWS.ACM(),
+        dynamoDb: new AWS.DynamoDB(),
+        secretsManager: new AWS.SecretsManager(),
+        resourceTableOverride: resourceTable,
+      });
+
+      // WHEN
+      await expect(importer.doDelete(physicalId))
+
+      // THEN
+        .rejects.toEqual(new Error(`Response from describeCertificate did not contain an empty InUseBy list after ${maxAttempts} attempts.`));
+      expect(queryStub.calledOnce).toBe(true);
+      expect(describeCertificateFake.callCount).toEqual(maxAttempts);
+      expect(backoffJitterStub.callCount).toEqual(maxAttempts);
+      expect(shouldContinueStub.callCount).toEqual(maxAttempts);
+    });
+
+    test('throws when deleting certificate from ACM fails', async () => {
+      // GIVEN
+      const resourceTable = new MockCompositeStringIndexTable();
+      const queryStub = sinon.stub(resourceTable, 'query').resolves({
+        key: { ARN: certArn },
+      });
+
+      const describeCertificateFake = sinon.fake.resolves({ Certificate: { InUseBy: [] }});
+      AWSMock.mock('ACM', 'describeCertificate', describeCertificateFake);
+
+      const error = new Error('error');
+      const deleteCertificateFake = sinon.fake.rejects(error);
+      AWSMock.mock('ACM', 'deleteCertificate', deleteCertificateFake);
+
+      const importer = new TestAcmCertificateImporter({
+        acm: new AWS.ACM(),
+        dynamoDb: new AWS.DynamoDB(),
+        secretsManager: new AWS.SecretsManager(),
+        resourceTableOverride: resourceTable,
+      });
+
+      // WHEN
+      await expect(importer.doDelete(physicalId))
+
+      // THEN
+        .rejects.toEqual(error);
+      expect(queryStub.calledOnce).toBe(true);
+      expect(describeCertificateFake.calledOnce).toBe(true);
+      expect(deleteCertificateFake.calledOnce).toBe(true);
+    });
+
+    test('warns when deleting certificate from ACM fails with AccessDeniedException', async () => {
+      // GIVEN
+      const resourceTable = new MockCompositeStringIndexTable();
+      const queryStub = sinon.stub(resourceTable, 'query').resolves({
+        key: { ARN: certArn },
+      });
+
+      const describeCertificateFake = sinon.fake.resolves({ Certificate: { InUseBy: [] }});
+      AWSMock.mock('ACM', 'describeCertificate', describeCertificateFake);
+
+      const error = new Error('AccessDeniedException');
+      const deleteCertificateFake = sinon.fake.rejects(error);
+      AWSMock.mock('ACM', 'deleteCertificate', deleteCertificateFake);
+
+      const importer = new TestAcmCertificateImporter({
+        acm: new AWS.ACM(),
+        dynamoDb: new AWS.DynamoDB(),
+        secretsManager: new AWS.SecretsManager(),
+        resourceTableOverride: resourceTable,
+      });
+
+      // WHEN
+      await expect(importer.doDelete(physicalId))
+
+      // THEN
+        .rejects.toEqual(error);
+      expect(queryStub.calledOnce).toBe(true);
+      expect(describeCertificateFake.calledOnce).toBe(true);
+      expect(deleteCertificateFake.calledOnce).toBe(true);
+      expect(consoleWarnSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(consoleWarnSpy.mock.calls.map(args => args[0]).join('\n')).toMatch(new RegExp(`Could not delete Certificate ${certArn}. Please ensure it has been deleted.`));
+    });
+
+    test('deletes the certificate', async () => {
+      // GIVEN
+      const resourceTable = new MockCompositeStringIndexTable();
+      const queryStub = sinon.stub(resourceTable, 'query').resolves({ key: { ARN: certArn } });
+      const deleteItemStub = sinon.stub(resourceTable, 'deleteItem').resolves(true);
+
+      const describeCertificateFake = sinon.fake.resolves({ Certificate: { InUseBy: [] }});
+      AWSMock.mock('ACM', 'describeCertificate', describeCertificateFake);
+
+      const deleteCertificateFake = sinon.fake.resolves({});
+      AWSMock.mock('ACM', 'deleteCertificate', deleteCertificateFake);
+
+      const importer = new TestAcmCertificateImporter({
+        acm: new AWS.ACM(),
+        dynamoDb: new AWS.DynamoDB(),
+        secretsManager: new AWS.SecretsManager(),
+        resourceTableOverride: resourceTable,
+      });
+
+      // WHEN
+      await expect(importer.doDelete(physicalId))
+
+      // THEN
+        .resolves.not.toThrow();
+      expect(queryStub.calledOnce).toBe(true);
+      expect(describeCertificateFake.calledOnce).toBe(true);
+      expect(deleteCertificateFake.calledOnce).toBe(true);
+      expect(deleteItemStub.calledOnce).toBe(true);
+    });
+  });
+});
+
+/**
+ * Specialization of AcmCertificateImporter that overrides methods inherited from
+ * DynamoBackedResource so that no API calls are made.
+ *
+ * This allows the testing code above to focus on the testing the AcmCertificateImporter
+ * class without having to deal with mocking out API calls from its parent class.
+ */
+class TestAcmCertificateImporter extends AcmCertificateImporter {
+  private readonly resourceTableOverride: CompositeStringIndexTable;
+
+  constructor(props: {
+    acm: AWS.ACM,
+    dynamoDb: AWS.DynamoDB,
+    secretsManager: AWS.SecretsManager,
+    resourceTableOverride?: CompositeStringIndexTable
+  }) {
+    super(props.acm, props.dynamoDb, props.secretsManager);
+    this.resourceTableOverride = props.resourceTableOverride ?? new MockCompositeStringIndexTable();
+  }
+
+  protected async databasePermissionsCheck(): Promise<void> {
+    // Do nothing
+    return;
+  }
+
+  protected async getResourceTable(): Promise<CompositeStringIndexTable> {
+    return this.resourceTableOverride;
+  }
+}
+
+/**
+ * Mock implementation of CompositeStringIndexTable that does not make API calls.
+ *
+ * This allows the test code above to instantiate a CompositeStringIndexTable object
+ * that can be mocked.
+ */
+class MockCompositeStringIndexTable extends CompositeStringIndexTable {
+  constructor() {
+    super(new AWS.DynamoDB(), '', '', '');
+  }
+
+  public async deleteTable(): Promise<void> {}
+
+  public async putItem(_props: {
+    primaryKeyValue: string,
+    sortKeyValue: string,
+    attributes?: object,
+    allow_overwrite?: boolean,
+  }): Promise<boolean> {
+    return true;
+  }
+
+  public async getItem(_props: {
+    primaryKeyValue: string,
+    sortKeyValue: string,
+  }): Promise<{ [key: string]: any } | undefined> {
+    return {};
+  }
+
+  public async deleteItem(_props: {
+    primaryKeyValue: string,
+    sortKeyValue: string,
+  }): Promise<boolean> {
+    return true;
+  }
+
+  public async query(
+    _primaryKeyValue: string,
+    _pageLimit?: number,
+  ): Promise<{ [key: string]: { [key: string]: any }}> {
+    return {};
+  }
+}


### PR DESCRIPTION
### Notes
- Adds a class that can be used to back off exponentially, optionally with jitter
- Adds (& refactors) exponential back off & retry logic in the ACM certificate importer lambda, to avoid failures due to the limit of importing 1 certificate per second (see [ACM limits](https://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html)). 

### Testing
- Wrote unit tests
- Built RFDK, deployed the example app, and ensured the ACM importer lambda function for the `RenderQueue` ran successfully
    - Treat this as a sanity check to make sure the regular case still works, since reproducing the error is difficult. The unit test added that tests the retry logic should be sufficient.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
