### PR TITLE
chore(docs): fix upgrade documentation version to 0.40

### DIFF
--- a/packages/aws-rfdk/docs/upgrade/index.md
+++ b/packages/aws-rfdk/docs/upgrade/index.md
@@ -7,4 +7,4 @@ upgrading to (or beyond) a version listed below, you should consult the the link
 *   [`0.27.x`](./upgrading-0.27.md)
 *   [`0.37.x`](./upgrading-0.37.md)
 *   [`0.38.x`](./upgrading-0.38.md)
-*   [`0.39.x`](./upgrading-0.39.md)
+*   [`0.40.x`](./upgrading-0.40.md)

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.40.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.40.md
@@ -1,13 +1,13 @@
-# Upgrading to RFDK v0.39.x or Newer
+# Upgrading to RFDK v0.40.x or Newer
 
-Starting in RFDK v0.39.0, the `SpotEventPluginFleet` construct now creates an [EC2 Launch Template](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html)
+Starting in RFDK v0.40.0, the `SpotEventPluginFleet` construct now creates an [EC2 Launch Template](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html)
 instead of using Launch Specifications. This change will reconfigure the Spot Event Plugin settings in Deadline to use a new Spot Fleet Request configuration. If you have active
-Spot Fleet Requests created by the Spot Event Plugin, upgrading to RFDK v0.39.x and redeploying your render farm will orphan those Spot Fleet Requests. Therefore, we highly
-recommend following these instructions to upgrade to RFDK v0.39.x:
+Spot Fleet Requests created by the Spot Event Plugin, upgrading to RFDK v0.40.x and redeploying your render farm will orphan those Spot Fleet Requests. Therefore, we highly
+recommend following these instructions to upgrade to RFDK v0.40.x:
 
 1. Disable the Spot Event Plugin in Deadline. Refer to the [Spot Event Plugin "State" option in Deadline](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/event-spot-configuration-options.html)
 for more information.
 2. Cancel any Spot Fleet Requests created by the Spot Event Plugin, which you can do by following these [instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-spot-fleets.html#cancel-spot-fleet).
-3. Upgrade to RFDK v0.39.x and redeploy your render farm.
+3. Upgrade to RFDK v0.40.x and redeploy your render farm.
 4. Once the deployment is complete, re-enable the Spot Event Plugin in Deadline. Refer to the [Spot Event Plugin "State" option in Deadline](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/event-spot-configuration-options.html)
 for more information.


### PR DESCRIPTION
Updates the RFDK version in the upgrade documentation added in https://github.com/aws/aws-rfdk/pull/513 to the correct version `0.40.x`

Note that the CHANGELOG in the release PR will need to be manually modified so the `BREAKING CHANGE` commit message is updated with the correct link

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
