### PR TITLE
fix(core): increase lambda timeout for X509Certificate* constructs

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -201,7 +201,7 @@ abstract class X509CertificateBase extends Construct {
       runtime: Runtime.NODEJS_12_X,
       layers: [ openSslLayer ],
       handler: props.lambdaHandler,
-      timeout: Duration.seconds(30),
+      timeout: Duration.seconds(90),
       logRetention: RetentionDays.ONE_WEEK,
     });
     this.database.grantReadWriteData(this.lambdaFunc);


### PR DESCRIPTION
## Problem

Fixes #475

A customer reported experiencing deployment failures related to the `X509CertificatePem` construct. The Lambda timed out and the Cfn response was not received.

## Solution

Increase the Lambda function timeout for the `X509CertificatePem` and `X509CertificatePkcs` constructs.

## Testing

*   Deployed the `All-in-AWS-Infrastructure-Basic` example app
*   Confirmed the Lambda functions for the `X509Certificate*` constructs are deployed with 90 second timeouts
*   Confirmed none of the custom resources time out

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
