### PR TITLE
fix(integ): make exit code reflect test success/failure

### DIFF
--- a/integ/components/deadline/common/scripts/bash/component_e2e.sh
+++ b/integ/components/deadline/common/scripts/bash/component_e2e.sh
@@ -3,22 +3,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -euo pipefail
+set -uo pipefail
+
+# Disable exit on error. Errors are manually handled by the script
+set +e
 
 COMPONENT_NAME=${1:-undefined}
 OPTION=${2:-undefined}
+
+SCRIPT_EXIT_CODE=0
 
 if [[ $(basename $(pwd)) != $COMPONENT_NAME ]]; then
   echo "ERROR: Script must be run from top directory of test component"
   exit 1
 fi
-
-function log_error () {
-  exit_code=$?
-  action=$1
-  echo "[${COMPONENT_NAME}] ${action} failed"
-  return $exit_code
-}
 
 SKIP_TEST_CHECK=\$SKIP_${COMPONENT_NAME}_TEST
 SKIP_TEST_CHECK=$(eval "echo $SKIP_TEST_CHECK" 2> /dev/null) || SKIP_TEST_CHECK=false
@@ -29,12 +27,45 @@ if [[ ! "${SKIP_TEST_CHECK}" = "true" ]]; then
   ensure_component_artifact_dir "${COMPONENT_NAME}"
 
   if [[ $OPTION != '--destroy-only' ]]; then
-    deploy_component_stacks $COMPONENT_NAME || log_error "app deployment"
-    execute_component_test $COMPONENT_NAME || log_error "running test suite"
+
+    deploy_component_stacks $COMPONENT_NAME
+    DEPLOY_EXIT_CODE=$?
+
+    if [[ $DEPLOY_EXIT_CODE -eq 0 ]]
+    then
+      echo "$(timestamp) [${COMPONENT_NAME}] running test suite started"
+
+      execute_component_test $COMPONENT_NAME
+      SCRIPT_EXIT_CODE=$?
+
+      echo "$(timestamp) [${COMPONENT_NAME}] running test suite complete"
+
+      test_report_path="${INTEG_TEMP_DIR}/${COMPONENT_NAME}/test-report.json"
+      if [[ -f "${test_report_path}" ]]
+      then
+        if [[ $(node -pe "require('${test_report_path}').numFailedTests") -eq 0 ]]
+        then
+          echo "$(timestamp) [${COMPONENT_NAME}] test suite passed"
+        else
+          echo "$(timestamp) [${COMPONENT_NAME}] test suite failed"
+        fi
+      fi
+    else
+      SCRIPT_EXIT_CODE=$DEPLOY_EXIT_CODE
+    fi
+
   fi
   if [[ $OPTION != '--deploy-and-test-only' ]]; then
     destroy_component_stacks $COMPONENT_NAME
+    DESTROY_EXIT_CODE=$?
+
+    # We want the exit-code to reflect the deploy and test portion if
+    # non-zero. Otherwise, destroy exit code should be used
+    if [[ $SCRIPT_EXIT_CODE -eq 0 ]]
+    then
+      SCRIPT_EXIT_CODE=$DESTROY_EXIT_CODE
+    fi
   fi
 fi
 
-exit 0
+exit $SCRIPT_EXIT_CODE

--- a/integ/components/deadline/common/scripts/bash/component_e2e_driver.sh
+++ b/integ/components/deadline/common/scripts/bash/component_e2e_driver.sh
@@ -38,10 +38,4 @@ ${COMPONENT_NAME}_START_TIME=${START_TIME}
 ${COMPONENT_NAME}_FINISH_TIME=${FINISH_TIME}
 EOF
 
-# Clean-up if test failed
-if [[ $test_exit_code -ne 0 ]]
-then
-    ../common/scripts/bash/component_e2e.sh "$COMPONENT_NAME" --destroy-only
-fi
-
-exit 0
+exit $test_exit_code

--- a/integ/components/deadline/common/scripts/bash/deploy-utils.sh
+++ b/integ/components/deadline/common/scripts/bash/deploy-utils.sh
@@ -110,12 +110,12 @@ function destroy_component_stacks () {
 
     echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack destroy started"
     npx cdk destroy --app cdk.out -e -f "${stack}" &>> "${destroy_log_path}"
-    STACK_DEPLOY_EXIT_CODE=$?
-    if [[ $STACK_DEPLOY_EXIT_CODE -ne 0 ]]
+    STACK_DESTROY_EXIT_CODE=$?
+    if [[ $STACK_DESTROY_EXIT_CODE -ne 0 ]]
     then
       echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack destroy failed"
       echo "$(timestamp) [${COMPONENT_NAME}] app destroy failed"
-      return $STACK_DEPLOY_EXIT_CODE
+      return $STACK_DESTROY_EXIT_CODE
     fi
     echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack destroy complete"
   done

--- a/integ/components/deadline/common/scripts/bash/deploy-utils.sh
+++ b/integ/components/deadline/common/scripts/bash/deploy-utils.sh
@@ -21,17 +21,30 @@ function ensure_component_artifact_dir () {
 function deploy_component_stacks () {
   COMPONENT_NAME=$1
 
-  echo "[${COMPONENT_NAME}] started"
+  echo "$(timestamp) [${COMPONENT_NAME}] app deployment started"
 
   ensure_component_artifact_dir "${COMPONENT_NAME}"
 
   # Generate the cdk.out directory which includes a manifest.json file
   # this can be used to determine the deployment ordering
-  echo "[${COMPONENT_NAME}] synthesizing started"
-  npx cdk synth &> "${INTEG_TEMP_DIR}/${COMPONENT_NAME}/synth.log"
-  echo "[${COMPONENT_NAME}] synthesizing complete"
+  echo "$(timestamp) [${COMPONENT_NAME}] synthesizing started"
+  # Synthesis requires AWS API calls for the context methods
+  # (https://docs.aws.amazon.com/cdk/latest/guide/context.html#context_methods)
+  # in our case this is for stack.availabilityZones
+  run_aws_interaction_hook
 
-  echo "[${COMPONENT_NAME}] app deployment started"
+  npx cdk synth &> "${INTEG_TEMP_DIR}/${COMPONENT_NAME}/synth.log"
+  SYNTH_EXIT_CODE=$?
+  echo $SYNTH_EXIT_CODE > "${INTEG_TEMP_DIR}/${COMPONENT_NAME}/synth-exit-code"
+  if [[ $SYNTH_EXIT_CODE -ne 0 ]]
+  then
+    echo "$(timestamp) [${COMPONENT_NAME}] synthesizing failed"
+    echo "$(timestamp) [${COMPONENT_NAME}] app deployment failed"
+    return $SYNTH_EXIT_CODE
+  fi
+  echo "$(timestamp) [${COMPONENT_NAME}] synthesizing complete"
+
+  echo "$(timestamp) [${COMPONENT_NAME}] app deployment started"
 
   # Empty the deploy log file in case it was non-empty
   deploy_log_path="${INTEG_TEMP_DIR}/${COMPONENT_NAME}/deploy.txt"
@@ -40,14 +53,24 @@ function deploy_component_stacks () {
   for stack in $(cdk_stack_deploy_order); do
     run_aws_interaction_hook
 
-    echo "[${COMPONENT_NAME}] -> [${stack}] stack deployment started"
+    echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack deployment started"
     npx cdk deploy --app cdk.out --require-approval=never -e "${stack}" &>> "${deploy_log_path}"
-    echo "[${COMPONENT_NAME}] -> [${stack}] stack deployment complete"
+    STACK_DEPLOY_EXIT_CODE=$?
+    if [[ $STACK_DEPLOY_EXIT_CODE -ne 0 ]]
+    then
+      # Save exit code
+      echo $STACK_DEPLOY_EXIT_CODE > "${INTEG_TEMP_DIR}/${COMPONENT_NAME}/deploy-exit-code"
+
+      echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack deployment failed"
+      echo "$(timestamp) [${COMPONENT_NAME}] app deployment failed"
+      return $STACK_DEPLOY_EXIT_CODE
+    fi
+    echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack deployment complete"
   done
 
-  echo "[${COMPONENT_NAME}] app deployment complete"
-  
-  return 0
+  echo 0 > "${INTEG_TEMP_DIR}/${COMPONENT_NAME}/deploy-exit-code"
+
+  echo "$(timestamp) [${COMPONENT_NAME}] app deployment complete"
 }
 
 function cdk_stack_deploy_order () {
@@ -68,20 +91,8 @@ function execute_component_test () {
   test_report_path="${INTEG_TEMP_DIR}/${COMPONENT_NAME}/test-report.json"
   test_output_path="${INTEG_TEMP_DIR}/${COMPONENT_NAME}/test-output.txt"
 
-  echo "[${COMPONENT_NAME}] running test suite started"
   ensure_component_artifact_dir "${COMPONENT_NAME}"
   yarn run test "$COMPONENT_NAME.test" --json --outputFile="${test_report_path}" &> "${test_output_path}"
-  echo "[${COMPONENT_NAME}] running test suite complete"
-
-
-  if [[ -f "${test_report_path}" && $(node -pe "require('${test_report_path}').numFailedTests") -eq 0 ]]
-  then
-    echo "[${COMPONENT_NAME}] test suite passed"
-  else
-    echo "[${COMPONENT_NAME}] test suite failed"
-  fi
-
-  return 0
 }
 
 function destroy_component_stacks () {
@@ -89,7 +100,7 @@ function destroy_component_stacks () {
 
   ensure_component_artifact_dir "${COMPONENT_NAME}"
 
-  echo "[${COMPONENT_NAME}] app destroy started"
+  echo "$(timestamp) [${COMPONENT_NAME}] app destroy started"
 
   destroy_log_path="${INTEG_TEMP_DIR}/${COMPONENT_NAME}/destroy.txt"
   # Empty the destroy log file in case it was non-empty
@@ -97,16 +108,21 @@ function destroy_component_stacks () {
   for stack in $(cdk_stack_destroy_order); do
     run_aws_interaction_hook
 
-    echo "[${COMPONENT_NAME}] -> [${stack}] stack destroy started"
+    echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack destroy started"
     npx cdk destroy --app cdk.out -e -f "${stack}" &>> "${destroy_log_path}"
-    echo "[${COMPONENT_NAME}] -> [${stack}] stack destroy complete"
+    STACK_DEPLOY_EXIT_CODE=$?
+    if [[ $STACK_DEPLOY_EXIT_CODE -ne 0 ]]
+    then
+      echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack destroy failed"
+      echo "$(timestamp) [${COMPONENT_NAME}] app destroy failed"
+      return $STACK_DEPLOY_EXIT_CODE
+    fi
+    echo "$(timestamp) [${COMPONENT_NAME}] -> [${stack}] stack destroy complete"
   done
 
-  # Clean up artifacts
-  rm -f "./cdk.context.json"
-  rm -rf "./cdk.out"
+  echo "$(timestamp) [${COMPONENT_NAME}] app destroy complete"
+}
 
-  echo "[${COMPONENT_NAME}] app destroy complete"
-
-  return 0
+function timestamp() {
+  date "+%Y-%m-%dT%H:%M:%S"
 }

--- a/integ/scripts/bash/deploy-infrastructure.sh
+++ b/integ/scripts/bash/deploy-infrastructure.sh
@@ -10,7 +10,7 @@ shopt -s globstar
 INFRASTRUCTURE_APP="$INTEG_ROOT/components/_infrastructure"
 cd "$INFRASTRUCTURE_APP"
 mkdir -p "${INTEG_TEMP_DIR}/infrastructure"
-echo "[infrastructure] deployment started"
+echo "$(date "+%Y-%m-%dT%H:%M:%S") [infrastructure] deployment started"
 
 # Handle errors manually
 set +e
@@ -22,10 +22,10 @@ deploy_exit_code=$?
 # If an exit code was returned from the deployment, output the deploy log
 if [[ $deploy_exit_code -ne 0 ]]
 then
-    echo "[infrastructure] deployment failed"
+    echo "$(date "+%Y-%m-%dT%H:%M:%S") [infrastructure] deployment failed"
     cat "${INTEG_TEMP_DIR}/infrastructure/deploy.txt"
 else
-    echo "[infrastructure] deployment complete"
+    echo "$(date "+%Y-%m-%dT%H:%M:%S") [infrastructure] deployment complete"
 fi
 
 cd "$INTEG_ROOT"

--- a/integ/scripts/bash/tear-down.sh
+++ b/integ/scripts/bash/tear-down.sh
@@ -30,6 +30,10 @@ fi
 # Set variables from script
 source $BASH_SCRIPTS/set-test-variables.sh
 
+# This is a best-effort. If any component fails to destroy, we proceed and try
+# the others. Disable the exit on error option
+set +e
+
 for COMPONENT in **/cdk.json; do
     # In case the yarn install was done inside this integ package, there are some example cdk.json files in the aws-cdk
     # package we want to avoid.

--- a/integ/scripts/bash/teardown-infrastructure.sh
+++ b/integ/scripts/bash/teardown-infrastructure.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 source "$INTEG_ROOT/components/deadline/common/scripts/bash/deploy-utils.sh"
 
-echo "[infrastructure] destroy started"
+echo "$(timestamp) [infrastructure] destroy started"
 INFRASTRUCTURE_APP="$INTEG_ROOT/components/_infrastructure"
 cd "$INFRASTRUCTURE_APP"
 
@@ -15,17 +15,17 @@ run_aws_interaction_hook
 
 mkdir -p "${INTEG_TEMP_DIR}/infrastructure"
 
-# Hide the deploy log unless something goes wrong (save the scrollback buffer)
+# Hide the destroy log unless something goes wrong (save the scrollback buffer)
 npx cdk destroy "*" -f &> "${INTEG_TEMP_DIR}/infrastructure/destroy.txt"
 destroy_exit_code=$?
 
-# If an exit code was returned from the deployment, output the deploy log
+# If an exit code was returned from the destroy, output the destroy log
 if [[ $destroy_exit_code -ne 0 ]]
 then
-    echo "[infrastructure] deployment failed"
+    echo "$(timestamp) [infrastructure] destroy failed"
     cat "${INTEG_TEMP_DIR}/infrastructure/destroy.txt"
 else
-    echo "[infrastructure] deployment complete"
+    echo "$(timestamp) [infrastructure] destroy complete"
 fi
 
 exit $destroy_exit_code


### PR DESCRIPTION
# Problem

## 1. Exit Code

The exit code returned by the `integ/scripts/bash/rfdk-integ-e2e.sh` script does not properly reflect the result of the integration test. When the test fails, the script can return a exit code of `0`. RFDK release automation relies on the exit code reflecting the result of the test.

## 2.  Error Handling

The error handling in the bash scripting of the RFDK e2e test framework does not work as expected. When there is a synthesis or deploy failure, the scripting continues processing and attempts to execute the tests. This produces strange errors in the test output that can cause confusion and cause readers to misinterpret why a test failed.

## 3. Pre-interaction Hook

The RFDK e2e integration test framework allows specifying a `PRE_AWS_INTERACTION_HOOK` environment variable that points to a bash function. It is supposed to be invoked by the framework before any AWS APIs are interacted with. This hook was not being invoked before synthesizing each test component's CDK app. CDK makes some API calls during synthesis if the CDK app makes use of [CDK context methods](https://docs.aws.amazon.com/cdk/latest/guide/context.html#context_methods), which the apps do use.

# Solution

## 1. Exit Code

The various bash scripts were adjusted so that exit codes are bubbled up to the component driver script (`component-e2e-driver.sh`) and returned by that script. This uses the first non-zero exit code in the following order:

*   Synthesis failure
*   Deploy failure
*   Test failure
*   Destroy failure

If all of these steps succeed, then `component-e2e-driver.sh` will have an exit code of `0`.

The entry-point script (`rfdk-integ-e2e.sh`), uses `xargs` to call `component-e2e-driver.sh`. This command returns an exit code of `123` if any sub-process it spawns returns an exit code between 1-125. If a sub-process returns a different non-zero exit code, it returns an exit code of `1` ([docs](https://man7.org/linux/man-pages/man1/xargs.1.html#EXIT_STATUS)).

## 2. Error Handling

After some debugging, it was determined that the following statements were the cause of error:

https://github.com/aws/aws-rfdk/blob/0cc67238645e24805590412776d262c8e6b9ec49/integ/components/deadline/common/scripts/bash/component_e2e.sh#L32-L33

Each of the above lines is considered a bash "list". The LHS of these lists is a call to a bash function (`deploy_component_stacks` and `execute_component_test` respectively). Those functions had assumed that the bash `set -e` option was set and any error would short-circuit the function execution and return a non-zero exit code. According to the [`bash` documentation](https://man7.org/linux/man-pages/man1/bash.1.html) for the `-e` option:

>   Exit immediately if a pipeline (which may consist of a single simple command), a list, or a compound command (see `SHELL GRAMMAR` above), exits with a non-zero status.  The shell does not exit if the command that fails is part of the command list immediately following a `while` or `until` keyword, part of the test following the `if` or `elif` reserved words, part of any command executed in a `&&` or `||` list except the command following the final `&&` or `||`, any command in a pipeline but the last, or if the command's return value is being inverted with `!`.

A minimal reproducer was created:

```sh
function bar() {
  set +e
  echo "shell opts: $-"
  false
  echo "I'm immortal"
}
```

Then:

```sh
$ # With outer error-handling enabled
$ set -e
$ bar || echo 'I'm mortal'
shell opts: himBH
I'm immortal
$ # With outer error-handling disabled
$ set +e
$ bar || echo 'I'm mortal' 
shell opts: himBH
I'm immortal
```

Based on this conclusion, the `component-e2e.sh` was modified to move away from a bash "list" and instead disable the `-e` flag and handling errors manually.

## 3. Pre-interaction Hook

Added a call to `run_aws_interaction_hook` before each CDK app is synthesized.

## Other Changes

- output timestamps for live progress logging
- make output more consistent
- clean up format of test report
- show synth log on synth failures

# Testing

- Ran the tests and confirmed that both synth and deploy failures cause both:
    - Short-circuit the test execution
    - Cause the outer script to return a non-zero exit code
- Ran the tests and confirmed that a fully successful test synth/deploy/test/destroy returns a zero exit code

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
