### PR TITLE
fix(core): Convert group & pool names in SpotEventPluginFleet to lowercase

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -577,7 +577,7 @@ export class ConfigureSpotEventPlugin extends Construct {
 
     const spotFleetRequestConfigurations = fleet.deadlineGroups.map(group => {
       const spotFleetRequestConfiguration: SpotFleetRequestConfiguration = {
-        [group]: spotFleetRequestProps,
+        [group.toLowerCase()]: spotFleetRequestProps,
       };
       return spotFleetRequestConfiguration;
     });

--- a/packages/aws-rfdk/lib/deadline/test/spot-event-plugin-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/spot-event-plugin-fleet.test.ts
@@ -70,7 +70,7 @@ let vpc: IVpc;
 let renderQueue: IRenderQueue;
 let rcsImage: AssetImage;
 
-const groupName = 'group_name';
+const groupName = 'Group_Name';
 const deadlineGroups = [
   groupName,
 ];
@@ -238,7 +238,7 @@ describe('SpotEventPluginFleet', () => {
 
       // THEN
       expect(fleet.userData).toBeDefined();
-      expect(renderedUserData).toMatch(groupName);
+      expect(renderedUserData).toMatch(groupName.toLocaleLowerCase());
     });
 
     test('adds RFDK tags', () => {
@@ -360,7 +360,7 @@ describe('SpotEventPluginFleet', () => {
       const imageConfig = workerMachineImage.getImage(fleet);
 
       // THEN
-      expect(fleet.deadlineGroups).toBe(deadlineGroups);
+      expect(fleet.deadlineGroups).toStrictEqual(deadlineGroups.map(group => group.toLocaleLowerCase()));
       expect(fleet.instanceTypes).toBe(instanceTypes);
       expect(fleet.imageId).toBe(imageConfig.imageId);
       expect(fleet.osType).toBe(imageConfig.osType);
@@ -642,7 +642,7 @@ describe('SpotEventPluginFleet', () => {
 
     test('adds deadline pools to user data', () => {
       // GIVEN
-      const pool1 = 'pool1';
+      const pool1 = 'Pool1';
       const pool2 = 'pool2';
 
       // WHEN
@@ -661,8 +661,8 @@ describe('SpotEventPluginFleet', () => {
       const renderedUserData = fleet.userData.render();
 
       // THEN
-      expect(renderedUserData).toMatch(pool1);
-      expect(renderedUserData).toMatch(pool2);
+      expect(renderedUserData).toMatch(pool1.toLocaleLowerCase());
+      expect(renderedUserData).toMatch(pool2.toLocaleLowerCase());
     });
 
     test('uses provided ssh key name', () => {


### PR DESCRIPTION
### Problem
Groups & pools are always lowercase in Deadline.
The SpotEventPluginFleet is passing the Group/Pool names through as given, without ensuring that they are in lower case. With the SpotEventPluginFleet currently not creating the required groups, this means that it is impossible for a customer to create the required group on their own if they ask for one that has uppercase characters in it.

### Solution
 - Convert group and pool names lo lowercase
 - Changed validation for group names

### Testing

 - Deployed farm with group and pool that names contain capital symbols.
 - Verified that spot configuration deployed with converted group name.
 - Created pool and group with lowercase names and send a job with this pool and group.
 - Make sure that worker was spawned and rendered this job.
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
