### PR TITLE
fix(deadline): fix issue in client TLS configuration for Deadline 10.1.18.5

### DIFF
--- a/integ/components/deadline/common/scripts/bastion/utils/configure-deadline.sh
+++ b/integ/components/deadline/common/scripts/bastion/utils/configure-deadline.sh
@@ -23,8 +23,7 @@ if [ -d "$CERT" ]; then
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxyUseSSL True
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxySSLCA "$CERT/ca-cert.crt"
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ClientSSLAuthentication NotRequired
-  # Set Deadline to use repository connection validated by TLS; ChangeRepositorySkipValidation is a workaround that saves the values without testing them
-  sudo $DEADLINE/deadlinecommand ChangeRepositorySkipValidation Proxy $ENDPOINT "$CERT/ca-cert.crt" >/dev/null
+  sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxyRoot $ENDPOINT
 
 else
   # Non-TLS connections can connect to the repository directly

--- a/packages/aws-rfdk/lib/deadline/scripts/python/client-rq-connection.py
+++ b/packages/aws-rfdk/lib/deadline/scripts/python/client-rq-connection.py
@@ -173,7 +173,7 @@ def configure_deadline( config ):
             print("Testing Deadline connection...")
             stdout.flush()
             try:
-                call_deadline_command(['GetJobs'])
+                call_deadline_command(['GetRepositoryVersion'])
             except Exception as e:
                 print('Deadline connection error: %s' % e)
             print("Deadline connection configured correctly")

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -51,8 +51,8 @@ export const REPO_DC_ASSET = {
 };
 
 export const RQ_CONNECTION_ASSET = {
-  Bucket: 'AssetParameters74fd6cba5cebe5a13738b535ab6b010a0fe1154689bad4df3ef49ed7bddc1075S3Bucket0337801D',
-  Key: 'AssetParameters74fd6cba5cebe5a13738b535ab6b010a0fe1154689bad4df3ef49ed7bddc1075S3VersionKey144181B5',
+  Bucket: 'AssetParametersfd2517b91b53ebe13fa425370792a214fe2d9ca5fef04190186c1e20f77e338dS3Bucket006428E9',
+  Key: 'AssetParametersfd2517b91b53ebe13fa425370792a214fe2d9ca5fef04190186c1e20f77e338dS3VersionKey1CB2D684',
 };
 
 export function linuxCloudWatchScriptBoilerplate(scriptParams: string) {


### PR DESCRIPTION
## Problem

The behavior of the `ChangeRepository[SkipValidation]` Deadline command in 10.1.18.5 has changed. It now clears the `ProxySSLCA` setting in `deadline.ini` before attempting to apply/validate the configuration. RFDK relied on the previous behavior where the `ProxySSLCA` was left unchanged.

## Solution

We cannot use `ChangeRepository` without supplying a "client certificate" since this will disable TLS. Instead, we have switched from using `ChangeRepository` to instead use `SetIniFileSetting ProxyRoot <RQ_ENDPOINT>` .  RFDK also relied on having `ChangeRepository` validate the connection and error if the connection settings were incorrect. We now change that validation to instead run a separate Deadline command to test the connection.

We made the same change to the Deadline configuration script that runs on the RFDK integ tests.

## Testing

**WIP...**

Proposed test plan:

1.  Deploy the `All-in-AWS-Basic` example app using staged recipes for Deadline `10.1.18.5` and Deadline 10.1.18.5 AWS Portal AMIs. Confirm that the deploy succeeds and Workers are connected properly to Deadline. Repeat for Linux/Windows workers and for pre-`10.1.18` Worker AMIs.
2.  Run the RFDK integ tests and confirm they pass for both pre `10.1.18` and `10.1.18.5`


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
