### PR TITLE
fix(deadline): change dependency when configuring repository clients …

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -841,7 +841,7 @@ export class Repository extends Construct implements IRepository {
 
     // Add an explicit dependency on the Repository. This ensures that deployments of the Repository construct precede
     // deployments of the client and the repository is fully setup.
-    props.containers.taskDefinition.node.addDependency(this);
+    props.containers.taskDefinition.node.addDependency(this.installerGroup);
 
     // Configure a named volume in the task-definition that points to the container host's mount-point of the repository
     // file-system
@@ -875,7 +875,7 @@ export class Repository extends Construct implements IRepository {
   public configureClientInstance(props: InstanceDirectConnectProps): void {
     // Add an explicit dependency on the Repository. This ensures that deployments of the Repository construct precede
     // deployments of the client and the repository is fully setup.
-    props.host.node.addDependency(this);
+    props.host.node.addDependency(this.installerGroup);
 
     this.setupDirectConnect(props.host, props.mountPoint);
 


### PR DESCRIPTION
The `configureClientX` methods of the `Repository` explicitly add a dependency on the `Repository` construct for the client being configured. This caused a circular dependency between the security group of the `DeploymentInstance` in the `RenderQueue` that configures Deadline Secrets Management and the `SecurityGroupIngress` rules created for both the repository file system and the database security groups.

This resolves this issue by depending on the installer ASG of `Repository` instead of the entire construct, which removes the dependency on the `SecurityGroupIngress` rules mentioned.

This change affected the following resources in my synthesized SEP example app:
- RenderQueueConfigureRepositoryASGInstanceRoleDefaultPolicy7E48B0F4
- RenderQueueConfigureRepositoryASGInstanceRole784FD930
- RenderQueueConfigureRepositoryASGInstanceSecurityGroup0D830E15
- RenderQueueConfigureRepositoryASGLaunchConfig1FC70216
- RenderQueueConfigureRepositoryDeploymentInstanceLogGroupWrapperC9F7AFDD
- RenderQueueConfigureRepositoryStringParameter7292654A

<details><summary>Dependencies that were removed: (based on my cdk synth of the SEP example)</summary>

```json
[
        "RepositoryDocumentDatabaseInstance16AEFBD22",
        "RepositoryDocumentDatabase4A1EFF43",
        "RepositoryDocumentDatabaseSecretAttachment02F024E0",
        "RepositoryDocumentDatabaseSecretC7D4DD31",
        "RepositoryDocumentDatabaseSecurityGroupfromSEPStackRenderQueueClusterRCSCapacityInstanceSecurityGroup8A8F7712IndirectPortFD7F871A",
        "RepositoryDocumentDatabaseSecurityGroupfromSEPStackRenderQueueConfigureRepositoryASGInstanceSecurityGroup868459FCIndirectPort6B0231DC",
        "RepositoryDocumentDatabaseSecurityGroupfromSEPStackRepositoryInstallerInstanceSecurityGroupAA565053IndirectPort1B5B934C",
        "RepositoryDocumentDatabaseSecurityGroup5238B91F",
        "RepositoryDocumentDatabaseSubnetsAAD9E2E3",
        "RepositoryFileSystemAccessPointF8D7F7D7",
        "RepositoryFileSystemEfsSecurityGroupfromSEPStackRenderQueueClusterRCSCapacityInstanceSecurityGroup8A8F771220499F851974",
        "RepositoryFileSystemEfsSecurityGroupfromSEPStackRenderQueueConfigureRepositoryASGInstanceSecurityGroup868459FC204995674470",
        "RepositoryFileSystemEfsSecurityGroupfromSEPStackRepositoryInstallerInstanceSecurityGroupAA56505320497FAD3796",
        "RepositoryFileSystemEfsSecurityGroupfromSEPStackRepositoryPadEfsStorageLambdaSecurityGroupC11AA3B8204957EE662B",
        "RepositoryFileSystemEfsSecurityGroup2F80AB4B",
        "RepositoryFileSystemPaddingAccessPointB0563FFF",
        "RepositoryFileSystem7F4576B8",
        "RepositoryPadEfsStorageCustomResourcePolicy41948B60",
        "RepositoryPadEfsStorage3DB86023",
        "RepositoryPadEfsStorageDiskUsageLogRetention271D7DB4",
        "RepositoryPadEfsStorageDiskUsage3F79B285",
        "RepositoryPadEfsStorageDiskUsageServiceRoleDefaultPolicy9E971433",
        "RepositoryPadEfsStorageDiskUsageServiceRoleCB4B1148",
        "RepositoryPadEfsStorageLambdaSecurityGroup29924A18",
        "RepositoryPadEfsStorageLambdaSecurityGrouptoSEPStackRepositoryFileSystemEfsSecurityGroupC5A9510620499551931D",
        "RepositoryPadEfsStoragePadFilesystemLogRetentionEFB167C1",
        "RepositoryPadEfsStoragePadFilesystem33750813",
        "RepositoryPadEfsStoragePadFilesystemServiceRoleDefaultPolicy765C3070",
        "RepositoryPadEfsStoragePadFilesystemServiceRole33EE10CB",
        "RepositoryPadEfsStorageStateMachine97F62484",
        "RepositoryPadEfsStorageStateMachineRoleDefaultPolicy903A88C4",
        "RepositoryPadEfsStorageStateMachineRoleB8775481",
        "RepositoryParameterGroup80396AF6",
        "RepositoryRepositoryLogGroupWrapperCC273A9C",
        "RepositorySMAdminUser24327599",
        "RepositoryStringParameter767222D9"
]
```

</details>

<details><summary>Dependencies that remain: (based on SEP stack)</summary>

```json
[
        "RepositoryFileSystemEfsMountTarget1203FD4FA",
        "RepositoryFileSystemEfsMountTarget25DF8B8CA",
        "RepositoryInstallerASGFEABE4E4",
        "RepositoryInstallerInstanceProfile4A373BA0",
        "RepositoryInstallerInstanceRoleDefaultPolicy6CFA3306",
        "RepositoryInstallerInstanceRole360B8949",
        "RepositoryInstallerInstanceSecurityGroup4F6D60A1",
        "RepositoryInstallerLaunchConfig827056E5",
]
```

</details>

### Testing
- Verified the basic (tiered) example app deploys and tears down successfully
- Verify the SEP (single stack) example app deploys and tears down successfully

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
