### PR TITLE
fix(deadline): change ownership of repository files when applicable

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
@@ -151,6 +151,13 @@ export class MountableBlockVolume implements IMountableLinuxFilesystem {
   }
 
   /**
+   * @inheritdoc
+   */
+  public usesUserPosixPermissions(): boolean {
+    return true;
+  }
+
+  /**
    * Grant required permissions to the target. The mounting script requires two permissions:
    * 1) Permission to describe the volume
    * 2) Permission to attach the volume

--- a/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
@@ -195,6 +195,22 @@ export class MountableEfs implements IMountableLinuxFilesystem {
   }
 
   /**
+   * @inheritdoc
+   */
+  public usesUserPosixPermissions(): boolean {
+    if (this.accessPoint) {
+      // We cannot determine if the access point forces a POSIX user in the import case
+      if (!(this.accessPoint instanceof efs.AccessPoint)) {
+        throw new Error(`MountableEfs.usesUserPosixPermissions() only supports efs.AccessPoint instances, got "${this.accessPoint.constructor.name}"`);
+      }
+
+      const accessPointResource = this.accessPoint.node.defaultChild as efs.CfnAccessPoint;
+      return !accessPointResource.posixUser;
+    }
+    return true;
+  }
+
+  /**
    * Uses a CDK escape-hatch to fetch the UID/GID of the access point POSIX user.
    *
    * @param accessPoint The access point to obtain the POSIX user for

--- a/packages/aws-rfdk/lib/core/lib/mountable-filesystem.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-filesystem.ts
@@ -65,4 +65,13 @@ export interface IMountableLinuxFilesystem {
    * @param mount  The directory, or drive letter, to mount the filesystem to.
    */
   mountToLinuxInstance(target: IMountingInstance, mount: LinuxMountPointProps): void;
+
+  /**
+   * Returns whether the mounted file-system evaluates the UID/GID of the system user accessing the file-system.
+   *
+   * Some network file-systems provide features to fix a UID/GID for all access to the mounted file-system and ignore
+   * the system user accessing the file. If this is the case, an implementing class must indicate this in the return
+   * value.
+   */
+  usesUserPosixPermissions(): boolean;
 }

--- a/packages/aws-rfdk/lib/core/lib/mountable-fsx-lustre.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-fsx-lustre.ts
@@ -109,6 +109,13 @@ export class MountableFsxLustre implements IMountableLinuxFilesystem {
   }
 
   /**
+   * @inheritdoc
+   */
+  public usesUserPosixPermissions(): boolean {
+    return true;
+  }
+
+  /**
    * Fetch the Asset singleton for the FSx for Lustre mounting scripts, or generate it if needed.
    */
   protected mountAssetSingleton(scope: IConstruct): Asset {

--- a/packages/aws-rfdk/lib/core/test/mountable-ebs.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-ebs.test.ts
@@ -309,4 +309,17 @@ describe('Test MountableBlockVolume', () => {
     expect(matches).toHaveLength(2);
     expect(matches[0]).toBe(matches[1]);
   });
+
+  test('.usesUserPosixPermissions() is true', () => {
+    // GIVEN
+    const mount1 = new MountableBlockVolume(ebsVol, {
+      blockVolume: ebsVol,
+    });
+
+    // WHEN
+    const usesUserPosixPermissions = mount1.usesUserPosixPermissions();
+
+    // THEN
+    expect(usesUserPosixPermissions).toEqual(true);
+  });
 });

--- a/packages/aws-rfdk/lib/core/test/mountable-fsx-lustre.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-fsx-lustre.test.ts
@@ -199,4 +199,17 @@ describe('MountableFsxLustre', () => {
     // THEN
     expect(userData).toMatch(new RegExp(escapeTokenRegex(`bash ./mountFsxLustre.sh \${Token[TOKEN.\\d+]} /mnt/fsx/fs1 \${Token[TOKEN.\\d+]}/${fileset} rw`)));
   });
+
+  test('.usesUserPosixPermissions() is true', () => {
+    // GIVEN
+    const mount = new MountableFsxLustre(fs, {
+      filesystem: fs,
+    });
+
+    // WHEN
+    const usesUserPosixPermissions = mount.usesUserPosixPermissions();
+
+    // THEN
+    expect(usesUserPosixPermissions).toEqual(true);
+  });
 });

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -676,7 +676,9 @@ export class Repository extends Construct implements IRepository {
       repositoryInstallationPath,
       props.version,
       props.repositorySettings,
-      Repository.REPOSITORY_OWNER,
+      // Change ownership of the Deadline repository files if-and-only-if the mounted file-system
+      // uses the POSIX permissions based on the process' user UID/GID
+      this.fileSystem.usesUserPosixPermissions() ? Repository.REPOSITORY_OWNER : undefined,
     );
 
     this.configureSelfTermination();

--- a/packages/aws-rfdk/lib/deadline/test/repository.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/repository.test.ts
@@ -1225,11 +1225,15 @@ test('imports repository settings', () => {
   expect(installerGroup.userData.render()).toContain(`aws s3 cp '${repositorySettings.s3ObjectUrl}'`);
 });
 
-test('changes ownership of repository files', () => {
+test('IFileSystem.usesUserPosixPermissions() = true changes ownership of repository files', () => {
   // GIVEN
   const repo = new Repository(stack, 'Repository', {
     version,
     vpc,
+    fileSystem: {
+      mountToLinuxInstance: (_target, _mount) => {},
+      usesUserPosixPermissions: () => true,
+    },
   });
 
   // WHEN
@@ -1237,4 +1241,22 @@ test('changes ownership of repository files', () => {
 
   // THEN
   expect(script).toMatch('-o 1000:1000');
+});
+
+test('IFileSystem.usesUserPosixPermissions() = false does not change ownership of repository files', () => {
+  // GIVEN
+  const repo = new Repository(stack, 'Repository', {
+    version,
+    vpc,
+    fileSystem: {
+      mountToLinuxInstance: (_target, _mount) => {},
+      usesUserPosixPermissions: () => false,
+    },
+  });
+
+  // WHEN
+  const script = (repo.node.defaultChild as AutoScalingGroup).userData.render();
+
+  // THEN
+  expect(script).not.toMatch('-o 1000:1000');
 });

--- a/packages/aws-rfdk/lib/deadline/test/repository.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/repository.test.ts
@@ -1225,7 +1225,7 @@ test('imports repository settings', () => {
   expect(installerGroup.userData.render()).toContain(`aws s3 cp '${repositorySettings.s3ObjectUrl}'`);
 });
 
-test('IFileSystem.usesUserPosixPermissions() = true changes ownership of repository files', () => {
+test('IMountableLinuxFilesystem.usesUserPosixPermissions() = true changes ownership of repository files', () => {
   // GIVEN
   const repo = new Repository(stack, 'Repository', {
     version,

--- a/packages/aws-rfdk/lib/deadline/test/repository.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/repository.test.ts
@@ -1243,7 +1243,7 @@ test('IMountableLinuxFilesystem.usesUserPosixPermissions() = true changes owners
   expect(script).toMatch('-o 1000:1000');
 });
 
-test('IFileSystem.usesUserPosixPermissions() = false does not change ownership of repository files', () => {
+test('IMountableLinuxFilesystem.usesUserPosixPermissions() = false does not change ownership of repository files', () => {
   // GIVEN
   const repo = new Repository(stack, 'Repository', {
     version,


### PR DESCRIPTION
BREAKING CHANGE: MountableEfs will not work with the Repository construct when
created with an imported EFS Access Point

## Problem

In #461, the `Repository` construct's user-data script was modified to run `chown` to change the ownership of the Deadline Repository files. When [`MountableEfs`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.MountableEfs.html) is used with an EFS Access Point that fixes the POSIX user, the `chown` operation fails.

This is a breaking change for any users that have adopted what we demonstrate in the `All-In-AWS-Infrastructure-Basic` example app:

https://github.com/aws/aws-rfdk/blob/b83c0e0823ef94e9df44112e194bc1bb2bf9e25a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts#L105-L139

## Solution

Added a new method to the `IMountableLinuxFilesystem` interface (TypeScript: `.usesUserPosixPermissions()`) Python: `.uses_user_posix_permissions()`) shared by `MountableEfs` / `MountableFsxLustre` / `MountableBlockVolume` to be able to query at synthesis-time whether the mounted file-system uses the POSIX user permission of the host system. In the case described in the problem, `MountableEfs` returns `false` when an EFS access point is provided with a fixed POSIX user. All other `Mountable*` classes return `true`.

---

**NOTE:** EFS Access Points do not require a POSIX user to be specified and there is no way to determine whether an imported EFS Access Point (e.g. [`AccessPoint.fromAccessPointId(...)`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-efs.AccessPoint.html#static-fromwbraccesswbrpointwbridscope-id-accesspointid)) has a POSIX user. For this reason, the imported access points will throw an exception when calling `.usesUserPosixPermissions()`. Otherwise, if we add the `chown` command with an access point, deployment will fail. If we omit the `chown` without the access point, the `RenderQueue` will not have file-system permissions to the Deadline Repository files.

This is why we are considering this a breaking change, since prior to the introduction of the `chown` operation, imported EFS Access Points were supported.

---

The `Repository` construct now uses this method to determine whether it needs to change the ownership of the Deadline Repository files after the install completes.

## Testing

1.  Deployed the `All-In-AWS-Infrastructure-Basic` example app in this repository in its current form (EFS with an access point fixing the POSIX user) and verified that:
    1.  the deployment (and repository installation) succeeds.
    2.  connected a Monitor to the farm, and submitted a ping job and confirmed the render completes and task logs can be viewed (verifies repository file-system permissions are correct for the `RenderQueue`)
    3.  from the bastion, inspected the mounted EFS file-system and confirmed the Deadline Repository files are owned by UID/GID of `10000:10000` as specified by the access point.
1.  Modified the `All-In-AWS-Infrastructure-Basic` example app to use an FSx Lustre file-system for the Deadline Repository and verified that:
    1.  the deployment (and repository installation) succeeds.
    2.  connected a Monitor to the farm, and submitted a ping job and confirmed the render completes and task logs can be viewed (verifies repository file-system permissions are correct for the `RenderQueue`)
    3.  from the bastion, inspected the mounted FSx file-system and confirmed the Deadline Repository files are owned by UID/GID of `1000:1000` as the `Repository` construct is expected to `chown` the files for proper POSIX access by the `RenderQueue`.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
