### PR TITLE
chore(integ): set secrets management admin credentials to destroy

### DIFF
--- a/integ/lib/storage-struct.ts
+++ b/integ/lib/storage-struct.ts
@@ -228,6 +228,7 @@ export class StorageStruct extends Construct {
       },
       secretsManagementSettings: {
         enabled: props.enableSecretsManagement ?? false,
+        credentialsRemovalPolicy: RemovalPolicy.DESTROY,
       },
     });
 


### PR DESCRIPTION
This sets the removal policy to destroy for the secret containing the Deadline Secrets Management admin credentials in the integration tests, so they don't get left behind to clutter up our AWS account after a run.

I tested this by deploying the Secrets Management test suite into my AWS account and confirmed that there was no SMAdmin secret still in the account after the tests finished tearing down.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
