### PR TITLE
fix(deadline): fix type assumption in configure_identity_registration_settings.py error handling

### DIFF
--- a/packages/aws-rfdk/lib/deadline/scripts/python/configure_identity_registration_settings.py
+++ b/packages/aws-rfdk/lib/deadline/scripts/python/configure_identity_registration_settings.py
@@ -300,7 +300,7 @@ class DeadlineSecretsCommandClient(object):
 
         result = json.loads(self._call_deadline_command(transformed_args))
 
-        if 'ok' in result.keys():
+        if isinstance(result, dict) and 'ok' in result.keys():
             if result['ok'] == False:
                 raise ValueError('DeadlineCommandError: \n%s' % (result))
 


### PR DESCRIPTION
## Problem

In #604, we added error-handling when the Deadline version supplied to the `RenderQueue` did not include the required Deadline commands to manage [Deadline identity registration settings](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html#identity-management-registration-settings-ref-label).

This error handling introduced a regression since in the happy path, the JSON serialization returns a python `list` and not a `dict`. When a compatible Deadline version is supplied, the following error was emitted in the `/renderfarm/ConfigureRepository` CloudWatch log group:

```txt
Traceback (most recent call last):
  File "/home/ec2-user/configure_identity_registration_settings.py", line 618, in <module>
    __main__(*sys.argv[1:])
  File "/home/ec2-user/configure_identity_registration_settings.py", line 613, in __main__
    apply_registration_settings(config)
  File "/home/ec2-user/configure_identity_registration_settings.py", line 594, in apply_registration_settings
    prior_rfdk_settings = get_rfdk_registration_settings(dl_secrets)
  File "/home/ec2-user/configure_identity_registration_settings.py", line 388, in get_rfdk_registration_settings
    for registration_setting in dl_secrets.run_json('GetLoadBalancerIdentityRegistrationSettings')
  File "/home/ec2-user/configure_identity_registration_settings.py", line 303, in run_json
    if 'ok' in result.keys():
AttributeError: 'list' object has no attribute 'keys'
```

## Solution

A type-check was added to first check if the resulting object is a `dict` before checking its keys.

## Testing

Deployed the `All-In-AWS-Infrastructure-Basic` TypeScript example app with both code paths:

*   A supported Deadline version (includes Deadline secrets management identity registration settings commands)
*   An unsupported Deadline version (does not include Deadline secrets management identity registration settings commands)

### Happy Case

In the happy case, the deployment succeeds and identity registration settings are created successfully.

### Unsupported Deadline Client Case

In the case where the Deadline version does not support the correct commands, the python script catches the error and fails the deployment. In the CloudWatch log group, the following is shown:

```
Traceback (most recent call last):
  File "/home/ec2-user/configure_identity_registration_settings.py", line 618, in <module>
    __main__(*sys.argv[1:])
  File "/home/ec2-user/configure_identity_registration_settings.py", line 613, in __main__
    apply_registration_settings(config)
  File "/home/ec2-user/configure_identity_registration_settings.py", line 594, in apply_registration_settings
    prior_rfdk_settings = get_rfdk_registration_settings(dl_secrets)
  File "/home/ec2-user/configure_identity_registration_settings.py", line 388, in get_rfdk_registration_settings
    for registration_setting in dl_secrets.run_json('GetLoadBalancerIdentityRegistrationSettings')
  File "/home/ec2-user/configure_identity_registration_settings.py", line 305, in run_json
    raise ValueError('DeadlineCommandError: \n%s' % (result))
ValueError: DeadlineCommandError:
{'ok': False, 'result': 'Error: [SecretsManagement] Command is not supported. (GetLoadBalancerIdentityRegistrationSettings)'}
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
