### PR TITLE
chore(deadline): add error handling for deadlinecommand json mode in configure_identity_registration_settings.py

### DIFF
--- a/packages/aws-rfdk/lib/deadline/scripts/python/configure_identity_registration_settings.py
+++ b/packages/aws-rfdk/lib/deadline/scripts/python/configure_identity_registration_settings.py
@@ -298,7 +298,13 @@ class DeadlineSecretsCommandClient(object):
         # Prepend the arguments with the json command-line flag
         transformed_args = ['--json'] + transformed_args
 
-        return json.loads(self._call_deadline_command(transformed_args))
+        result = json.loads(self._call_deadline_command(transformed_args))
+
+        if 'ok' in result.keys():
+            if result['ok'] == False:
+                raise ValueError('DeadlineCommandError: \n%s' % (result))
+
+        return result
 
     def dry_run(self, *args: Iterable[str]):
         transformed_args = self._transform_args(args)


### PR DESCRIPTION
## Overview

Added additional error logging to `configure_identity_registration_settings.py` for when a Deadline Command with the `--json` flag fails. When this happens, a valid json object is returned that looks similar to:

```
{'ok': False, 'result': 'Error: [SecretsManagement] Command is not supported. (GetLoadBalancerIdentityRegistrationSettings)'}
```

## Testing
I deployed an RFDK app that used a version of Deadline on the `DeploymentInstance` that didn't have our changes to add new Deadline Commands for Secrets Management and confirmed that it handled the failure by printing the following error message:
```
Traceback (most recent call last):
  File "/home/ec2-user/configure_identity_registration_settings.py", line 621, in <module>
    __main__(*sys.argv[1:])
  File "/home/ec2-user/configure_identity_registration_settings.py", line 616, in __main__
    apply_registration_settings(config)
  File "/home/ec2-user/configure_identity_registration_settings.py", line 597, in apply_registration_settings
    prior_rfdk_settings = get_rfdk_registration_settings(dl_secrets)
  File "/home/ec2-user/configure_identity_registration_settings.py", line 391, in get_rfdk_registration_settings
    for registration_setting in dl_secrets.run_json('GetLoadBalancerIdentityRegistrationSettings')
  File "/home/ec2-user/configure_identity_registration_settings.py", line 307, in run_json
    raise ValueError('DeadlineCommandError: \n%s' % (result))
ValueError: DeadlineCommandError:
{'ok': False, 'result': 'Error: [SecretsManagement] Command is not supported. (GetLoadBalancerIdentityRegistrationSettings)'}
```
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
