### PR TITLE
fix(deadline): fix issue in client TLS configuration for Deadline 10.1.18.5

### DIFF
--- a/integ/components/deadline/common/scripts/bastion/utils/configure-deadline.sh
+++ b/integ/components/deadline/common/scripts/bastion/utils/configure-deadline.sh
@@ -21,10 +21,10 @@ if [ -d "$CERT" ]; then
 
   # Set up client connection settings for TLS by altering ini file with deadlinecommand
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxyUseSSL True
+  sudo $DEADLINE/deadlinecommand SetIniFileSetting ConnectionType Remote
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxySSLCA "$CERT/ca-cert.crt"
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ClientSSLAuthentication NotRequired
-  # Set Deadline to use repository connection validated by TLS; ChangeRepositorySkipValidation is a workaround that saves the values without testing them
-  sudo $DEADLINE/deadlinecommand ChangeRepositorySkipValidation Proxy $ENDPOINT "$CERT/ca-cert.crt" >/dev/null
+  sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxyRoot $ENDPOINT
 
 else
   # Non-TLS connections can connect to the repository directly

--- a/packages/aws-rfdk/lib/deadline/scripts/python/client-rq-connection.py
+++ b/packages/aws-rfdk/lib/deadline/scripts/python/client-rq-connection.py
@@ -12,7 +12,7 @@ import errno
 import os
 import re
 import subprocess
-from sys import platform
+from sys import platform, stdout
 
 import boto3
 
@@ -133,8 +133,8 @@ def configure_deadline( config ):
 
     # Ensure that the client is configured to connect to a Remote RCS.
     call_deadline_command(['SetIniFileSetting', 'ConnectionType', 'Remote'])
+    call_deadline_command(['SetIniFileSetting', 'ProxyRoot', config.render_queue.address])
 
-    repo_args = ['ChangeRepository','Proxy',config.render_queue.address]
     if config.render_queue.scheme == 'http':
         print( "Configuring Deadline to connect to the Render Queue (%s) using HTTP Traffic" % config.render_queue.address )
         #Ensure SSL is disabled
@@ -144,7 +144,7 @@ def configure_deadline( config ):
 
     else:
         print("Configuring Deadline to connect to the Render Queue using HTTPS Traffic")
-        call_deadline_command(['SetIniFileSetting','ProxyUseSSL','True'])
+        call_deadline_command(['SetIniFileSetting', 'ProxyUseSSL', 'True'])
 
         try:
             os.makedirs(CERT_DIR)
@@ -168,7 +168,13 @@ def configure_deadline( config ):
 
             call_deadline_command(['SetIniFileSetting', 'ProxySSLCA', cert_path])
             call_deadline_command(['SetIniFileSetting', 'ClientSSLAuthentication', 'NotRequired'])
-            repo_args.append(cert_path)
+
+            # Validate Deadline connection
+            print("Testing Deadline connection...")
+            stdout.flush()
+            call_deadline_command(['GetRepositoryVersion'])
+
+            print("Deadline connection configured correctly")
         else:
             """
             If we are configuring Deadline to connect using a client cert we need to:
@@ -182,17 +188,17 @@ def configure_deadline( config ):
             with open(cert_path, 'wb') as f:
                 f.write(cert_contents)
 
-            call_deadline_command(['SetIniFileSetting', 'ProxySSLCA', cert_path])
             call_deadline_command(['SetIniFileSetting', 'ClientSSLAuthentication', 'Required'])
+
+            repo_args = ['ChangeRepository', 'Proxy', config.render_queue.address]
             repo_args.append(cert_path)
             if config.client_tls_cert_passphrase:
                 passphrase = fetch_secret(config.client_tls_cert_passphrase)
                 repo_args.append(passphrase)
 
-    change_repo_results = call_deadline_command(repo_args)
-    if change_repo_results.startswith('Deadline configuration error:'):
-        print(change_repo_results)
-        raise Exception(change_repo_results)
+            change_repo_results = call_deadline_command(repo_args)
+            print('Running: %s\nResult: %s' % (repo_args, change_repo_results))
+
 
 def call_deadline_command(arguments):
     """
@@ -208,6 +214,8 @@ def call_deadline_command(arguments):
         raise Exception('Failed to call Deadline.')
 
     output, errors = proc.communicate()
+    if proc.returncode != 0:
+        raise ValueError('DeadlineCommandError: \n%s\n%s' % (output, errors))
     return output
 
 def get_deadline_command():

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -51,8 +51,8 @@ export const REPO_DC_ASSET = {
 };
 
 export const RQ_CONNECTION_ASSET = {
-  Bucket: 'AssetParameters74fd6cba5cebe5a13738b535ab6b010a0fe1154689bad4df3ef49ed7bddc1075S3Bucket0337801D',
-  Key: 'AssetParameters74fd6cba5cebe5a13738b535ab6b010a0fe1154689bad4df3ef49ed7bddc1075S3VersionKey144181B5',
+  Bucket: 'AssetParametersb61797635329f0b0ec0b710b31d49f0e41c1936849266d8a9aed82e1616c9077S3Bucket4D5EEE4A',
+  Key: 'AssetParametersb61797635329f0b0ec0b710b31d49f0e41c1936849266d8a9aed82e1616c9077S3VersionKey9B7B46A0',
 };
 
 export function linuxCloudWatchScriptBoilerplate(scriptParams: string) {


### PR DESCRIPTION
I applied a fix to [this draft PR](https://github.com/aws/aws-rfdk/pull/537) to get the integ tests to pass, so I've created a new PR from my fork.

## Problem

The behavior of the `ChangeRepository[SkipValidation]` Deadline command in 10.1.18.5 has changed. It now clears the `ProxySSLCA` setting in `deadline.ini` before attempting to apply/validate the configuration. RFDK relied on the previous behavior where the `ProxySSLCA` was left unchanged.

## Solution

We cannot use `ChangeRepository` without supplying a "client certificate" since this will disable TLS. Instead, we have switched from using `ChangeRepository` to instead use `SetIniFileSetting ProxyRoot <RQ_ENDPOINT>` .  RFDK also relied on having `ChangeRepository` validate the connection and error if the connection settings were incorrect. We now change that validation to instead run a separate Deadline command to test the connection.

We made the same change to the Deadline configuration script that runs on the RFDK integ tests.

## Testing

The RFDK integ tests are now passing using the Deadline Client 10.1.18.5 to stage the Docker recipes and the `Deadline Worker Base Image Windows 10.1.18.5 2021-07-30T215517Z - ami-0d5da435a9d85896b` AMI for the worker fleets. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
