### PR TITLE
feat(deadline): create Deadline Groups and Pools on deploy for ConfigureSpotEventPlugin

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/python/README.md
@@ -73,8 +73,6 @@ These instructions assume that your working directory is `examples/deadline/All-
 7. You can now [connect to the farm](https://docs.aws.amazon.com/rfdk/latest/guide/connecting-to-render-farm.html) and [submit rendering jobs](https://docs.aws.amazon.com/rfdk/latest/guide/first-rfdk-app.html#_optional_submit_a_job_to_the_render_farm).
 
     **Note:** In order for the Spot Event Plugin to create a Spot Fleet Request you need to:
-    * Create the Deadline Group associated with the Spot Fleet Request Configuration. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
-    * Create the Deadline Pools to which the fleet Workers are added. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
     * Submit the job with the assigned Deadline Group and Deadline Pool. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/job-submitting.html#submitting-jobs).
 
     **Note:** Disable 'Allow Workers to Perform House Cleaning If Pulse is not Running' in the 'Configure Repository Options' when using Spot Event Plugin. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/event-spot.html#prerequisites).

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/README.md
@@ -66,8 +66,6 @@ These instructions assume that your working directory is `examples/deadline/All-
 7. You can now [connect to the farm](https://docs.aws.amazon.com/rfdk/latest/guide/connecting-to-render-farm.html) and [submit rendering jobs](https://docs.aws.amazon.com/rfdk/latest/guide/first-rfdk-app.html#_optional_submit_a_job_to_the_render_farm).
 
     **Note:** In order for the Spot Event Plugin to create a Spot Fleet Request you need to:
-    * Create the Deadline Group associated with the Spot Fleet Request Configuration. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
-    * Create the Deadline Pools to which the fleet Workers are added. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
     * Submit the job with the assigned Deadline Group and Deadline Pool. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/job-submitting.html#submitting-jobs).
 
     **Note:** Disable 'Allow Workers to Perform House Cleaning If Pulse is not Running' in the 'Configure Repository Options' when using Spot Event Plugin. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/event-spot.html#prerequisites).

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -45,8 +45,6 @@ The `ConfigureSpotEventPlugin` construct has two main responsibilities:
 ---
 
 **Note:** This construct will configure the Spot Event Plugin, but the Spot Fleet Requests will not be created unless you:
-- Create the Deadline Group associated with the Spot Fleet Request Configuration. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
-- Create the Deadline Pools to which the fleet Workers are added. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
 - Submit the job with the assigned Deadline Group and Deadline Pool. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/job-submitting.html#submitting-jobs).
 
 ---
@@ -232,8 +230,6 @@ This construct represents a Spot Fleet launched by the [Deadline's Spot Event Pl
 
 This construct is expected to be used as an input to the [ConfigureSpotEventPlugin](#configure-spot-event-plugin) construct. `ConfigureSpotEventPlugin` construct will generate a Spot Fleet Request Configuration from each provided `SpotEventPluginFleet` and will set these configurations to the Spot Event Plugin.
 
-_**Note:** You will have to create the groups manually using Deadline before submitting jobs. See https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html
-
 ```ts
 const vpc = new Vpc(/* ... */);
 const renderQueue = new RenderQueue(stack, 'RenderQueue', /* ... */);
@@ -276,8 +272,6 @@ const fleet = new SpotEventPluginFleet(this, 'SpotEventPluginFleet', {
 #### Adding Deadline Pools
 
 You can add the Workers to Deadline's Pools providing a list of pools as following:
-
-_**Note:** You will have to create the pools manually using Deadline before submitting jobs. See https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html
 
 ```ts
 const fleet = new SpotEventPluginFleet(this, 'SpotEventPluginFleet', {

--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -459,6 +459,8 @@ export class ConfigureSpotEventPlugin extends Construct {
     };
     const spotFleetRequestConfigs = this.mergeSpotFleetRequestConfigs(props.spotFleets);
 
+    const deadlineGroups = Array.from(new Set(props.spotFleets?.map(fleet => fleet.deadlineGroups).reduce((p, c) => p.concat(c), [])));
+    const deadlinePools = Array.from(new Set(props.spotFleets?.map(fleet => fleet.deadlinePools).reduce((p, c) => p?.concat(c ?? []), [])));
     const properties: SEPConfiguratorResourceProps = {
       connection: {
         hostname: props.renderQueue.endpoint.hostname,
@@ -468,6 +470,8 @@ export class ConfigureSpotEventPlugin extends Construct {
       },
       spotFleetRequestConfigurations: spotFleetRequestConfigs,
       spotPluginConfigurations: pluginConfig,
+      deadlineGroups,
+      deadlinePools,
     };
 
     const resource = new CustomResource(this, 'Default', {

--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -317,8 +317,6 @@ export interface ConfigureSpotEventPluginProps {
  * Logs for all AWS Lambdas are automatically recorded in Amazon CloudWatch.
  *
  * This construct will configure the Spot Event Plugin, but the Spot Fleet Requests will not be created unless you:
- * - Create the Deadline Group associated with the Spot Fleet Request Configuration. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
- * - Create the Deadline Pools to which the fleet Workers are added. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html).
  * - Submit the job with the assigned Deadline Group and Deadline Pool. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/job-submitting.html#submitting-jobs).
  *
  * Important: Disable 'Allow Workers to Perform House Cleaning If Pulse is not Running' in the 'Configure Repository Options'

--- a/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
@@ -388,6 +388,13 @@ export class SpotEventPluginFleet extends Construct implements ISpotEventPluginF
   public readonly deadlineGroups: string[];
 
   /**
+   * Deadline pools the workers need to be assigned to.
+   *
+   * @default - Workers are not assigned to any pool
+   */
+  public readonly deadlinePools?: string[];
+
+  /**
    * Name of SSH keypair to grant access to instances.
    *
    * @default - No SSH access will be possible.
@@ -413,6 +420,7 @@ export class SpotEventPluginFleet extends Construct implements ISpotEventPluginF
     super(scope, id);
 
     this.deadlineGroups = props.deadlineGroups.map(group => group.toLocaleLowerCase());
+    this.deadlinePools = props.deadlinePools?.map(pool => pool.toLocaleLowerCase());
     this.validateProps(props);
 
     this.securityGroups = props.securityGroups ?? [ new SecurityGroup(this, 'SpotFleetSecurityGroup', { vpc: props.vpc }) ];
@@ -463,7 +471,7 @@ export class SpotEventPluginFleet extends Construct implements ISpotEventPluginF
       renderQueue: props.renderQueue,
       workerSettings: {
         groups: this.deadlineGroups,
-        pools: props.deadlinePools?.map(pool => pool.toLocaleLowerCase()),
+        pools: this.deadlinePools,
         region: props.deadlineRegion,
       },
       userDataProvider: props.userDataProvider,

--- a/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
@@ -90,9 +90,6 @@ export interface SpotEventPluginFleetProps {
   /**
    * Deadline groups these workers need to be assigned to.
    *
-   * Note that you will have to create the groups manually using Deadline before submitting jobs.
-   * See https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html
-   *
    * Also, note that the Spot Fleet configuration does not allow using wildcards as part of the Group name
    * as described here https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/event-spot.html#wildcards
    */
@@ -100,9 +97,6 @@ export interface SpotEventPluginFleetProps {
 
   /**
    * Deadline pools these workers need to be assigned to.
-   *
-   * Note that you will have to create the pools manually using Deadline before submitting jobs.
-   * See https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/pools-and-groups.html
    *
    * @default - Workers are not assigned to any pool.
    */

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/handler.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/handler.ts
@@ -47,6 +47,14 @@ export class SEPConfiguratorResource extends SimpleCustomResource {
   public async doCreate(_physicalId: string, resourceProperties: SEPConfiguratorResourceProps): Promise<object|undefined> {
     const spotEventPluginClient = await this.spotEventPluginClient(resourceProperties.connection);
 
+    if (!await spotEventPluginClient.addGroups(resourceProperties.deadlineGroups)) {
+      throw new Error('Failed to add group collection.');
+    }
+
+    if (!await spotEventPluginClient.addPools(resourceProperties.deadlinePools)) {
+      throw new Error('Failed to add pool collection.');
+    }
+
     if (resourceProperties.spotFleetRequestConfigurations) {
       const convertedSpotFleetRequestConfigs = convertSpotFleetRequestConfiguration(resourceProperties.spotFleetRequestConfigurations);
       const stringConfigs = JSON.stringify(convertedSpotFleetRequestConfigs);

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/handler.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/handler.ts
@@ -48,11 +48,11 @@ export class SEPConfiguratorResource extends SimpleCustomResource {
     const spotEventPluginClient = await this.spotEventPluginClient(resourceProperties.connection);
 
     if (!await spotEventPluginClient.addGroups(resourceProperties.deadlineGroups)) {
-      throw new Error('Failed to add group collection.');
+      throw new Error(`Failed to add Deadline group(s) ${resourceProperties.deadlineGroups}`);
     }
 
     if (!await spotEventPluginClient.addPools(resourceProperties.deadlinePools)) {
-      throw new Error('Failed to add pool collection.');
+      throw new Error(`Failed to add Deadline pool(s) ${resourceProperties.deadlinePools}`);
     }
 
     if (resourceProperties.spotFleetRequestConfigurations) {

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/test/handler.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/test/handler.test.ts
@@ -487,12 +487,12 @@ describe('SEPConfiguratorResource', () => {
       mockSpotEventPluginClient.addGroups = jest.fn( (a) => returnFalse(a) );
 
       // WHEN
-      const promise = handler.doCreate('physicalId', noConfigs);
+      const promise = handler.doCreate('physicalId', allConfigs);
 
       // THEN
       await expect(promise)
         .rejects
-        .toThrowError(/Failed to add group collection./);
+        .toThrowError(`Failed to add Deadline group(s) ${allConfigs.deadlineGroups}`);
     });
 
     test('throw when cannot add pools', async () => {
@@ -500,12 +500,12 @@ describe('SEPConfiguratorResource', () => {
       mockSpotEventPluginClient.addPools = jest.fn( (a) => returnFalse(a) );
 
       // WHEN
-      const promise = handler.doCreate('physicalId', noConfigs);
+      const promise = handler.doCreate('physicalId', allConfigs);
 
       // THEN
       await expect(promise)
         .rejects
-        .toThrowError(/Failed to add pool collection./);
+        .toThrowError(`Failed to add Deadline pool(s) ${allConfigs.deadlinePools}`);
     });
 
     test('throw when cannot save spot fleet request configs', async () => {

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/test/handler.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/test/handler.test.ts
@@ -205,24 +205,44 @@ describe('SEPConfiguratorResource', () => {
     connection: validConnection,
   };
 
+  const deadlineGroups =  ['group_name'];
+  const deadlinePools =  ['pool_name'];
+
   const allConfigs: SEPConfiguratorResourceProps = {
     spotPluginConfigurations: validSpotEventPluginConfig,
     connection: validConnection,
     spotFleetRequestConfigurations: validSpotFleetRequestConfig,
+    deadlineGroups,
+    deadlinePools,
   };
 
   const noConfigs: SEPConfiguratorResourceProps = {
     connection: validConnection,
   };
 
+  async function returnTrue(_v1: any): Promise<boolean> {
+    return true;
+  }
+
+  async function returnFalse(_v1: any): Promise<boolean> {
+    return false;
+  }
+
   describe('doCreate', () => {
     let handler: SEPConfiguratorResource;
-    let mockSpotEventPluginClient: { saveServerData: jest.Mock<any, any>; configureSpotEventPlugin: jest.Mock<any, any>; };
+    let mockSpotEventPluginClient: {
+      saveServerData: jest.Mock<any, any>;
+      configureSpotEventPlugin: jest.Mock<any, any>;
+      addGroups: jest.Mock<any, any>;
+      addPools: jest.Mock<any, any>;
+    };
 
     beforeEach(() => {
       mockSpotEventPluginClient = {
-        saveServerData: jest.fn(),
-        configureSpotEventPlugin: jest.fn(),
+        saveServerData: jest.fn( (a) => returnTrue(a) ),
+        configureSpotEventPlugin: jest.fn( (a) => returnTrue(a) ),
+        addGroups: jest.fn( (a) => returnTrue(a) ),
+        addPools: jest.fn( (a) => returnTrue(a) ),
       };
 
       handler = new SEPConfiguratorResource(new AWS.SecretsManager());
@@ -242,9 +262,6 @@ describe('SEPConfiguratorResource', () => {
 
     test('with no configs', async () => {
       // GIVEN
-      async function returnTrue(_v1: any): Promise<boolean> {
-        return true;
-      }
       const mockSaveServerData = jest.fn( (a) => returnTrue(a) );
       mockSpotEventPluginClient.saveServerData = mockSaveServerData;
       const mockConfigureSpotEventPlugin = jest.fn( (a) => returnTrue(a) );
@@ -261,9 +278,6 @@ describe('SEPConfiguratorResource', () => {
 
     test('save spot fleet request configs', async () => {
       // GIVEN
-      async function returnTrue(_v1: any): Promise<boolean> {
-        return true;
-      }
       const mockSaveServerData = jest.fn( (a) => returnTrue(a) );
       mockSpotEventPluginClient.saveServerData = mockSaveServerData;
 
@@ -281,9 +295,6 @@ describe('SEPConfiguratorResource', () => {
 
     test('save spot fleet request configs without BlockDeviceMappings', async () => {
       // GIVEN
-      async function returnTrue(_v1: any): Promise<boolean> {
-        return true;
-      }
       const mockSaveServerData = jest.fn( (a) => returnTrue(a) );
       mockSpotEventPluginClient.saveServerData = mockSaveServerData;
 
@@ -326,9 +337,6 @@ describe('SEPConfiguratorResource', () => {
 
     test('save spot fleet request configs without Ebs', async () => {
       // GIVEN
-      async function returnTrue(_v1: any): Promise<boolean> {
-        return true;
-      }
       const mockSaveServerData = jest.fn( (a) => returnTrue(a) );
       mockSpotEventPluginClient.saveServerData = mockSaveServerData;
 
@@ -375,9 +383,6 @@ describe('SEPConfiguratorResource', () => {
 
     test('save spot event plugin configs', async () => {
       // GIVEN
-      async function returnTrue(_v1: any): Promise<boolean> {
-        return true;
-      }
       const mockConfigureSpotEventPlugin = jest.fn( (a) => returnTrue(a) );
       mockSpotEventPluginClient.configureSpotEventPlugin = mockConfigureSpotEventPlugin;
 
@@ -407,14 +412,22 @@ describe('SEPConfiguratorResource', () => {
       expect(mockConfigureSpotEventPlugin.mock.calls[0][0]).toEqual([...configs, ...securitySettings]);
     });
 
-    test('save both configs', async () => {
+    test('save server data', async () => {
       // GIVEN
-      async function returnTrue(_v1: any): Promise<boolean> {
-        return true;
-      }
       const mockSaveServerData = jest.fn( (a) => returnTrue(a) );
       mockSpotEventPluginClient.saveServerData = mockSaveServerData;
 
+      // WHEN
+      const result = await handler.doCreate('physicalId', allConfigs);
+
+      // THEN
+      expect(result).toBeUndefined();
+      expect(mockSaveServerData.mock.calls.length).toBe(1);
+      expect(mockSaveServerData.mock.calls[0][0]).toEqual(JSON.stringify(validConvertedSpotFleetRequestConfig));
+    });
+
+    test('configure spot event plugin', async () => {
+      // GIVEN
       const mockConfigureSpotEventPlugin = jest.fn( (a) => returnTrue(a) );
       mockSpotEventPluginClient.configureSpotEventPlugin = mockConfigureSpotEventPlugin;
 
@@ -436,22 +449,67 @@ describe('SEPConfiguratorResource', () => {
       }];
 
       // WHEN
-      const result = await handler.doCreate('physicalId', allConfigs);
+      await handler.doCreate('physicalId', allConfigs);
 
       // THEN
-      expect(result).toBeUndefined();
-      expect(mockSaveServerData.mock.calls.length).toBe(1);
-      expect(mockSaveServerData.mock.calls[0][0]).toEqual(JSON.stringify(validConvertedSpotFleetRequestConfig));
-
       expect(mockConfigureSpotEventPlugin.mock.calls.length).toBe(1);
       expect(mockConfigureSpotEventPlugin.mock.calls[0][0]).toEqual([...configs, ...securitySettings]);
     });
 
+    test('create groups', async () => {
+      // GIVEN
+      const mockAddGroups = jest.fn( (a) => returnTrue(a) );
+      mockSpotEventPluginClient.addGroups = mockAddGroups;
+
+      // WHEN
+      await handler.doCreate('physicalId', allConfigs);
+
+      // THEN
+      expect(mockAddGroups.mock.calls.length).toBe(1);
+      expect(mockAddGroups).toHaveBeenCalledWith(deadlineGroups);
+    });
+
+    test('create pools', async () => {
+      // GIVEN
+      const mockAddPools = jest.fn( (a) => returnTrue(a) );
+      mockSpotEventPluginClient.addPools = mockAddPools;
+
+      // WHEN
+      await handler.doCreate('physicalId', allConfigs);
+
+      // THEN
+      expect(mockAddPools.mock.calls.length).toBe(1);
+      expect(mockAddPools).toHaveBeenCalledWith(deadlinePools);
+    });
+
+    test('throw when cannot add groups', async () => {
+      // GIVEN
+      mockSpotEventPluginClient.addGroups = jest.fn( (a) => returnFalse(a) );
+
+      // WHEN
+      const promise = handler.doCreate('physicalId', noConfigs);
+
+      // THEN
+      await expect(promise)
+        .rejects
+        .toThrowError(/Failed to add group collection./);
+    });
+
+    test('throw when cannot add pools', async () => {
+      // GIVEN
+      mockSpotEventPluginClient.addPools = jest.fn( (a) => returnFalse(a) );
+
+      // WHEN
+      const promise = handler.doCreate('physicalId', noConfigs);
+
+      // THEN
+      await expect(promise)
+        .rejects
+        .toThrowError(/Failed to add pool collection./);
+    });
+
     test('throw when cannot save spot fleet request configs', async () => {
       // GIVEN
-      async function returnFalse(_v1: any): Promise<boolean> {
-        return false;
-      }
       const mockSaveServerData = jest.fn( (a) => returnFalse(a) );
       mockSpotEventPluginClient.saveServerData = mockSaveServerData;
 
@@ -466,9 +524,6 @@ describe('SEPConfiguratorResource', () => {
 
     test('throw when cannot save spot event plugin configs', async () => {
       // GIVEN
-      async function returnFalse(_v1: any): Promise<boolean> {
-        return false;
-      }
       const mockConfigureSpotEventPlugin = jest.fn( (a) => returnFalse(a) );
       mockSpotEventPluginClient.configureSpotEventPlugin = mockConfigureSpotEventPlugin;
 

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/types.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/types.ts
@@ -23,6 +23,16 @@ export interface SEPConfiguratorResourceProps {
    * See https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/event-spot.html#event-plugin-configuration-options
    */
   readonly spotPluginConfigurations?: PluginSettings;
+
+  /**
+   * Deadline groups that are used by these fleets.
+   */
+  readonly deadlineGroups?: string[];
+
+  /**
+   * Deadline pools that are used by these fleets.
+   */
+  readonly deadlinePools?: string[];
 }
 
 /**

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/configure-spot-event-plugin/test/spot-event-plugin-client.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/configure-spot-event-plugin/test/spot-event-plugin-client.test.ts
@@ -439,25 +439,4 @@ describe('SpotEventPluginClient', () => {
       );
     }
   });
-
-  test.each([
-    [poolsColection.Pools,1],
-    [[], 0],
-  ])('successful call addPool with %s', async (poolsCollection: string[], requestsCount: number) => {
-    // GIVEN
-    // eslint-disable-next-line dot-notation
-    spotEventPluginClient['deadlineClient'].GetRequest = jest.fn().mockResolvedValue(successfulPoolResponse);
-    // eslint-disable-next-line dot-notation
-    spotEventPluginClient['deadlineClient'].PostRequest = jest.fn().mockReturnValue(true);
-
-    // WHEN
-    await spotEventPluginClient.addPools(poolsCollection);
-
-    // THEN
-    // eslint-disable-next-line dot-notation
-    expect(spotEventPluginClient['deadlineClient'].GetRequest).toBeCalledTimes(requestsCount);
-
-    // eslint-disable-next-line dot-notation
-    expect(spotEventPluginClient['deadlineClient'].PostRequest).toBeCalledTimes(requestsCount);
-  });
 });


### PR DESCRIPTION
### Problem 
After creating and configuring a spot fleet via RFDK constructs `SpotEventPluginFleet` & `ConfigureSpotEventPlugin`, there is a requirement for manually creating deadline groups and pools before the spot fleet request can be created.

### Solution
 - Add requests to create Groups/Pools during SEP configuration

### Testing
 - Deployed fleet with two new groups and two new pools
 - Validated that groups and pools were created
 - Deployed updated configuration with two fleets where groups are different but with same one pool
 - Validated that new groups and pool created.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
