### PR TITLE
chore: update lambda runtimes to node 16

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -138,7 +138,7 @@ export class ExportingLogGroup extends Construct {
       handler: 'index.handler',
       lambdaPurpose: 'LogGroupExporter',
       logRetention: RetentionDays.ONE_DAY,
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       uuid: this.LOG_EXPORTER_UUID,
     });
 

--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -394,7 +394,7 @@ export class HealthMonitor extends HealthMonitorBase {
 
     this.unhealthyFleetActionLambda = new SingletonFunction(this, 'UnhealthyFleetAction', {
       code: Code.fromAsset(path.join(__dirname, '..', '..', 'lambdas', 'nodejs', 'unhealthyFleetAction')),
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       handler: 'index.handler',
       lambdaPurpose: 'unhealthyFleetTermination',
       timeout: Duration.seconds(300),

--- a/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
@@ -165,7 +165,7 @@ export class ImportedAcmCertificate extends Construct implements ICertificate {
       },
       layers: [ openSslLayer ],
       retryAttempts: 0,
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       timeout: Duration.minutes(5),
     });
 

--- a/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
@@ -198,7 +198,7 @@ export class MongoDbPostInstallSetup extends Construct {
       environment: {
         DEBUG: 'false',
       },
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       handler: 'mongodb.configureMongo',
       layers: [ openSslLayer ],
       timeout: Duration.minutes(2),

--- a/packages/aws-rfdk/lib/core/lib/pad-efs-storage.ts
+++ b/packages/aws-rfdk/lib/core/lib/pad-efs-storage.ts
@@ -196,7 +196,7 @@ export class PadEfsStorage extends Construct {
 
     const lambdaProps: any = {
       code: Code.fromAsset(path.join(__dirname, '..', '..', 'lambdas', 'nodejs')),
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_16_X,
       logRetention: RetentionDays.ONE_WEEK,
       // Required for access point...
       vpc: props.vpc,

--- a/packages/aws-rfdk/lib/core/lib/staticip-server.ts
+++ b/packages/aws-rfdk/lib/core/lib/staticip-server.ts
@@ -324,7 +324,7 @@ export class StaticPrivateIpServer extends Construct implements IConnectable, IG
       eventHandler = new LambdaFunction(stack, functionUniqueId, {
         code: handlerCode,
         handler: 'index.handler',
-        runtime: Runtime.NODEJS_12_X,
+        runtime: Runtime.NODEJS_16_X,
         description: `Created by RFDK StaticPrivateIpServer to process instance launch lifecycle events in stack '${stack.stackName}'. This lambda attaches an ENI to newly launched instances.`,
         logRetention: RetentionDays.THREE_DAYS,
       });

--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -199,7 +199,7 @@ abstract class X509CertificateBase extends Construct {
         DATABASE: this.database.tableName,
         DEBUG: 'false',
       },
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       layers: [ openSslLayer ],
       handler: props.lambdaHandler,
       timeout: Duration.seconds(90),

--- a/packages/aws-rfdk/lib/core/test/mongodb-post-install.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-post-install.test.ts
@@ -119,7 +119,7 @@ describe('MongoDbPostInstall', () => {
           DEBUG: 'false',
         },
       },
-      Runtime: 'nodejs12.x',
+      Runtime: 'nodejs16.x',
       VpcConfig: {
         SecurityGroupIds: [
           {

--- a/packages/aws-rfdk/lib/core/test/pad-efs-storage.test.ts
+++ b/packages/aws-rfdk/lib/core/test/pad-efs-storage.test.ts
@@ -79,7 +79,7 @@ describe('Test PadEfsStorage', () => {
           },
         ],
         Handler: 'pad-efs-storage.getDiskUsage',
-        Runtime: 'nodejs14.x',
+        Runtime: 'nodejs16.x',
         Timeout: 300,
         VpcConfig: {
           SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],
@@ -104,7 +104,7 @@ describe('Test PadEfsStorage', () => {
           },
         ],
         Handler: 'pad-efs-storage.padFilesystem',
-        Runtime: 'nodejs14.x',
+        Runtime: 'nodejs16.x',
         Timeout: 900,
         VpcConfig: {
           SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],

--- a/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
+++ b/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
@@ -88,7 +88,7 @@ describe('Test StaticIpServer', () => {
 
     cdkExpect(stack).to(haveResourceLike('AWS::Lambda::Function', {
       Handler: 'index.handler',
-      Runtime: 'nodejs12.x',
+      Runtime: 'nodejs16.x',
       Description: 'Created by RFDK StaticPrivateIpServer to process instance launch lifecycle events in stack \'StackName\'. This lambda attaches an ENI to newly launched instances.',
     }));
 

--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -448,7 +448,7 @@ export class ConfigureSpotEventPlugin extends Construct {
         DEBUG: 'false',
         LAMBDA_TIMEOUT_MINS: timeoutMins.toString(),
       },
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       handler: 'configure-spot-event-plugin.configureSEP',
       timeout: Duration.minutes(timeoutMins),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
@@ -195,7 +195,7 @@ AWS Thinkbox EULA.
       uuid: '08553416-1fc9-4be9-a818-609a31ae1b5b',
       description: 'Used by the ThinkboxDockerImages construct to look up the ECR repositories where AWS Thinkbox publishes Deadline container images.',
       code: lambdaCode,
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       handler: 'ecr-provider.handler',
       timeout: Duration.seconds(30),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/lib/version-query.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/version-query.ts
@@ -168,7 +168,7 @@ export class VersionQuery extends VersionQueryBase {
       uuid: '2e19e243-16ee-4d1a-a3c9-18d35eddd446',
       description: 'Used by the Version construct to get installer locations for a specific Deadline version.',
       code: lambdaCode,
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       handler: 'version-provider.handler',
       timeout: Duration.seconds(30),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/lib/wait-for-stable-service.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/wait-for-stable-service.ts
@@ -74,7 +74,7 @@ export class WaitForStableService extends Construct {
       environment: {
         DEBUG: 'false',
       },
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_16_X,
       handler: 'wait-for-stable-service.wait',
       timeout: Duration.minutes(15),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/test/version-query.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/version-query.test.ts
@@ -64,7 +64,7 @@ test('VersionQuery constructor full version', () => {
         'Arn',
       ],
     },
-    Runtime: 'nodejs12.x',
+    Runtime: 'nodejs16.x',
   }));
 });
 

--- a/packages/aws-rfdk/lib/deadline/test/wait-for-stable-service.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/wait-for-stable-service.test.ts
@@ -89,7 +89,7 @@ describe('WaitForStableService', () => {
           DEBUG: 'false',
         },
       },
-      Runtime: 'nodejs12.x',
+      Runtime: 'nodejs16.x',
       Timeout: 900,
     }));
   });


### PR DESCRIPTION
### Changes
Updates the Node.js runtimes for our Lambda functions to v16

### Testing
`yarn build`, then ran the integration tests and verified they succeeded

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
