### PR TITLE
fix(deadline): allow traffic from RenderQueue to UsageBasedLicensing

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -114,6 +114,11 @@ export interface IRenderQueue extends IConstruct, IConnectable {
   readonly endpoint: ConnectableApplicationEndpoint;
 
   /**
+   * A connections object for controlling access of the compute resources that host the render queue.
+   */
+  readonly backendConnections: Connections;
+
+  /**
    * Configures an ECS cluster to be able to connect to a RenderQueue
    * @returns An environment mapping that is used to configure the Docker Images
    */
@@ -186,6 +191,11 @@ abstract class RenderQueueBase extends Construct implements IRenderQueue {
    * @inheritdoc
    */
   public abstract readonly repository: IRepository;
+
+  /**
+   * @inheritdoc
+   */
+  public abstract readonly backendConnections: Connections;
 
   /**
    * Configures an ECS cluster to be able to connect to a RenderQueue
@@ -315,6 +325,11 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
   public readonly repository: IRepository;
 
   /**
+   * @inheritdoc
+   */
+  public readonly backendConnections: Connections;
+
+  /**
    * Whether SEP policies have been added
    */
   private haveAddedSEPPolicies: boolean = false;
@@ -439,6 +454,8 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       // @ts-ignore
       securityGroup: props.securityGroups?.backend,
     });
+
+    this.backendConnections = this.asg.connections;
 
     /**
      * The ECS-optimized AMI that is defaulted to when adding capacity to a cluster does not include the awscli or unzip

--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -444,9 +444,12 @@ export interface UsageBasedLicensingProps {
  *
  * The Deadline License Forwarder is set up to run within an AWS ECS task.
  *
- * Access to the running License Forwarder is gated by a security group that, by default, allows no ingress;
- * when a Deadline Worker requires access to licensing, then the RFDK constructs will grant that worker’s security group
- * ingress on TCP port 17004 as well as other ports as required by the specific licenses being used.
+ * Access to the running License Forwarder is gated by a security group that, by default, only allows ingress from the
+ * Render Queue (in order to register Workers for license forwarding).
+ *
+ * When a Deadline Worker requires access to licensing via `UsageBasedLicensing.grantPortAccess(...)`, then the RFDK
+ * constructs will grant that worker’s security group ingress on TCP port 17004 as well as other ports as required by
+ * the specific licenses being used.
  *
  * Note: This construct does not currently implement the Deadline License Forwarder's Web Forwarding functionality.
  * This construct is not usable in any China region.
@@ -616,6 +619,9 @@ export class UsageBasedLicensing extends Construct implements IGrantable {
         vpcSubnets,
       });
     }
+
+    // Grant the render queue the ability to connect to the license forwarder to register workers
+    this.asg.connections.allowFrom(props.renderQueue.backendConnections, Port.tcp(UsageBasedLicensing.LF_PORT));
 
     // Tag deployed resources with RFDK meta-data
     tagConstruct(this);


### PR DESCRIPTION
## Problem

When rendering jobs with [Deadline Third-Party Usage Based Licensing (UBL)](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/licensing-usage-based.html#licensing-3rd-party-ubl-ref-label) with a fleet of 50 workers, the API endpoints served by the [`RenderQueue` construct](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.RenderQueue.html) become locked-up and eventually return `503 Service Unavailable` responses. The health checks on the Application Load Balancer detect this problem and signal to ECS to replace the task - causing a render farm disruption.

## Solution

It was determined that the RCS request handlers were blocked attempting to communicate with the [Deadline License Forwarder](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/license-forwarder.html) deployed by the [`UsageBasedLicensing` construct](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.UsageBasedLicensing.html). It was discovered that RFDK does not create a security group rule to allow this traffic from the `RenderQueue` &rarr; `UsageBasedLicensing`. The [Deadline Remote Connection Server](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/remote-connection-server.html) uses a long connection timeout and with a sufficiently large number of workers rendering jobs, the request handling threads become blocked waiting for these connections to time out.

The solution is to add a security group rule when creating a `UsageBasedLicensing` construct instance to allow this traffic and avoid connection timeouts.

## Testing

*   Synthesis tests were added to cover this behavior
*   The `AWS-All-In-Infrastructure-Basic` example app was configured to use UBL. It deployed successfully and all `RenderQueue` performance degradations and disruptions disappeared

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
