### PR TITLE
fix(lambda-layers): add ap-southeast-3 to region deny list

### DIFF
--- a/lambda-layers/lib/get-regions.ts
+++ b/lambda-layers/lib/get-regions.ts
@@ -9,6 +9,7 @@ import { SSM } from 'aws-sdk';
 const REGION_DENY_LIST = [
   'af-south-1',
   'ap-east-1',
+  'ap-southeast-3',
   'eu-south-1',
   'me-south-1',
 ];


### PR DESCRIPTION
The `ap-southeast-3` region has been added to AWS as an opt-in region. (See "Available Regions" under https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html ).

This PR adds this region to the region deny list for building lambda layers.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
