### PR TITLE
chore(deps): use jsii/superchain:node14 for rfdk development

### DIFF
--- a/scripts/rfdk_build_environment.sh
+++ b/scripts/rfdk_build_environment.sh
@@ -42,5 +42,5 @@ docker run --rm \
     ${USER_OPT} \
     --net=host -it \
     --env DOTNET_CLI_TELEMETRY_OPTOUT=1 \
-    jsii/superchain
+    jsii/superchain:node14
 


### PR DESCRIPTION
### Problem
Image `jsii/superchain` by default is using NodeJS 10.
We need to use NodeJS 14 in building environment script

### Testing
Built and pack our last code with this changes.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
