### PR TITLE
fix(examples): change EFS access point for repository to use root

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
@@ -116,6 +116,14 @@ class StorageTier(Stack):
             removal_policy=RemovalPolicy.DESTROY
         )
 
+        # Initialize the UID and GID of the POSIX user that the Repository will be accessing the filesystem as.
+        # The Deadline Repository requires root access to the filesystem to perform the repository setup. If mounting this
+        # filesystem on a machine that does not require root access, you should use another access point with a different user.
+        repository_user = PosixUser(
+          uid='0',
+          gid='0'
+        )
+
         # Create an EFS access point that is used to grant the Repository and RenderQueue with write access to the
         # Deadline Repository directory in the EFS file-system.
         access_point = AccessPoint(
@@ -127,8 +135,8 @@ class StorageTier(Stack):
             # the owning UID/GID set as specified here. These should be set up to grant read and write access to the
             # UID/GID configured in the "poxis_user" property below.
             create_acl=Acl(
-                owner_uid='10000',
-                owner_gid='10000',
+                owner_uid=repository_user.uid,
+                owner_gid=repository_user.gid,
                 permissions='750',
             ),
 
@@ -139,10 +147,7 @@ class StorageTier(Stack):
             # these UID/GID values instead of those from the user on the system where the EFS is mounted. If you intend
             # to use the same EFS file-system for other purposes (e.g. render assets, plug-in storage), you may want to
             # evaluate the UID/GID permissions based on your requirements.
-            posix_user=PosixUser(
-                uid='10000',
-                gid='10000'
-            )
+            posix_user=repository_user
         )
 
         self.mountable_file_system = MountableEfs(

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -306,6 +306,9 @@ export interface RepositoryProps {
   /**
    * Specify the file system where the deadline repository needs to be initialized.
    *
+   * If using EFS access points, you must give access to the filesystem as the root user (UID=0 & GID=0)
+   * for the Deadline Repository setup to succeed.
+   *
    * If not providing a filesystem, then we will provision an Amazon EFS filesystem for you.
    * This filesystem will contain files for the Deadline Repository filesystem. It will also
    * contain 40GB of additional padding files (see RFDK's PadEfsStorage for details) to increase


### PR DESCRIPTION
### Notes
The [PR](https://github.com/aws/aws-rfdk/pull/461) that added integration with FSx for Lustre also added a step in the `Repository` installer script to `chown` the repository files. This broke the basic example app because it uses an EFS access point with a POSIX user that isn't root, causing the `chown` operations to fail.

This PR addresses this by changing the EFS access point in the basic example app to give access as root, with some added comments about using a different POSIX user when mounting to anything other than the Repository.

### Testing
- Deployed the Typescript app and verified the Repository installer script succeeded
- Deployed the Python app and verified the Repository installer script succeeded

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
