### PR TITLE
feat(examples): use dedicated subnets in All-In-AWS-Infrastructure-Basic example

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/compute_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/compute_tier.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from dataclasses import dataclass
 from typing import (
     List,
@@ -16,7 +17,8 @@ from aws_cdk.aws_ec2 import (
     BastionHostLinux,
     IMachineImage,
     IVpc,
-    Port
+    Port,
+    SubnetSelection
 )
 from aws_cdk.aws_s3_assets import (
   Asset
@@ -34,7 +36,8 @@ from aws_rfdk.deadline import (
     WorkerInstanceFleet,
 )
 
-import os
+
+from . import subnets
 
 @dataclass
 class ComputeTierProps(StackProps):
@@ -101,6 +104,9 @@ class ComputeTier(Stack):
             self,
             'HealthMonitor',
             vpc=props.vpc,
+            vpc_subnets=SubnetSelection(
+                subnet_group_name=subnets.INFRASTRUCTURE.name
+            ),
             # TODO - Evaluate deletion protection for your own needs. This is set to false to
             # cleanly remove everything when this stack is destroyed. If you would like to ensure
             # that this resource is not accidentally deleted, you should set this to true.
@@ -111,6 +117,9 @@ class ComputeTier(Stack):
             self,
             'WorkerFleet',
             vpc=props.vpc,
+            vpc_subnets=SubnetSelection(
+                subnet_group_name=subnets.WORKERS.name
+            ),
             render_queue=props.render_queue,
             worker_machine_image=props.worker_machine_image,
             health_monitor=self.health_monitor,

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/subnets.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/subnets.py
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aws_cdk.aws_ec2 import SubnetConfiguration, SubnetType
+
+
+# Subnets for undistinguished render farm back-end infrastructure
+INFRASTRUCTURE = SubnetConfiguration(
+    name='Infrastructure',
+    subnet_type=SubnetType.PRIVATE,
+    # 1,022 IP addresses
+    cidr_mask=22
+)
+
+# Subnets for publicly accessible infrastructure
+PUBLIC = SubnetConfiguration(
+    name='Public',
+    subnet_type=SubnetType.PUBLIC,
+    # 14 IP addresses. We only require one ENI per internet gateway per AZ, but leave some extra room
+    # should there be a need for externally accessible ENIs
+    cidr_mask=28
+)
+
+# Subnets for the Render Queue Application Load Balancer (ALB).
+#
+# It is considered good practice to put a load blanacer in dedicated subnets. Additionally, the subnets
+# must have a CIDR block with a bitmask of at least /27 and at least 8 free IP addresses per subnet.
+# ALBs can scale up to a maximum of 100 IP addresses distributed across all subnets. Assuming only 2 AZs
+# (the minimum) we should have 50 IPs per subnet = CIDR mask of /26
+#
+# See:
+# - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer
+# - https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/lib/deadline/README.md#render-queue-subnet-placement
+RENDER_QUEUE_ALB = SubnetConfiguration(
+    name='RenderQueueALB',
+    subnet_type=SubnetType.PRIVATE,
+    # 62 IP addresses
+    cidr_mask=26
+)
+
+# Subnets for the Usage-Based Licensing
+USAGE_BASED_LICENSING = SubnetConfiguration(
+    name='UsageBasedLicensing',
+    subnet_type=SubnetType.PRIVATE,
+    # 14 IP addresses
+    cidr_mask=28
+)
+
+# Subnets for the Worker instances
+WORKERS = SubnetConfiguration(
+    name='Workers',
+    subnet_type=SubnetType.PRIVATE,
+    # 4,094 IP addresses
+    cidr_mask=20
+)

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/compute-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/compute-tier.ts
@@ -27,6 +27,8 @@ import {
 import { Asset } from '@aws-cdk/aws-s3-assets';
 import * as path from 'path'
 
+import { Subnets } from './subnets';
+
 /**
  * Properties for {@link ComputeTier}.
  */
@@ -123,6 +125,9 @@ export class ComputeTier extends cdk.Stack {
 
     this.healthMonitor = new HealthMonitor(this, 'HealthMonitor', {
       vpc: props.vpc,
+      vpcSubnets: {
+        subnetGroupName: Subnets.INFRASTRUCTURE.name,
+      },
       // TODO - Evaluate deletion protection for your own needs. This is set to false to
       // cleanly remove everything when this stack is destroyed. If you would like to ensure
       // that this resource is not accidentally deleted, you should set this to true.
@@ -131,6 +136,9 @@ export class ComputeTier extends cdk.Stack {
 
     this.workerFleet = new WorkerInstanceFleet(this, 'WorkerFleet', {
       vpc: props.vpc,
+      vpcSubnets: {
+        subnetGroupName: Subnets.WORKERS.name,
+      },
       renderQueue: props.renderQueue,
       workerMachineImage: props.workerMachineImage,
       healthMonitor: this.healthMonitor,

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/network-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/network-tier.ts
@@ -20,6 +20,8 @@ import {
 } from '@aws-cdk/aws-route53';
 import * as cdk from '@aws-cdk/core';
 
+import { Subnets } from './subnets';
+
 /**
  * The network tier consists of all constructs that are required for the foundational
  * networking between the various components of the Deadline render farm.
@@ -71,16 +73,35 @@ export class NetworkTier extends cdk.Stack {
     this.vpc = new Vpc(this, 'Vpc', {
       maxAzs: 2,
       subnetConfiguration: [
-        {
-          name: 'Public',
-          subnetType: SubnetType.PUBLIC,
-          cidrMask: 28,
-        },
-        {
-          name: 'Private',
-          subnetType: SubnetType.PRIVATE,
-          cidrMask: 18, // 16,382 IP addresses
-        },
+        /**
+         * Subnets for undistinguished render farm back-end infrastructure
+         */
+        Subnets.INFRASTRUCTURE,
+        /**
+         * Subnets for publicly accessible infrastructure
+         */
+        Subnets.PUBLIC,
+        /**
+         * Subnets for the Render Queue Application Load Balancer (ALB).
+         *
+         * It is considered good practice to put a load blanacer in dedicated subnets. Additionally, the subnets must
+         * have a CIDR block with a bitmask of at least /27 and at least 8 free IP addresses per subnet. ALBs can scale
+         * up to a maximum of 100 IP addresses distributed across all subnets. Assuming only 2 AZs (the minimum) we
+         * should have 50 IPs per subnet = CIDR mask of /26
+         *
+         * See:
+         * - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer
+         * - https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/lib/deadline/README.md#render-queue-subnet-placement
+         */
+        Subnets.RENDER_QUEUE_ALB,
+        /**
+         * Subnets for Usage-Based Licensing
+         */
+        Subnets.USAGE_BASED_LICENSING,
+        /**
+         * Subnets for the Worker instances
+         */
+        Subnets.WORKERS,
       ],
       // VPC flow logs are a security best-practice as they allow us
       // to capture information about the traffic going in and out of

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/subnets.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/subnets.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SubnetConfiguration, SubnetType } from '@aws-cdk/aws-ec2';
+
+export class Subnets {
+  /**
+   * Subnets for undistinguished render farm back-end infrastructure
+   */
+   public static readonly INFRASTRUCTURE: SubnetConfiguration = {
+    name: 'Infrastructure',
+    subnetType: SubnetType.PRIVATE,
+    // 1,022 IP addresses
+    cidrMask: 22,
+  };
+
+  /**
+   * Subnets for publicly accessible infrastructure
+   */
+  public static readonly PUBLIC: SubnetConfiguration = {
+    name: 'Public',
+    subnetType: SubnetType.PUBLIC,
+    // 14 IP addresses. We only require one ENI per internet gateway per AZ, but leave some extra room
+    // should there be a need for externally accessible ENIs
+    cidrMask: 28,
+  };
+
+  /**
+   * Subnets for the Render Queue Application Load Balancer (ALB).
+   *
+   * It is considered good practice to put a load blanacer in dedicated subnets. Additionally, the subnets must have a
+   * CIDR block with a bitmask of at least /27 and at least 8 free IP addresses per subnet. ALBs can scale up to a
+   * maximum of 100 IP addresses distributed across all subnets. Assuming only 2 AZs (the minimum) we should have 50 IPs
+   * per subnet = CIDR mask of /26
+   *
+   * See:
+   * - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer
+   * - https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/lib/deadline/README.md#render-queue-subnet-placement
+   */
+  public static readonly RENDER_QUEUE_ALB: SubnetConfiguration = {
+    name: 'RenderQueueALB',
+    subnetType: SubnetType.PRIVATE,
+    // 62 IP addresses
+    cidrMask: 26,
+  };
+
+  /**
+   * Subnets for the Usage-Based Licensing
+   */
+  public static readonly USAGE_BASED_LICENSING: SubnetConfiguration = {
+    name: 'UsageBasedLicensing',
+    subnetType: SubnetType.PRIVATE,
+    // 14 IP addresses
+    cidrMask: 28,
+  };
+
+  /**
+   * Subnets for the Worker instances
+   */
+  public static readonly WORKERS: SubnetConfiguration = {
+    name: 'Workers',
+    subnetType: SubnetType.PRIVATE,
+    // 4,094 IP addresses
+    cidrMask: 20,
+  };
+}

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -175,6 +175,8 @@ IP address. Application Load Balancers can scale to use any available IP address
 exclusively for the Render Queue's ALB.
 1. The size of the subnet can be limited to only what is necessary for your workload, avoiding an overly permissive auto-registration rule.
 
+Please consult the [`All-In-AWS-Infrastructure-Basic` example CDK application](https://github.com/aws/aws-rfdk/blob/release/examples/deadline/All-In-AWS-Infrastructure-Basic) for a reference implementation that demonstrates dedicated subnets.
+
 For more details on dedicated subnet placements, see:
 - [Render Queue Subnet Placement](#render-queue-subnet-placement)
 - [Worker Instance Fleet Subnet Placement](#worker-instance-fleet-subnet-placement)


### PR DESCRIPTION
## Summary

In #576, RFDK was modified to automatically configure Deadline Secrets Management identity registration settings based on the subnets used by RFDK Deadline constructs. This sets up the rules with least-privilege such that the farm will always function, but in order to further scope-down the identity registration settings rules, RFDK users should deploy RFDK Deadline constructs into their own dedicated subnets.

This PR modifies the `All-In-AWS-Infrastructure-Basic` example CDK applications to use dedicated subnets as we now recommend in our documentation.

Updated the Deadline `README.md` to point to the example for a reference implementation.

## Testing

Built and deployed Python and TypeScript example apps and verified that:

*   Python
    *  All instances are deployed in the proper subnets
    *  The Render Queue ALB is deployed in its own dedicated subnets
    *  RFDK creates Deadline Secrets Management identity registration settings for only the subnets involved
    *  End-to-end UBL render using SM succeeds
*   TypeScript
    *  All instances are deployed in the proper subnets
    *  The Render Queue ALB is deployed in its own dedicated subnets
    *  RFDK creates Deadline Secrets Management identity registration settings for only the subnets involved
    *  End-to-end UBL render using SM succeeds

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
