### PR TITLE
chore(deps): use latest jsii/superchain container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: jsii/superchain
+      image: jsii/superchain:1-buster-slim-node14
 
     strategy:
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,10 @@ The developers actively use Linux for development, but macOS and the Windows Sub
 
 To build, we use the [jsii/superchain docker container](https://hub.docker.com/r/jsii/superchain).
 
-1. Acquire the latest `jsii/superchain:node14` docker image, if you do not already have it.
+1. Acquire the latest `jsii/superchain:1-buster-slim-node14` docker image, if you do not already have it.
 
     ```bash
-    docker pull jsii/superchain:node14
+    docker pull jsii/superchain:1-buster-slim-node14
     ```
 
 2. Enter the docker container

--- a/packages/aws-rfdk/lib/lambdas/nodejs/pad-efs-storage/filesystem-ops.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/pad-efs-storage/filesystem-ops.ts
@@ -100,7 +100,7 @@ export async function determineNextSequentialFilename(location: string): Promise
 export async function writePaddingFile(filename: string, filesize: number): Promise<void> {
   const execPromise = promisify(exec);
   const numberOfBlocks = filesize / 32;
-  const command = `/usr/bin/dd if=/dev/zero of=${filename} bs=32M count=${numberOfBlocks}`;
+  const command = `dd if=/dev/zero of=${filename} bs=32M count=${numberOfBlocks}`;
   console.log(`Writing ${filesize}MiB to ${filename}: ${command}`);
   const { stderr } = await execPromise(command);
   console.log(stderr);

--- a/packages/aws-rfdk/lib/lambdas/nodejs/pad-efs-storage/test/handlers.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/pad-efs-storage/test/handlers.test.ts
@@ -168,9 +168,9 @@ describe('Testing getDiskUsage behavior', () => {
     setDefaultFilesize(64);
 
     const execPromise = promisify(exec);
-    await execPromise(`/usr/bin/dd if=/dev/zero of=${join(tempDirectory, 'file1.tmp')} bs=32M count=2`);
+    await execPromise(`dd if=/dev/zero of=${join(tempDirectory, 'file1.tmp')} bs=32M count=2`);
     await fsp.mkdir(join(tempDirectory, 'subdir'));
-    await execPromise(`/usr/bin/dd if=/dev/zero of=${join(tempDirectory, 'subdir', 'file2.tmp')} bs=32M count=2`);
+    await execPromise(`dd if=/dev/zero of=${join(tempDirectory, 'subdir', 'file2.tmp')} bs=32M count=2`);
 
     // WHEN
     const usage = await getDiskUsage({

--- a/scripts/rfdk_build_environment.sh
+++ b/scripts/rfdk_build_environment.sh
@@ -42,5 +42,5 @@ docker run --rm \
     ${USER_OPT} \
     --net=host -it \
     --env DOTNET_CLI_TELEMETRY_OPTOUT=1 \
-    jsii/superchain:node14
+    jsii/superchain:1-buster-slim-node14
 


### PR DESCRIPTION
## Background

In https://github.com/aws/jsii/pull/2949, the `jsii/superchain` Docker images are migrating from using an `amazonlinux` base image to Debian base container image. This changes the version of OpenSSL from `1.0.x` &rarr; `1.1.x`. In this same PR, the container image tag conventions were changed.

## Problem

We need to migrate to using the new `jsii/superchain` Docker image tags, since the old ones are no longer maintained.

[The `jsii/superchain` documentation](https://github.com/aws/jsii/tree/d87c4a8de950dd75cb8334a28f8ceab2060dcc9e/superchain#image-tags) states:

>   `:node14` (users shoudl migrate to `:1-buster-slim-node14`)

When testing this, we run into errors:

<details><summary><b>Test Errors</b> (click to expand)</summary>

```
 FAIL  lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.js
  ● generate self-signed

    expect(received).toContain(expected) // indexOf

    Expected substring: "Issuer: CN=TestCN, O=TestO, OU=TestOU"
    Received string:    "Certificate:
        Data:
            Version: 3 (0x2)
            Serial Number:
                2f:e4:de:7f:51:55:e9:7a:de:45:00:41:2f:d4:46:f7:65:b8:f1:19
            Signature Algorithm: sha256WithRSAEncryption
            Issuer: CN = TestCN, O = TestO, OU = TestOU
            Validity
                Not Before: Oct 26 18:11:49 2021 GMT
                Not After : Oct 25 18:11:49 2024 GMT
            Subject: CN = TestCN, O = TestO, OU = TestOU
            Subject Public Key Info:
                Public Key Algorithm: rsaEncryption
                    RSA Public-Key: (2048 bit)
                    Modulus:
                        00:b6:d5:7b:29:a4:37:44:6c:40:59:de:04:77:f9:
                        ec:24:d0:9b:c5:0f:8c:20:cf:12:b6:60:e6:0d:18:
                        c6:1e:ae:a6:14:94:12:ae:8f:d8:a0:45:c7:d0:59:
                        ee:71:4b:6c:20:2d:01:ba:3a:bf:4a:0b:32:61:29:
                        5e:1f:a0:d9:35:a1:5d:08:03:a4:93:4b:da:48:18:
                        be:72:66:de:82:8f:d5:4c:95:90:5d:26:d5:b9:26:
                        54:b4:a2:7c:c1:ac:37:61:14:a7:0d:e6:1f:32:7f:
                        42:b6:64:a8:19:39:6b:dc:ad:75:55:6d:ac:a3:99:
                        f0:4f:a9:56:07:4a:fa:37:b5:60:34:0f:55:10:d7:
                        85:4b:dd:1a:f5:48:8f:59:34:dc:f2:7c:f5:b3:7e:
                        8f:5d:93:fe:c4:79:b9:65:6d:4d:b2:b9:f4:f3:32:
                        ef:9d:18:74:37:60:07:2b:62:9f:be:f8:f4:eb:ac:
                        dc:4f:6d:8b:3e:91:5f:54:d1:ae:45:b7:55:82:ea:
                        04:d2:b6:9a:b7:a4:e0:6f:99:64:e0:28:03:a2:f8:
                        41:90:47:47:a0:96:32:9a:f8:7f:61:73:e6:1f:b4:
                        e4:1a:2e:78:5f:9c:03:4d:f6:aa:59:0e:7c:f8:f7:
                        5f:eb:2b:e8:09:ba:d5:08:50:89:b6:1e:47:df:d8:
                        b3:a7
                    Exponent: 65537 (0x10001)
            X509v3 extensions:
                X509v3 Subject Key Identifier:·
                    B1:24:E2:9F:D8:50:BF:E9:0C:AA:52:63:B8:A5:B7:42:51:83:2B:DC
                X509v3 Authority Key Identifier:·
                    keyid:B1:24:E2:9F:D8:50:BF:E9:0C:AA:52:63:B8:A5:B7:42:51:83:2B:DC·
                X509v3 Basic Constraints: critical
                    CA:TRUE
        Signature Algorithm: sha256WithRSAEncryption
             4c:2d:fa:4d:7c:c2:e1:cf:23:3e:6c:b0:bd:20:db:2d:f8:b7:
             04:df:cd:99:ee:86:34:5c:c0:d3:13:69:e6:c2:a2:a9:98:c7:
             6c:f7:5e:f2:6e:0e:eb:67:34:45:f7:07:64:e9:4e:cb:a8:a3:
             92:16:97:27:47:0c:2b:d4:aa:ff:ed:bb:f4:ac:38:c6:43:e1:
             bf:ac:70:be:b0:f6:39:f6:a5:da:3a:1d:43:15:e2:a9:87:69:
             7e:a7:c3:5e:4d:5c:f9:e4:d7:5e:3f:7b:7d:50:58:63:7d:57:
             61:3b:3d:10:ab:3c:b7:55:83:26:dc:98:4e:d8:e2:fe:56:b6:
             61:d8:c7:e0:67:97:b8:9b:97:63:00:13:43:53:cc:fd:4d:fd:
             2d:d0:ae:85:d9:a8:94:21:c9:9e:e7:65:21:98:31:5d:d9:d3:
             e7:f4:e9:61:b5:13:4a:2e:93:80:36:e7:bf:dc:45:9a:cf:63:
             ce:09:4c:b4:38:51:9c:3e:07:9e:41:67:c5:cb:c9:1b:80:20:
             d5:f6:d0:26:52:61:cb:23:6d:1b:3b:fb:d3:b3:d7:8a:cc:a4:
             84:14:61:30:ce:4c:85:92:e1:c7:3d:67:3d:b6:d5:ac:fc:e9:
             87:2f:c2:93:b0:ad:32:c1:6d:e1:2c:55:f3:d0:de:87:45:dc:
             02:cf:d4:e3
    "

      70 |   expect(certificate.certChain).toEqual('');
      71 |
    > 72 |   expect(certVerification).toContain('Issuer: CN=TestCN, O=TestO, OU=TestOU');
         |                            ^
      73 |   expect(certVerification).toContain('Subject: CN=TestCN, O=TestO, OU=TestOU');
      74 |   expect(certVerification).toContain('Version: 3 (0x2)');
      75 |   expect(certVerification).toContain('Public-Key: (2048 bit)');

      at Object.<anonymous> (lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.ts:72:28)

  ● generate signed certificate

    expect(received).toContain(expected) // indexOf

    Expected substring: "Issuer: CN=TestCN, O=TestO, OU=TestOU"
    Received string:    "Certificate:
        Data:
            Version: 1 (0x0)
            Serial Number:
                7a:de:2e:d1:65:00:e1:46:b0:04:62:be:aa:e1:23:9f:cf:c1:ba:3f
            Signature Algorithm: sha256WithRSAEncryption
            Issuer: CN = TestCN, O = TestO, OU = TestOU
            Validity
                Not Before: Oct 26 18:11:49 2021 GMT
                Not After : Oct 25 18:11:49 2024 GMT
            Subject: CN = CertCN, O = CertO, OU = CertOU
            Subject Public Key Info:
                Public Key Algorithm: rsaEncryption
                    RSA Public-Key: (2048 bit)
                    Modulus:
                        00:a8:ff:43:2d:0a:89:af:b0:d4:8a:2a:c8:3e:b5:
                        6a:0a:71:c4:2e:7c:a9:fb:d9:88:46:06:d3:40:b8:
                        4c:73:47:ac:0a:73:02:a5:20:7f:9d:b5:4f:7c:68:
                        18:ca:44:b7:36:22:7f:b5:dc:0f:74:61:d0:53:c2:
                        52:4d:10:33:20:a7:01:80:ee:da:98:fc:56:ad:fb:
                        fd:0f:8d:c0:1d:6c:b2:c0:47:d7:89:74:f5:b9:bf:
                        7e:45:92:e1:46:c1:87:2d:9b:4d:40:33:98:48:97:
                        8c:23:18:e1:af:be:0a:3b:cd:9a:0b:5e:7a:9c:c6:
                        0f:aa:c4:e1:f1:d4:c3:f7:e0:7c:aa:2e:c6:b5:ae:
                        9a:65:80:42:15:5b:2b:ec:b1:b7:b7:1d:c2:fe:ca:
                        07:0b:b4:c3:e5:66:3d:f5:58:11:99:7f:da:1f:ce:
                        53:f6:85:23:4a:37:b6:7f:7a:e0:7c:04:4f:74:cf:
                        54:10:a8:86:a4:8c:0c:16:af:7f:1b:b4:55:b8:ee:
                        3d:f1:a5:14:31:84:f7:68:c0:2b:41:13:de:84:94:
                        ac:86:b1:e3:cf:b1:81:0d:82:eb:b0:e0:27:39:a4:
                        5d:f9:64:55:3e:1d:95:84:b3:47:ee:62:08:94:08:
                        fb:4f:99:a9:3c:13:c1:62:83:58:4c:85:e3:b9:80:
                        ac:75
                    Exponent: 65537 (0x10001)
        Signature Algorithm: sha256WithRSAEncryption
             55:43:e2:07:d0:b1:54:5c:92:46:7a:1f:31:28:37:9a:e5:b1:
             ae:3b:30:eb:57:6f:3c:b8:d8:5c:da:fa:d9:70:48:4b:7c:74:
             b6:f4:ce:c5:b1:48:49:49:72:9d:2c:fd:56:5c:04:4e:ef:62:
             24:8d:d1:4f:7d:52:da:f3:6f:00:e6:7b:c3:67:69:22:75:ed:
             80:31:58:11:64:df:9e:a0:65:67:19:8d:a4:1f:a6:0f:a8:4a:
             89:65:f3:d0:3e:f2:27:50:a3:5d:aa:49:1c:f6:0e:c2:b4:67:
             82:75:56:01:2f:38:2f:6e:a6:ba:71:ab:0b:46:e7:54:a2:b8:
             74:be:5a:69:8f:ee:a8:24:14:5e:08:6d:e5:e2:54:3d:9d:b5:
             6e:9d:f6:8d:a2:ba:66:1e:5f:9c:43:fe:0b:34:2f:87:c9:56:
             dd:28:5c:44:70:46:af:12:72:68:ed:e2:97:28:ed:63:a8:4a:
             88:44:06:3a:d6:f1:5f:5a:90:90:c8:ba:18:43:02:b6:02:d9:
             c5:75:2d:86:00:4e:e2:5c:c8:e9:c3:4f:47:d4:2e:33:f2:fe:
             d8:b5:a8:3f:3c:c7:ef:e2:7f:c1:6c:55:52:06:78:4a:f0:5b:
             78:62:b4:82:3f:ab:eb:49:1e:09:e9:30:44:50:e1:a2:33:7b:
             0f:d2:8c:ec
    "

      158 |   expect(certificate.passphrase).toBe(passphrase);
      159 |
    > 160 |   expect(certVerification).toContain('Issuer: CN=TestCN, O=TestO, OU=TestOU');
          |                            ^
      161 |   expect(certVerification).toContain('Subject: CN=CertCN, O=CertO, OU=CertOU');
      162 |   expect(certVerification).toContain('Public-Key: (2048 bit)');
      163 |   // ex: Not After : May 22 22:13:24 2023 GMT

      at Object.<anonymous> (lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.ts:160:28)

  ● convert to PKCS #12

    expect(received).toContain(expected) // indexOf

    Expected substring: "MAC verified OK"
    Received string:    "MAC: sha1, Iteration 2048
    MAC length: 20, salt length: 8
    PKCS7 Encrypted data: pbeWithSHA1And40BitRC2-CBC, Iteration 2048
    Certificate bag
    Certificate bag
    PKCS7 Data
    Shrouded Keybag: pbeWithSHA1And3-KeyTripleDES-CBC, Iteration 2048
    "

      236 |
      237 |   // THEN
    > 238 |   expect(pkcs12Validation.stderr).toContain('MAC verified OK');
          |                                   ^
      239 |   // Must have the certificate's cert
      240 |   expect(validationOut).toContain('subject=/CN=CertCN/O=CertO/OU=CertOU\nissuer=/CN=TestCN/O=TestO/OU=TestOU\n-----BEGIN CERTIFICATE-----');
      241 |   // Must have the CA cert

      at Object.<anonymous> (lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.ts:238:35)

FAIL lib/lambdas/nodejs/pad-efs-storage/test/handlers.test.js
  ● Testing filesystem modifications › Add to empty directory
    Command failed: /usr/bin/dd if=/dev/zero of=/tmp/tmp.ZVcDHX/00000 bs=32M count=2
    /bin/sh: 1: /usr/bin/dd: not found
  ● Testing filesystem modifications › Append to directory
    Command failed: /usr/bin/dd if=/dev/zero of=/tmp/tmp.RbOq00/00008 bs=32M count=2
    /bin/sh: 1: /usr/bin/dd: not found
  ● Testing getDiskUsage behavior › Correctly calculates disk usage
    Command failed: /usr/bin/dd if=/dev/zero of=/tmp/tmp.lYDXJi/file1.tmp bs=32M count=2
    /bin/sh: 1: /usr/bin/dd: not found
  ● Testing padFilesystem macro behavior › Adds file if needed
    Command failed: /usr/bin/dd if=/dev/zero of=/tmp/tmp.72syyF/00000 bs=32M count=2
    /bin/sh: 1: /usr/bin/dd: not found
  ● Testing padFilesystem macro behavior › Removes file if needed
    Command failed: /usr/bin/dd if=/dev/zero of=/tmp/tmp.jKNcPJ/00000 bs=32M count=2
    /bin/sh: 1: /usr/bin/dd: not found
  ● Testing padFilesystem macro behavior › No change to filesystem
    Command failed: /usr/bin/dd if=/dev/zero of=/tmp/tmp.7rdQxO/00000 bs=32M count=2
    /bin/sh: 1: /usr/bin/dd: not found
```

</details>

These errors originate from two problems:

1. The RFDK X509 certificate tests run the following commands and make assertions about the contents of the standard output emitted:

    ```sh
    openssl x509 x509 -noout -text ...
    openssl rsa -noout -text ...
    ```

    The format of the output has changed between these OpenSSL versions.

2.  The path to the `dd` command has changes from `/usr/bin/dd` &rarr; `/bin/dd` when going from Amazon Linux 2 to Debian

## Solution

Relax/generalize the tests and RFDK code so that tests pass for both OpenSSL versions and for any `dd` path.

## Testing

Ran the tests using both versions of OpenSSL and confirmed they pass.

### OpenSSL 1.0

```
$ git rev-parse HEAD
24221a9141f5d92f744a2368e3834dfb076830cd
$ git status
On branch jsii_debian_image_compat
nothing to commit, working tree clean
$ openssl version
OpenSSL 1.0.2u  20 Dec 2019
$ yarn run jest lib/lambdas/nodejs/lib/x509-certs/
yarn run v1.22.17
$ /local/home/ec2-user/workplace/aws-rfdk/node_modules/.bin/jest lib/lambdas/nodejs/lib/x509-certs/
 PASS  lib/lambdas/nodejs/lib/x509-certs/test/distinguished_name.test.js
 PASS  lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.js

=============================== Coverage summary ===============================
Statements   : 100% ( 131/131 )
Branches     : 96% ( 24/25 )
Functions    : 100% ( 14/14 )
Lines        : 100% ( 128/128 )
================================================================================

Test Suites: 2 passed, 2 total
Tests:       28 passed, 28 total
Snapshots:   0 total
Time:        2.028 s
Ran all test suites matching /lib\/lambdas\/nodejs\/lib\/x509-certs\//i.
Done in 2.64s.
```

### OpenSSL 1.1

```
$ git rev-parse HEAD
24221a9141f5d92f744a2368e3834dfb076830cd
$ git status
On branch jsii_debian_image_compat
nothing to commit, working tree clean
$ openssl version
OpenSSL 1.1.1d  10 Sep 2019
$ yarn run jest lib/lambdas/nodejs/lib/x509-certs/
yarn run v1.22.15
warning Skipping preferred cache folder "/home/ec2-user/.cache/yarn" because it is not writable.
warning Selected the next writable cache folder in the list, will be "/tmp/.yarn-cache-6388445".
$ /local/home/ec2-user/workplace/aws-rfdk/node_modules/.bin/jest lib/lambdas/nodejs/lib/x509-certs/
 PASS  lib/lambdas/nodejs/lib/x509-certs/test/distinguished_name.test.js
 PASS  lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.js

=============================== Coverage summary ===============================
Statements   : 100% ( 131/131 )
Branches     : 96% ( 24/25 )
Functions    : 100% ( 14/14 )
Lines        : 100% ( 128/128 )
================================================================================

Test Suites: 2 passed, 2 total
Tests:       28 passed, 28 total
Snapshots:   0 total
Time:        2.104 s
Ran all test suites matching /lib\/lambdas\/nodejs\/lib\/x509-certs\//i.
Done in 2.71s.
```

Also ran the full RFDK tests (`yarn test` from the `packages/aws-rfdk` directory) on an Amazon Linux 2 and from within the `jsii/superchain:1-buster-slim-node14` container and both succeeded.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
