### PR TITLE
chore(integ): improve logging when refreshing credentials

### DIFF
--- a/integ/scripts/bash/run-e2e-automated.sh
+++ b/integ/scripts/bash/run-e2e-automated.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 refreshcreds() {
-    echo "Refreshing credentials"
+    echo "${1:-} Refreshing credentials"
     unset AWS_ACCESS_KEY_ID
     unset AWS_SECRET_ACCESS_KEY
     unset AWS_SESSION_TOKEN

--- a/integ/scripts/bash/tear-down.sh
+++ b/integ/scripts/bash/tear-down.sh
@@ -49,7 +49,7 @@ for COMPONENT in **/cdk.json; do
     fi
 done
 
-run_aws_interaction_hook
+run_aws_interaction_hook "$(timestamp)"
 
 cd "$INFRASTRUCTURE_APP" && npx cdk destroy "*" -f
 

--- a/integ/scripts/bash/tear-down.sh
+++ b/integ/scripts/bash/tear-down.sh
@@ -49,7 +49,7 @@ for COMPONENT in **/cdk.json; do
     fi
 done
 
-run_aws_interaction_hook "$(timestamp)"
+run_aws_interaction_hook "$(timestamp) [infrastructure]"
 
 cd "$INFRASTRUCTURE_APP" && npx cdk destroy "*" -f
 

--- a/integ/scripts/bash/teardown-infrastructure.sh
+++ b/integ/scripts/bash/teardown-infrastructure.sh
@@ -11,7 +11,7 @@ echo "$(timestamp) [infrastructure] destroy started"
 INFRASTRUCTURE_APP="$INTEG_ROOT/components/_infrastructure"
 cd "$INFRASTRUCTURE_APP"
 
-run_aws_interaction_hook
+run_aws_interaction_hook "$(timestamp) [infrastructure]"
 
 mkdir -p "${INTEG_TEMP_DIR}/infrastructure"
 


### PR DESCRIPTION
### Notes
- Enhances our logging when refreshing AWS credentials in our integration tests.

### Testing
- Ran the Repository integration tests and verified the refresh credential logs were enhanced.
<details><summary>RFDK Integration Test Logs</summary>

```
 Refreshing credentials
RFDK end-to-end integration tests started Fri Jul  9 17:04:42 UTC 2021
Setting test variables...
2021-07-09T17:04:43 [infrastructure] deployment started
2021-07-09T17:07:44 [infrastructure] deployment complete
2021-07-09T17:07:44 [deadline_01_repository] app deployment started
2021-07-09T17:07:44 [deadline_01_repository] synthesizing started
2021-07-09T17:07:44 [deadline_01_repository] Refreshing credentials
2021-07-09T17:08:06 [deadline_01_repository] synthesizing complete
2021-07-09T17:08:06 [deadline_01_repository] app deployment started
2021-07-09T17:08:06 [deadline_01_repository] Refreshing credentials
2021-07-09T17:08:06 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1625850283724726336] stack deployment started
2021-07-09T17:28:17 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1625850283724726336] stack deployment complete
2021-07-09T17:28:17 [deadline_01_repository] Refreshing credentials
2021-07-09T17:28:17 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1625850283724726336] stack deployment started
2021-07-09T17:32:53 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1625850283724726336] stack deployment complete
2021-07-09T17:32:53 [deadline_01_repository] app deployment complete
2021-07-09T17:32:53 [deadline_01_repository] running test suite started
2021-07-09T17:32:53 [deadline_01_repository] Refreshing credentials
2021-07-09T17:33:31 [deadline_01_repository] running test suite complete
2021-07-09T17:33:31 [deadline_01_repository] test suite passed
2021-07-09T17:33:31 [deadline_01_repository] app destroy started
2021-07-09T17:33:31 [deadline_01_repository] Refreshing credentials
2021-07-09T17:33:31 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1625850283724726336] stack destroy started
2021-07-09T17:35:49 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1625850283724726336] stack destroy complete
2021-07-09T17:35:49 [deadline_01_repository] Refreshing credentials
2021-07-09T17:35:50 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1625850283724726336] stack destroy started
2021-07-09T17:42:06 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1625850283724726336] stack destroy complete
2021-07-09T17:42:06 [deadline_01_repository] app destroy complete
2021-07-09T17:42:06 [infrastructure] destroy started
2021-07-09T17:42:06 [infrastructure] Refreshing credentials
2021-07-09T17:44:06 [infrastructure] destroy complete
Complete!
Pretest setup runtime: 0m 1s
Infrastructure stack deploy runtime: 3m 1s
Infrastructure stack cleanup runtime: 2m 0s

============================================================
[deadline_01_repository]: TEST REPORT
============================================================

Exit code: 0

----------------------------------------------
[deadline_01_repository]: Test output
----------------------------------------------

yarn run v1.22.10
$ jest deadline_01_repository.test --json --outputFile=/local/home/jericht/repositories/github/aws-rfdk/integ/.e2etemp/deadline_01_repository/test-report.json
PASS components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts (35.547 s)
  Deadline Repository tests (RFDK-created DB and EFS)
    DocumentDB tests
      ✓ DL-1-1: Deadline DB is initialized (3325 ms)
    EFS tests
      ✓ DL-1-2: EFS is initialized (1 ms)
      ✓ DL-1-3: repository.ini version matches Deadline installer
    CloudWatch LogGroup tests
      ✓ DL-1-4: CloudWatch LogGroup contains two LogStreams
      cloud-init-output LogStream tests
        ✓ DL-1-5: cloud-init-output is initialized
        ✓ DL-1-6: cloud-init-output does not contain INSTALLER_DB_ARGS (1 ms)
      DeadlineRepositoryInstallationLogs LogStream tests
        ✓ DL-1-7: DeadlineRepositoryInstallationLogs is initialized (1 ms)
  Deadline Repository tests (User-created DB and EFS)
    DocumentDB tests
      ✓ DL-2-1: Deadline DB is initialized (3274 ms)
    EFS tests
      ✓ DL-2-2: EFS is initialized
      ✓ DL-2-3: repository.ini version matches Deadline installer
    CloudWatch LogGroup tests
      ✓ DL-2-4: CloudWatch LogGroup contains two LogStreams
      cloud-init-output LogStream tests
        ✓ DL-2-5: cloud-init-output is initialized (1 ms)
        ✓ DL-2-6: cloud-init-output does not contain INSTALLER_DB_ARGS
      DeadlineRepositoryInstallationLogs LogStream tests
        ✓ DL-2-7: DeadlineRepositoryInstallationLogs is initialized (1 ms)
  Deadline Repository tests (User-created MongoDB)
    DocumentDB tests
      ✓ DL-3-1: Deadline DB is initialized (3308 ms)
    EFS tests
      ✓ DL-3-2: EFS is initialized
      ✓ DL-3-3: repository.ini version matches Deadline installer
    CloudWatch LogGroup tests
      ✓ DL-3-4: CloudWatch LogGroup contains two LogStreams
      cloud-init-output LogStream tests
        ✓ DL-3-5: cloud-init-output is initialized
        ✓ DL-3-6: cloud-init-output does not contain INSTALLER_DB_ARGS
      DeadlineRepositoryInstallationLogs LogStream tests
        ✓ DL-3-7: DeadlineRepositoryInstallationLogs is initialized

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        36.001 s
Ran all test suites matching /deadline_01_repository.test/i.
Test results written to: .e2etemp/deadline_01_repository/test-report.json
Done in 36.58s.

Results for test component deadline_01_repository: 
  -Tests ran:     21
  -Tests passed:  21
  -Tests failed:  0
  -Deploy runtime:     32m 54s
  -Test suite runtime: 0m 36s
  -Cleanup runtime:    -59m -8s

============================================================
[deadline_02_renderQueue]: TEST REPORT
============================================================

Exit code: 0


============================================================
[deadline_03_workerFleetHttp]: TEST REPORT
============================================================

Exit code: 0


============================================================
[deadline_04_workerFleetHttps]: TEST REPORT
============================================================

Exit code: 0

Cleaning up folders...
yarn run v1.22.10
$ ./scripts/bash/cleanup.sh
Done in 0.12s.
Exiting...
```

</details>

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
