### PR TITLE
chore(docs): link to 0.38.0 upgrade docs in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### ⚠ BREAKING CHANGES
 
-RFDK will configure Deadline Secrets Management automatically when using Deadline 10.1.19.x or higher. If your CDK app uses the `Repository` construct with an un-pinned [`VersionQuery`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.VersionQuery.html), then upgrading RFDK set up Deadline Secrets Management. Using Deadline Secrets Management is strongly encouraged for securing Deadline render farms, however it can potentially impact your workflows within Deadline. Please review the [Deadline Secrets Management documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) to learn about the feature.
+RFDK will configure Deadline Secrets Management automatically when using Deadline 10.1.19.x or higher. If your CDK app uses the `Repository` construct with an un-pinned [`VersionQuery`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.VersionQuery.html), then upgrading RFDK will set up Deadline Secrets Management. Using Deadline Secrets Management is strongly encouraged for securing Deadline render farms, however it can potentially impact your workflows within Deadline. Please review the [Deadline Secrets Management documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) to learn about the feature.
 
 See the [RFDK 0.38.x upgrade documentation](https://github.com/aws/aws-rfdk/blob/v0.38.0/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md)
 for more details and guidance on how to upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this project will be documented in this file. See [standa
 * [10.1.9.2 to 10.1.19.4](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
 
 
+### ⚠ BREAKING CHANGES
+
+RFDK will configure Deadline Secrets Management automatically when using Deadline 10.1.19.x or higher. If your CDK app uses the `Repository` construct with an un-pinned [`VersionQuery`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.VersionQuery.html), then upgrading RFDK set up Deadline Secrets Management. Using Deadline Secrets Management is strongly encouraged for securing Deadline render farms, however it can potentially impact your workflows within Deadline. Please review the [Deadline Secrets Management documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) to learn about the feature.
+
+See the [RFDK 0.38.x upgrade documentation](https://github.com/aws/aws-rfdk/blob/v0.38.0/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md)
+for more details and guidance on how to upgrade.
+
 ### Features
 
 * **deadline:** add Deadline Secrets Management integration in the Render Queue ([#528](https://github.com/aws/aws-rfdk/issues/528)) ([48baa18](https://github.com/aws/aws-rfdk/commit/48baa185b274030cab29a235469536585822313f))
@@ -53,7 +60,7 @@ created with an imported EFS Access Point
 the Render Queue will be modified to have it enabled and using the
 default certificate and hosted zone. To keep external TLS disabled, the
 `enabled` flag on the `RenderQueueExternalTLSProps` can be set to false;
-however, we strongly encourage you to enable TLS. See the[RFDK 0.37.x upgrade documentation](https://github.com/aws/aws-rfdk/blob/v0.37.0/packages/aws-rfdk/docs/upgrade/upgrading-0.37.md)
+however, we strongly encourage you to enable TLS. See the [RFDK 0.37.x upgrade documentation](https://github.com/aws/aws-rfdk/blob/v0.37.0/packages/aws-rfdk/docs/upgrade/upgrading-0.37.md)
 for more details and guidance on how to upgrade.
 
 ### Features


### PR DESCRIPTION
## Problem

When releasing RFDK 0.38.0, we forgot to link to the RFDK 0.38 upgrade documentation.

## Solution

Added a "BREAKING CHANGES" section to the RFDK 0.38.0 changelog section which explains how RFDK will configure Deadline Secrets Management if the `Repository` is provided with the minimum supported version (Deadline 10.1.19.x).

The choice of marking this as a "breaking" change is debatable, however if someone does not pin their `VersionQuery` to a Deadline release, then they would upgrade to using Deadline 10.1.19+ and thus enable Deadline Secrets Management which potentially impacts a user's workflows/automation.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
