### PR TITLE
fix(integ): add special case in repository tests for deadline 10.1.18.5

### DIFF
--- a/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
+++ b/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
@@ -198,7 +198,7 @@ describe.each(testCases)('Deadline Repository tests (%s)', (_, id) => {
           expectedVersion = deadlineVersion!;
           break;
       }
-      const regex = new RegExp('\\[DeadlineRepository\\]\nVersion=' + expectedVersion);
+      const regex = new RegExp('\\[DeadlineRepository\\]\nVersion=' + expectedVersion.replace('.', '\\.'));
       expect(output).toEqual(expect.stringMatching(regex));
     });
   });

--- a/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
+++ b/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
@@ -187,7 +187,18 @@ describe.each(testCases)('Deadline Repository tests (%s)', (_, id) => {
        * Input:           Output from command to print contents of repository.ini delivered via SSM command
        * Expected result: Contents of repository.ini matches a regex string indicating the correct version number
       **********************************************************************************************************/
-      var regex = new RegExp('\\[DeadlineRepository\\]\nVersion=' + deadlineVersion);
+      let expectedVersion: string;
+      switch (deadlineVersion) {
+        // Special case for Deadline 10.1.18.5 since it appears as 10.1.18.4 due to known issues in Deadline's build pipeline
+        case '10.1.18.5':
+          expectedVersion = '10.1.18.4';
+          break;
+
+        default:
+          expectedVersion = deadlineVersion!;
+          break;
+      }
+      const regex = new RegExp('\\[DeadlineRepository\\]\nVersion=' + expectedVersion);
       expect(output).toEqual(expect.stringMatching(regex));
     });
   });


### PR DESCRIPTION
Adds a special case in the Repository integration tests for Deadline 10.1.18.5, since it appears as Deadline 10.1.18.4 due to known issues in Deadline's build pipeline

### Testing
Ran the repository integration tests and verified they succeeded

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
