### PR TITLE
fix(deadline): reinstall repository even if version is not changed

### DIFF
--- a/packages/aws-rfdk/lib/deadline/scripts/bash/installDeadlineRepository.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/installDeadlineRepository.sh
@@ -82,8 +82,7 @@ if test -f "$REPOSITORY_FILE_PATH"; then
     # The proper way to achieve this is to use a ini config manager tool to get the value of required key.
     source $REPOSITORY_FILE_PATH > /dev/null 2>&1 || true
     if [[ "$Version" = "$DEADLINE_REPOSITORY_VERSION" ]]; then
-        echo "Repository version $DEADLINE_REPOSITORY_VERSION already exists at path $REPOSITORY_FILE_PATH. Not proceeding with Repository installation."
-        exit 0
+        echo "Repository version $DEADLINE_REPOSITORY_VERSION already exists at path $REPOSITORY_FILE_PATH."
     else
         SplitVersion=(${Version//./ })
         SplitRepoVersion=(${DEADLINE_REPOSITORY_VERSION//./ })


### PR DESCRIPTION
### Problem
With current logic we are not able enable Secret Management or change other repository settings without updating repository version.

### Solution
Allowing run repository installation even when repository version wasn't changed.

### Testing
- Deploying RFDK version without enabled SM
- Updating farm with enabled SM
- Make sure that SM was enabled.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
