### PR TITLE
chore(deadline): add secrets management documentation

### DIFF
--- a/packages/aws-rfdk/docs/upgrade/index.md
+++ b/packages/aws-rfdk/docs/upgrade/index.md
@@ -6,3 +6,4 @@ upgrading to (or beyond) a version listed below, you should consult the the link
 
 *   [`0.27.x`](./upgrading-0.27.md)
 *   [`0.37.x`](./upgrading-0.37.md)
+*   [`0.38.x`](./upgrading-0.38.md)

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
@@ -1,0 +1,53 @@
+# Upgrading to RFDK v0.38.x or Newer
+
+Starting in RFDK v0.38.0, [Deadline Secrets Management](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) will be enabled on the
+`Repository` and `RenderQueue` constructs by default when using Deadline 10.1.18 and later. This can cause some issues with existing farm configurations because Deadline Secrets Management requires:
+
+- The internal protocol on the Render Queue to be HTTPS
+- The external protocol on the Render Queue to be HTTPS
+
+Additionally, if you plan on upgrading to RFDK 0.38 or newer and Deadline 10.1.18 or newer, but do **not** want to enable Deadline Secrets Management, you may have to make changes to your RFDK application so that
+RFDK does not automatically configure Deadline Secrets Management on your farm.
+
+## Upgrading Farms and Enabling Deadline Secrets Management
+
+---
+
+_This section describes how to upgrade your RFDK farm while also enabling Deadline Secrets Management. If you would **not** like to enable Deadline Secrets Management, please skip to the
+next section "Upgrading Farms Without Enabling Deadline Secrets Management"._
+
+---
+
+To determine whether your `RenderQueue` is using HTTPS for internal and external protocols, you need to check what values you have set
+for the [`trafficEncryption`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.RenderQueue.html#trafficencryption) property.
+Your `RenderQueue` is using HTTPS for internal and external protocols if one of the following is true:
+
+1. You have not specified the `trafficEncryption` property for the `RenderQueue`
+2. You have specified the `trafficEncryption` property for the `RenderQueue` and the following are true:
+    1. The `internalProtocol` is `ApplicationProtocol.HTTPS`
+    2. One of the following is true for the `externalTLS` property:
+        1. `enabled` is `true`
+        2. There are values for both `acmCertificate` and `acmCertificateChain`
+        3. There is a value for `rfdkCertificate`
+
+If the above is true, all you need to do to enable Deadline Secrets Management is redeploy your RFDK application.
+
+If your `RenderQueue` is not using HTTPS for its internal and/or external protocols as described above, you will need to satisfy the conditions above before deploying your farm so that
+RFDK can successfully configure Deadline Secrets Management for you.
+
+## Upgrading Farms Without Enabling Deadline Secrets Management
+
+We highly recommend enabling Deadline Secrets Management on your render farm for the additional layer of security. However, if you would still like to upgrade your farm without enabling
+Deadline Secrets Management, you can do so by setting the `secretsManagementSettings` property of the `Repository` construct:
+
+```ts
+const repository = new Repository(this, 'Repository', {
+  vpc,
+  version,
+  secretsManagementSettings: {
+    enabled: false,
+  },
+});
+```
+
+With this set, neither the `Repository` or `RenderQueue` constructs will attempt to configure Deadline Secrets Management for you.

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
@@ -3,8 +3,8 @@
 Starting in RFDK v0.38.0, [Deadline Secrets Management](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) will be enabled on the
 `Repository` and `RenderQueue` constructs by default when using Deadline 10.1.19 and later. This can cause some issues with existing farm configurations because Deadline Secrets Management requires:
 
-- The internal protocol on the Render Queue to be HTTPS
-- The external protocol on the Render Queue to be HTTPS
+- The internal protocol on the Render Queue to be HTTPS ("internal" refers to traffic between the Deadline Remote Connection Server and the Render Queue's load balancer)
+- The external protocol on the Render Queue to be HTTPS ("external" refers to traffic between the Render Queue's load balancer and clients)
 
 Additionally, if you plan on upgrading to RFDK 0.38 or newer and Deadline 10.1.19 or newer, but do **not** want to enable Deadline Secrets Management, you may have to make changes to your RFDK application so that
 RFDK does not automatically configure Deadline Secrets Management on your farm.
@@ -17,6 +17,9 @@ _This section describes how to upgrade your RFDK farm while also enabling Deadli
 next section "Upgrading RFDK Without Enabling Deadline Secrets Management"._
 
 ---
+
+The first step to making sure you are ready to enable Deadline Secrets Management is to make sure you have HTTPS enabled on the `RenderQueue` for both the internal and external protocols.
+If you are upgrading from a version prior to 0.37, you should refer to the [v0.37 upgrade documentation](./upgrading-0.37.md) for details about how the `RenderQueue` will default to using HTTPS.
 
 Your `RenderQueue` will use HTTPS for both internal and external protocols for RFDK 0.38.0 if **EITHER** of the following are true:
 

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
@@ -14,7 +14,7 @@ RFDK does not automatically configure Deadline Secrets Management on your farm.
 ---
 
 _This section describes how to upgrade your RFDK farm while also enabling Deadline Secrets Management. If you would **not** like to enable Deadline Secrets Management, please skip to the
-next section "Upgrading Farms Without Enabling Deadline Secrets Management"._
+next section "Upgrading RFDK Without Enabling Deadline Secrets Management"._
 
 ---
 
@@ -29,9 +29,6 @@ Your `RenderQueue` will use HTTPS for both internal and external protocols for R
         1. You **HAVE NOT** specified the `trafficEncryption.externalTLS` (TypeScript) / `traffic_encryption.external_tls` (Python)
         1. You **HAVE NOT** specified `trafficEncryption.externalTLS.enabled` (TypeScript) / `traffic_encryption.external_tls.enabled` (Python)
         1. You **HAVE** specified `trafficEncryption.externalTLS.enabled` (TypeScript) / `traffic_encryption.external_tls.enabled` (Python) and it is set to `true` (TypeScript) / `True` (Python)
-
-If you have determined that your `RenderQueue` will use HTTPS for both internal and external protocols in RFDK 0.38.0, then all you need to do to enable Deadline Secrets Management is to upgrade
-your RFDK application to use 0.38.0 and re-deploy.
 
 The below example code snippets demonstrate what each case above may look like:
 
@@ -222,6 +219,9 @@ RenderQueue(self, 'RenderQueue',
 ```
 
 </details>
+
+If you have determined that your `RenderQueue` will use HTTPS for both internal and external protocols in RFDK 0.38.0, then all you need to do to enable Deadline Secrets Management is to upgrade
+your RFDK application to use RFDK `0.38.x` and Deadline `10.1.19.x` or higher and re-deploy.
 
 
 ## Upgrading RFDK Without Enabling Deadline Secrets Management

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
@@ -223,9 +223,14 @@ RenderQueue(self, 'RenderQueue',
 
 </details>
 
-If you have determined that your `RenderQueue` will use HTTPS for both internal and external protocols in RFDK 0.38.0, then all you need to do to enable Deadline Secrets Management is to upgrade
-your RFDK application to use RFDK `0.38.x` and Deadline `10.1.19.x` or higher and re-deploy.
+If you have determined that your `RenderQueue` will use HTTPS for both internal and external protocols in RFDK 0.38.0, then the next steps are to determine:
 
+- If you would like to set up your own administrator credentials for Deadline Secrets Management or let RFDK generate them for you
+- If you should restructure your VPC to use dedicated subnets for different constructs.
+
+More details on these considerations can be found in the [RFDK Deadline readme](../../lib/deadline/README.md).
+
+Finally, all you need to do to enable Deadline Secrets Management is to upgrade your RFDK application to use RFDK `0.38.x` and Deadline `10.1.19.x` or higher and re-deploy.
 
 ## Upgrading RFDK Without Enabling Deadline Secrets Management
 

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
@@ -22,7 +22,7 @@ To determine whether your `RenderQueue` is using HTTPS for internal and external
 for the [`trafficEncryption`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.RenderQueue.html#trafficencryption) property.
 Your `RenderQueue` is using HTTPS for internal and external protocols if one of the following is true:
 
-1. You have not specified the `trafficEncryption` property for the `RenderQueue`
+1. You have not specified the `trafficEncryption` or the `trafficEncryption.externalTLS` property for the `RenderQueue`
 2. You have specified the `trafficEncryption` property for the `RenderQueue` and the following are true:
     1. The `internalProtocol` is `ApplicationProtocol.HTTPS`
     2. One of the following is true for the `externalTLS` property:
@@ -35,11 +35,155 @@ If the above is true, all you need to do to enable Deadline Secrets Management i
 If your `RenderQueue` is not using HTTPS for its internal and/or external protocols as described above, you will need to satisfy the conditions above before deploying your farm so that
 RFDK can successfully configure Deadline Secrets Management for you.
 
+The below example code snippets demonstrate what each case above may look like:
+
+<details><summary><b>Typescript</b> (click to expand)</summary>
+
+```ts
+import { ApplicationProtocol } from '@aws-cdk/aws-elasticloadbalancingv2';
+import { RenderQueue } from 'aws-rfdk/deadline';
+
+new RenderQueue(this, 'RenderQueue', {
+  // no "trafficEncryption" property, so TLS is enabled externally by default
+  // ...
+});
+
+// OR
+
+new RenderQueue(this, 'RenderQueue', {
+  // ...
+  trafficEncryption: {
+    internalProtocol: ApplicationProtocol.HTTPS,
+    // No "externalTLS" property, so TLS is enabled externally by default
+  },
+  // ...
+});
+
+// OR
+
+new RenderQueue(this, 'RenderQueue', {
+  // ...
+  trafficEncryption: {
+    internalProtocol: ApplicationProtocol.HTTPS,
+    externalTLS: {
+      enabled: true,
+    },
+  },
+  // ...
+});
+
+// OR
+
+const certificate = // ...your ACM certificate
+const certificateChain = // ...your ACM certificate chain
+new RenderQueue(this, 'RenderQueue', {
+  // ...
+  trafficEncryption: {
+    internalProtocol: ApplicationProtocol.HTTPS,
+    externalTLS: {
+      acmCertificate: certificate,
+      acmCertificateChain: certificateChain,
+    },
+  },
+  // ...
+});
+
+// OR
+
+const certificate = // ...your X509 RFDK certificate
+new RenderQueue(this, 'RenderQueue', {
+  // ...
+  trafficEncryption: {
+    internalProtocol: ApplicationProtocol.HTTPS,
+    externalTLS: {
+      rfdkCertificate: certificate,
+    },
+  },
+  // ...
+});
+```
+
+</details>
+
+<details><summary><b>Python</b> (click to expand)</summary>
+
+```python
+from aws_cdk.aws_elasticloadbalancingv2 import ApplicationProtocol
+from aws_rfdk.deadline import (
+    RenderQueue,
+    RenderQueueExternalTLSProps,
+    RenderQueueTrafficEncryptionProps,
+)
+
+RenderQueue(self, 'RenderQueue',
+  # no "traffic_encryption" property, so TLS is enabled externally by default
+  # ...
+)
+
+# OR
+
+RenderQueue(self, 'RenderQueue',
+  # ...
+  traffic_encryption=RenderQueueTrafficEncryptionProps(
+    internal_protocol=ApplicationProtocol.HTTPS,
+    # No "external_tls" property, so TLS is enabled externally by default
+  ),
+  # ...
+)
+
+# OR
+
+RenderQueue(self, 'RenderQueue',
+  # ...
+  traffic_encryption=RenderQueueTrafficEncryptionProps(
+    internal_protocol=ApplicationProtocol.HTTPS,
+    external_tls=RenderQueueExternalTLSProps(
+      enabled=True,
+    ),
+  ),
+  # ...
+)
+
+# OR
+
+certificate = # ...your ACM certificate
+certificate_chain = # ...your ACM certificate chain
+RenderQueue(self, 'RenderQueue',
+  # ...
+  traffic_encryption=RenderQueueTrafficEncryptionProps(
+    internal_protocol=ApplicationProtocol.HTTPS,
+    external_tls=RenderQueueExternalTLSProps(
+      acmCertificate=certificate,
+      acmCertificateChain=certificate_chain,
+    ),
+  ),
+  # ...
+)
+
+# OR
+
+certificate = # ...your X509 RFDK certificate
+RenderQueue(self, 'RenderQueue',
+  # ...
+  traffic_encryption=RenderQueueTrafficEncryptionProps(
+    internal_protocol=ApplicationProtocol.HTTPS,
+    external_tls=RenderQueueExternalTLSProps(
+      rfdk_certificate=certificate,
+    ),
+  ),
+  # ...
+)
+```
+
+</details>
+
+
 ## Upgrading Farms Without Enabling Deadline Secrets Management
 
 We highly recommend enabling Deadline Secrets Management on your render farm for the additional layer of security. However, if you would still like to upgrade your farm without enabling
 Deadline Secrets Management, you can do so by setting the `secretsManagementSettings` property of the `Repository` construct:
 
+**Typescript:**
 ```ts
 const repository = new Repository(this, 'Repository', {
   vpc,
@@ -48,6 +192,17 @@ const repository = new Repository(this, 'Repository', {
     enabled: false,
   },
 });
+```
+
+**Python:**
+```python
+repository = Repository(self, 'Repository',
+  vpc=vpc,
+  version=version,
+  secrets_management_settings=SecretsManagementProps(
+    enabled=False,
+  ),
+)
 ```
 
 With this set, neither the `Repository` or `RenderQueue` constructs will attempt to configure Deadline Secrets Management for you.

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md
@@ -1,15 +1,15 @@
 # Upgrading to RFDK v0.38.x or Newer
 
 Starting in RFDK v0.38.0, [Deadline Secrets Management](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) will be enabled on the
-`Repository` and `RenderQueue` constructs by default when using Deadline 10.1.18 and later. This can cause some issues with existing farm configurations because Deadline Secrets Management requires:
+`Repository` and `RenderQueue` constructs by default when using Deadline 10.1.19 and later. This can cause some issues with existing farm configurations because Deadline Secrets Management requires:
 
 - The internal protocol on the Render Queue to be HTTPS
 - The external protocol on the Render Queue to be HTTPS
 
-Additionally, if you plan on upgrading to RFDK 0.38 or newer and Deadline 10.1.18 or newer, but do **not** want to enable Deadline Secrets Management, you may have to make changes to your RFDK application so that
+Additionally, if you plan on upgrading to RFDK 0.38 or newer and Deadline 10.1.19 or newer, but do **not** want to enable Deadline Secrets Management, you may have to make changes to your RFDK application so that
 RFDK does not automatically configure Deadline Secrets Management on your farm.
 
-## Upgrading Farms and Enabling Deadline Secrets Management
+## Upgrading RFDK and Enabling Deadline Secrets Management
 
 ---
 
@@ -18,22 +18,20 @@ next section "Upgrading Farms Without Enabling Deadline Secrets Management"._
 
 ---
 
-To determine whether your `RenderQueue` is using HTTPS for internal and external protocols, you need to check what values you have set
-for the [`trafficEncryption`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.RenderQueue.html#trafficencryption) property.
-Your `RenderQueue` is using HTTPS for internal and external protocols if one of the following is true:
+Your `RenderQueue` will use HTTPS for both internal and external protocols for RFDK 0.38.0 if **EITHER** of the following are true:
 
-1. You have not specified the `trafficEncryption` or the `trafficEncryption.externalTLS` property for the `RenderQueue`
-2. You have specified the `trafficEncryption` property for the `RenderQueue` and the following are true:
-    1. The `internalProtocol` is `ApplicationProtocol.HTTPS`
-    2. One of the following is true for the `externalTLS` property:
-        1. `enabled` is `true`
-        2. There are values for both `acmCertificate` and `acmCertificateChain`
-        3. There is a value for `rfdkCertificate`
+1. You **HAVE NOT** specified the `trafficEncryption` (TypeScript) / `traffic_encryption` (Python) property
+1. You **HAVE** specified the `trafficEncryption` (TypeScript) / `traffic_encryption` (Python) property **AND BOTH of the following are true**:
+    1. **EITHER** of the following are true:
+        1. You **HAVE NOT** specified the `trafficEncryption.internalProtocol` (TypeScript) / `traffic_encryption.internal_protocol` (Python)
+        1. You **HAVE** specified the `trafficEncryption.internalProtocol` (TypeScript) / `traffic_encryption.internal_protocol` (Python) and it is set to `ApplicationProtocol.HTTPS`
+    1. **EITHER** of the following are true:
+        1. You **HAVE NOT** specified the `trafficEncryption.externalTLS` (TypeScript) / `traffic_encryption.external_tls` (Python)
+        1. You **HAVE NOT** specified `trafficEncryption.externalTLS.enabled` (TypeScript) / `traffic_encryption.external_tls.enabled` (Python)
+        1. You **HAVE** specified `trafficEncryption.externalTLS.enabled` (TypeScript) / `traffic_encryption.external_tls.enabled` (Python) and it is set to `true` (TypeScript) / `True` (Python)
 
-If the above is true, all you need to do to enable Deadline Secrets Management is redeploy your RFDK application.
-
-If your `RenderQueue` is not using HTTPS for its internal and/or external protocols as described above, you will need to satisfy the conditions above before deploying your farm so that
-RFDK can successfully configure Deadline Secrets Management for you.
+If you have determined that your `RenderQueue` will use HTTPS for both internal and external protocols in RFDK 0.38.0, then all you need to do to enable Deadline Secrets Management is to upgrade
+your RFDK application to use 0.38.0 and re-deploy.
 
 The below example code snippets demonstrate what each case above may look like:
 
@@ -44,7 +42,31 @@ import { ApplicationProtocol } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { RenderQueue } from 'aws-rfdk/deadline';
 
 new RenderQueue(this, 'RenderQueue', {
-  // no "trafficEncryption" property, so TLS is enabled externally by default
+  // no "trafficEncryption" property, so TLS is enabled both internally and externally by default
+  // ...
+});
+
+// OR
+
+new RenderQueue(this, 'RenderQueue', {
+  // ...
+  trafficEncryption: {
+    // No "internalProtocol" property, so TLS is enabled internally by default
+    // No "externalTLS" property, so TLS is enabled externally by default
+  },
+  // ...
+});
+
+// OR
+
+new RenderQueue(this, 'RenderQueue', {
+  // ...
+  trafficEncryption: {
+    // No "internalProtocol" property, so TLS is enabled internally by default
+    externalTLS: {
+      // No "enabled" property, so external TLS will be enabled by default
+    },
+  },
   // ...
 });
 
@@ -116,7 +138,31 @@ from aws_rfdk.deadline import (
 )
 
 RenderQueue(self, 'RenderQueue',
-  # no "traffic_encryption" property, so TLS is enabled externally by default
+  # no "trafficEncryption" property, so TLS is enabled both internally and externally by default
+  # ...
+)
+
+# OR
+
+RenderQueue(self, 'RenderQueue',
+  # ...
+  traffic_encryption=RenderQueueTrafficEncryptionProps(
+    # No "internal_protocol" property, so TLS is enabled internally by default
+    # No "external_tls" property, so TLS is enabled externally by default
+  ),
+  # ...
+)
+
+# OR
+
+RenderQueue(self, 'RenderQueue',
+  # ...
+  traffic_encryption=RenderQueueTrafficEncryptionProps(
+    # No "internal_protocol" property, so TLS is enabled internally by default
+    external_tls=RenderQueueExternalTLSProps(
+      # No "enabled" property, so external TLS will be enabled by default
+    ),
+  ),
   # ...
 )
 
@@ -178,7 +224,7 @@ RenderQueue(self, 'RenderQueue',
 </details>
 
 
-## Upgrading Farms Without Enabling Deadline Secrets Management
+## Upgrading RFDK Without Enabling Deadline Secrets Management
 
 We highly recommend enabling Deadline Secrets Management on your render farm for the additional layer of security. However, if you would still like to upgrade your farm without enabling
 Deadline Secrets Management, you can do so by setting the `secretsManagementSettings` property of the `Repository` construct:

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -237,12 +237,29 @@ repository.configureClientInstance({
 
 By default, [Deadline Secrets Management](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) is enabled on the `Repository`.
 RFDK will create administator credentials for Deadline Secrets Management, store them in AWS Secrets Manager, and configure the Deadline Repository with those credentials. If you would like to use your own
-credentials for Deadline Secrets Management, you can do so by storing them in AWS Secrets Manager and providing the `Repository` the ARN of the Secret containing your credentials:
+credentials for Deadline Secrets Management, you can do so by storing them in AWS Secrets Manager and providing them to the `Repository` construct. The Secret must be a JSON document with the following format:
+
+```jsonc
+{
+  // Replace the values of these fields with your own values
+  "username": "your_username",
+  "password": "your_password"
+}
+```
+
+---
+
+_**Note:** The `password` should be at least 8 characters long and contain at least one lowercase letter, one uppercase letter, one symbol and one number._
+
+---
+
+You can then provide the ARN of the Secret containing your credentials to the `Repository` construct:
 
 ```ts
 const secretsManagementCredentials = Secret.fromSecretCompleteArn(
   this,
   'DeadlineSecretsManagementCredentials',
+  // Replace with your Secret ARN
   'yourSecretArn',
 );
 

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -166,10 +166,11 @@ The components that need auto-registration rules created for them include, but a
 RFDK creates auto-registration rules based on the Classless Inter-Domain Routing (CIDR) range of the subnet(s) that a component can be deployed into. Therefore, we highly recommend
 creating a dedicated subnet for each component above for the following reasons:
 
-1. RFDK configures Deadline Secrets Management to auto-register identities from any host within the Render Queue's Application Load Balancer (ALB) subnets. This is necessary for RFDK
-to create [identity registration settings](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html#identity-management-registration-settings-ref-label)
-for other clients that connect to the Render Queue through its ALB (e.g. `UsageBasedLicensing`, `WorkerInstanceFleet`, and `SpotEventPluginFleet`). If other hosts are deployed into the same
-subnets as the Render Queue's ALB, they will be able to auto-register identities even though they don't have a corresponding identity registration setting.
+1. RFDK automatically configures Deadline Secrets Management [identity registration settings](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html#identity-management-registration-settings-ref-label).
+These settings are configured such that the Render Queue will register identities that are created by Deadline Clients (e.g. `UsageBasedLicensing`, `WorkerInstanceFleet`, and `SpotEventPluginFleet`)
+connecting via the Render Queue's Application Load Balancer (ALB). Deadline requires that you specify trusted load balancers when configuring identity registration settings by their connecting
+IP address. Application Load Balancers can scale to use any available IP address in the subnets, so the full subnet IP range is used by RFDK. For this reason, we recommend dedicating subnets
+exclusively for the Render Queue's ALB.
 1. The size of the subnet can be limited to only what is necessary for your workload, avoiding an overly permissive auto-registration rule.
 
 For more details on dedicated subnet placements, see:

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -163,6 +163,15 @@ const renderQueue = new RenderQueue(stack, 'RenderQueue', {
 });
 ```
 
+### Enabling Deadline Secrets Management on the Render Queue
+
+When [Deadline Secrets Management](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) is enabled on the `Repository` construct,
+the `RenderQueue` will automatically configure itself as a Server role in Deadline Secrets Management.
+
+TODO: Add more details about auto-registration rules and how to use them (also in dev guide)
+
+For more information on using Deadline Secrets Management in RFDK, please see the [RFDK Developer Guide](https://docs.aws.amazon.com/rfdk/latest/guide/deadline-secrets-management-rfdk.html).
+
 ## Repository
 
 ![architecture diagram](../../docs/diagrams/deadline/Repository.svg)
@@ -223,6 +232,31 @@ repository.configureClientInstance({
   mountPoint: '/mnt/repository'
 });
 ```
+
+### Configuring Deadline Secrets Management
+
+By default, [Deadline Secrets Management](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) is enabled on the `Repository`.
+RFDK will create administator credentials for Deadline Secrets Management, store them in AWS Secrets Manager, and configure the Deadline Repository with those credentials. If you would like to use your own
+credentials for Deadline Secrets Management, you can do so by storing them in AWS Secrets Manager and providing the `Repository` the ARN of the Secret containing your credentials:
+
+```ts
+const secretsManagementCredentials = Secret.fromSecretCompleteArn(
+  this,
+  'DeadlineSecretsManagementCredentials',
+  'yourSecretArn',
+);
+
+const repository = new Repository(this, 'Repository', {
+  vpc,
+  version,
+  secretsManagementSettings: {
+    enabled: true,
+    credentials: secretsManagementCredentials,
+  },
+});
+```
+
+For more information on using Deadline Secrets Management in RFDK, please see the [RFDK Developer Guide](https://docs.aws.amazon.com/rfdk/latest/guide/deadline-secrets-management-rfdk.html).
 
 ## Spot Event Plugin Fleet
 

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -166,7 +166,7 @@ const renderQueue = new RenderQueue(stack, 'RenderQueue', {
 ### Enabling Deadline Secrets Management on the Render Queue
 
 When [Deadline Secrets Management](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) is enabled on the `Repository` construct,
-the `RenderQueue` will automatically configure itself as a Server role in Deadline Secrets Management.
+the `RenderQueue` will automatically configure itself as a [Server role](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html#assigned-roles) in Deadline Secrets Management.
 
 TODO: Add more details about auto-registration rules and how to use them (also in dev guide)
 

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -188,7 +188,7 @@ export interface RenderQueueTrafficEncryptionProps {
   /**
    * Properties for configuring external TLS connections between the Render Queue and Deadline clients.
    *
-   * @default Plain HTTP communication is used
+   * @default A default certificate is generated and HTTPS communication is used
    */
   readonly externalTLS?: RenderQueueExternalTLSProps;
 


### PR DESCRIPTION
Adds documentation about Deadline Secrets Management to the API reference as well as an upgrade doc.

Couple notes:
- Left a TODO in the `RenderQueue` section about SM that will be expanded on in the PR that adds support for auto-registration rules
- To avoid duplicating instructions on using Deadline Secrets Management with RFDK, I've opted to link to the RFDK dev guide which will have more in depth instructions on how to use Deadline SM with RFDK (yet to be released).

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
