### PR TITLE
fix(deadline): configure identity registration settings using RenderQueue backend security group

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -378,7 +378,7 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
   /**
    * Depend on this to ensure that ECS Service is stable.
    */
-  private ecsServiceStabilized: WaitForStableService;
+  private readonly ecsServiceStabilized: WaitForStableService;
 
   constructor(scope: Construct, id: string, private readonly props: RenderQueueProps) {
     super(scope, id);
@@ -973,6 +973,7 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
     const deploymentInstanceNode = this.node.tryFindChild(CONFIGURE_REPOSITORY_CONSTRUCT_ID);
     if (deploymentInstanceNode === undefined) {
       return new DeploymentInstance(this, CONFIGURE_REPOSITORY_CONSTRUCT_ID, {
+        securityGroup: this.backendConnections.securityGroups[0],
         vpc: this.props.vpc,
         vpcSubnets: this.props.vpcSubnets ?? RenderQueue.DEFAULT_VPC_SUBNETS_OTHER,
       });

--- a/packages/aws-rfdk/lib/deadline/lib/secrets-management.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/secrets-management.ts
@@ -134,7 +134,6 @@ export class SecretsManagementIdentityRegistration extends Construct {
     });
 
     // Install python dependencies
-    this.preparePythonEnvironment(props);
     const localScriptFile = this.preparePythonScript(props);
     this.runPythonScript(props, localScriptFile);
 
@@ -284,14 +283,6 @@ export class SecretsManagementIdentityRegistration extends Construct {
         '--restartstalled', 'true',
         '--autoupdateoverride', 'False',
       ].join(' '),
-    );
-  }
-
-  private preparePythonEnvironment(props: SecretsManagementIdentityRegistrationProps) {
-    // The script must run as ec2-user because Repository.configureClientInstance(...) used above will store the
-    // credentials in a per-user credential store that is only available to "ec2-user".
-    props.deploymentInstance.userData.addCommands(
-      'sudo -u ec2-user python3 -m pip install --user boto3',
     );
   }
 }

--- a/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
@@ -2904,6 +2904,36 @@ describe('RenderQueue', () => {
       }));
     });
 
+    test('DeploymentInstance uses specified backend security group', () => {
+      // GIVEN
+      const backendSecurityGroupId = 'backend-sg-id';
+      const backendSecurityGroup = SecurityGroup.fromSecurityGroupId(stack, 'BackendSG', backendSecurityGroupId);
+      rqSecretsManagementProps = {
+        ...rqSecretsManagementProps,
+        securityGroups: {
+          backend: backendSecurityGroup,
+        },
+      };
+
+      // WHEN
+      const renderQueue = new RenderQueue(stack, 'SecretsManagementRenderQueue', rqSecretsManagementProps);
+
+      // THEN
+      // eslint-disable-next-line dot-notation
+      expect(renderQueue['deploymentInstance'].connections.securityGroups[0].securityGroupId).toEqual(backendSecurityGroupId);
+    });
+
+    test('DeploymentInstance uses implicitly created backend security group', () => {
+      // WHEN
+      const renderQueue = new RenderQueue(stack, 'SecretsManagementRenderQueue', rqSecretsManagementProps);
+
+      // THEN
+      // eslint-disable-next-line dot-notation
+      expect(renderQueue['deploymentInstance'].connections.securityGroups[0]).toBe(renderQueue.backendConnections.securityGroups[0]);
+      // eslint-disable-next-line dot-notation
+      expect(renderQueue['deploymentInstance'].connections.securityGroups[0]).toBe(renderQueue.asg.connections.securityGroups[0]);
+    });
+
     describe('client calls .configureSecretsManagementAutoRegistration()', () => {
       let callParams: any;
       let clientInstance: Instance;

--- a/packages/aws-rfdk/lib/deadline/test/secrets-management.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/secrets-management.test.ts
@@ -249,17 +249,6 @@ describe('SecretsManagementIdentityRegistration', () => {
       }));
     });
 
-    test('sets up Python environment', () => {
-      // WHEN
-      createTarget();
-
-      // THEN
-      // The script requires boto3 to query the subnets CIDR. This script runs
-      // as the ec2-user so we install this into the user's package directory
-      expect(deploymentInstance.userData.addCommands)
-        .toHaveBeenCalledWith('sudo -u ec2-user python3 -m pip install --user boto3');
-    });
-
     test('configures direct repository connection', () => {
       // WHEN
       createTarget();


### PR DESCRIPTION
Fixes #632

## Problem

See #632.

The root cause of the problem is that the internal `DeploymentInstance` created by the `RenderQueue` to configure Deadline Secrets Management [identity registration settings](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html#identity-management-registration-settings-ref-label) performs a number of actions that require network access to AWS service API endpoints and PyPI to fetch the `boto3` package.

When this instance is deployed in an isolated subnet (no internet access) PyPI cannot be reached. Also, when the `DeploymentInstance` cannot reach VPC endpoints, the user-data commands fail. The user-data is unable to send any signal to CloudFormation and the signal timeout rolls back the CloudFormation deployment.

## Solution

### VPC Endpoint Reachability

To deploying the `RenderQueue` into isolated subnets, the VPC supplied to the `RenderQueue` must be configured with sufficient VPC [gateway/interface endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html). The subnets specified by the `vpcSubnets` prop supplied to the `RenderQueue` must be configured with routes to the endpoints. 

In the case of [VPC interface endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html), each VPC interface endpoint will have an associated security group. Those security groups must allow ingress from the security groups of the `DeploymentInstance`. In RFDK 0.38.0, the `DeploymentInstance` created by the `RenderQueue` was created with its own Security Group, and there was no public API for RFDK users to access it. To overcome this, the following changes were made:

1.  Modified the `DeploymentInstance` internal construct to accept a `securityGroup` propery and forward this to the `AutoScalingGroup` created
2.  Modified the `RenderQueue` to construct its `DeploymentInstance` using its existing backend security group (used by the `RenderQueue`'s Auto-Scaling Group)

By having the `DeploymentInstance` share a security group with the other backend infrastructure of the `RenderQueue` (currently just the Auto-Scaling Group providing ECS capacity), users can then use the [`RenderQueue.backendConnections`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.RenderQueue.html#backendconnections) API to permit network traffic from the `DeploymentInstance` to the security group associated with the required VPC interface endpoints.

RFDK users who had deployed the `RenderQueue` into isolated subnets prior to RFDK 0.38.0 and used the `RenderQueue.backendConnections` API to permit traffic to their VPC interface endpoints will require no further changes. Similarly, if a user had instead used `RenderQueue.asg.connections` to permit access to their VPC interface endpoints will also require no change to their code.

### PyPI Reachability

To allow the `RenderQueue` is deployed into private subnets with no route to an internet gateway, the logic in the `configure_identity_registration_settings.py` was changed from using boto3 to instead launch a sub-process to invoke the equivalent AWS CLI commands.

## Testing

Reproduced the issue with the following CDK app: [minimal-rfdk-isolated-rq-deadline-sm-reproducer.tar.gz](https://github.com/aws/aws-rfdk/files/7557188/minimal-rfdk-isolated-rq-deadline-sm-reproducer.tar.gz)

To reproduce the problem, you must extract the archive, then from the extracted directory, run the following commands:

```sh
npm install
npm run stage
npm run build
npx cdk deploy "*"
```

To test the fix, I have simply [build and packaged the RFDK](https://github.com/aws/aws-rfdk/blob/mainline/CONTRIBUTING.md#building-the-packages) using this PR branch. Once built and packaged, I then installed the package using [these instructions](https://github.com/aws/aws-rfdk/blob/mainline/CONTRIBUTING.md#option-2----use-npmpip-to-install-the-rfdk-packages-into-your-environment). Finally, I re-deployed with:

```sh
npx cdk deploy "*"
```

and confirmed that the deployment succeeds and that the identity registration settings get applied correctly..

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
