### PR TITLE
feat(deadline): update to Deadline licensing terms

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
@@ -32,15 +32,13 @@ These instructions assume that your working directory is `examples/deadline/All-
     popd
     pip install ../../../../dist/python/aws-rfdk-<version>.tar.gz
     ```
-4.  You must read and accept the [AWS Thinkbox End-User License Agreement (EULA)](https://www.awsthinkbox.com/end-user-license-agreement) to deploy and run Deadline. To do so, change the value of the `accept_aws_thinkbox_eula` in `package/config.py`:
+4.  By downloading or using the Deadline software, you agree to the [AWS Customer Agreement](https://aws.amazon.com/agreement/)
+    and [AWS Intellectual Property License](https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+    is AWS Content as defined in those Agreements.
+    To accept these terms, change the value of `accept_aws_customer_agreement_and_ip_license` in `package/config.py`:
 
     ```py
-    # Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA
-    # for Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before
-    # using the AWS Thinkbox Deadline container images.
-    #
-    # See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
-    self.accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA
+    self.accept_aws_customer_agreement_and_ip_license: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
     ```
 5.  Change the value of the `deadline_version` variable in `package/config.py` to specify the desired version of Deadline to be deployed to your render farm. RFDK is compatible with Deadline versions 10.1.9.x and later. To see the available versions of Deadline, consult the [Deadline release notes](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html). It is recommended to use the latest version of Deadline available when building your farm, but to pin this version when the farm is ready for production use. For example, to pin to the latest `10.1.12.x` release of Deadline, use:
 

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/app.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/app.py
@@ -113,7 +113,7 @@ def main():
         root_ca=security.root_ca,
         dns_zone=network.dns_zone,
         deadline_version=config.deadline_version,
-        accept_aws_thinkbox_eula=config.accept_aws_thinkbox_eula,
+        user_aws_customer_agreement_and_ip_license_acceptance=config.accept_aws_customer_agreement_and_ip_license,
         enable_secrets_management=config.enable_secrets_management,
         secrets_management_secret_arn=config.secrets_management_secret_arn
     )

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/config.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/config.py
@@ -9,7 +9,7 @@ from typing import (
 
 from aws_rfdk import MongoDbSsplLicenseAcceptance
 from aws_rfdk.deadline import (
-    AwsThinkboxEulaAcceptance,
+    AwsCustomerAgreementAndIpLicenseAcceptance,
     UsageBasedLicense
 )
 
@@ -21,12 +21,11 @@ class AppConfig:
     TODO: Fill these in with your own values.
     """
     def __init__(self):
-        # Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA
-        # for Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before
-        # using the AWS Thinkbox Deadline container images.
-        #
-        # See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
-        self.accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA
+        # By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+        # and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+        # is AWS Content as defined in those Agreements.
+        # To accept these terms, change the value here to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
+        self.accept_aws_customer_agreement_and_ip_license: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
 
         # Fill this in if you want to receive alarm emails when:
         # 1) You are crossing thresholds on decreasing burst Credits on the Amazon EFS that is

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/service_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/service_tier.py
@@ -32,7 +32,7 @@ from aws_rfdk import (
     X509CertificatePem
 )
 from aws_rfdk.deadline import (
-    AwsThinkboxEulaAcceptance,
+    AwsCustomerAgreementAndIpLicenseAcceptance,
     DatabaseConnection,
     RenderQueue,
     RenderQueueHostNameProps,
@@ -74,8 +74,8 @@ class ServiceTierProps(StackProps):
     dns_zone: IPrivateHostedZone
     # Version of Deadline to use
     deadline_version: str
-    # Whether the AWS Thinkbox End-User License Agreement is accepted or not
-    accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance
+    # Whether the AWS Customer Agreement and AWS Intellectual Property License are agreed to.
+    user_aws_customer_agreement_and_ip_license_acceptance: AwsCustomerAgreementAndIpLicenseAcceptance
     # Whether to enable Deadline Secrets Management.
     enable_secrets_management: bool
     # The ARN of the AWS Secret containing the admin credentials for Deadline Secrets Management.
@@ -155,7 +155,7 @@ class ServiceTier(Stack):
             self,
             'Images',
             version=self.version,
-            user_aws_thinkbox_eula_acceptance=props.accept_aws_thinkbox_eula
+            user_aws_customer_agreement_and_ip_license_acceptance=props.user_aws_customer_agreement_and_ip_license_acceptance
         )
 
         server_cert = X509CertificatePem(

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
@@ -18,18 +18,15 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```
     yarn install
     ```
-3.  You must read and accept the [AWS Thinkbox End-User License Agreement (EULA)](https://www.awsthinkbox.com/end-user-license-agreement) to deploy and run Deadline. To do so, change the value of the `acceptAwsThinkboxEula` in `bin/config.ts`:
+3.  By downloading or using the Deadline software, you agree to the [AWS Customer Agreement](https://aws.amazon.com/agreement/)
+    and [AWS Intellectual Property License](https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+    is AWS Content as defined in those Agreements.
+    To accept these terms, change the value of `acceptAwsCustomerAgreementAndIpLicense` in `bin/config.ts`:
 
     ```ts
-    /**
-     * Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA for
-     * Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before using the
-     * AWS Thinkbox Deadline container images.
-     *
-     * See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
-     */
-    public readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA;
+    public readonly acceptAwsCustomerAgreementAndIpLicense: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
     ```
+
 4.  Change the value of the `deadlineVersion` variable in `bin/config.ts` to specify the desired version of Deadline to be deployed to your render farm. RFDK is compatible with Deadline versions 10.1.9.x and later. To see the available versions of Deadline, consult the [Deadline release notes](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html). It is recommended to use the latest version of Deadline available when building your farm, but to pin this version when the farm is ready for production use. For example, to pin to the latest `10.1.12.x` release of Deadline, use:
 
     ```ts

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
@@ -111,7 +111,7 @@ const service = new ServiceTier(app, 'ServiceTier', {
   ublLicenses: config.ublLicenses,
   rootCa: security.rootCa,
   dnsZone: network.dnsZone,
-  acceptAwsThinkboxEula: config.acceptAwsThinkboxEula,
+  userAwsCustomerAgreementAndIpLicenseAcceptance: config.acceptAwsCustomerAgreementAndIpLicense,
   enableSecretsManagement: config.enableSecretsManagement,
   secretsManagementSecretArn: config.secretsManagementSecretArn
 });

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/config.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/config.ts
@@ -6,7 +6,7 @@
 import 'source-map-support/register';
 import { UsageBasedLicense } from 'aws-rfdk/deadline';
 import { MongoDbSsplLicenseAcceptance } from 'aws-rfdk';
-import { AwsThinkboxEulaAcceptance } from 'aws-rfdk/deadline';
+import { AwsCustomerAgreementAndIpLicenseAcceptance } from 'aws-rfdk/deadline';
 
 /**
  * Configuration values for the sample app.
@@ -15,13 +15,12 @@ import { AwsThinkboxEulaAcceptance } from 'aws-rfdk/deadline';
  */
 class AppConfig {
   /**
-   * Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA for
-   * Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before using the
-   * AWS Thinkbox Deadline container images.
-   *
-   * See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
+   * By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+   * and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+   * is AWS Content as defined in those Agreements.
+   * To accept these terms, change the value here to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
    */
-  public readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA;
+  public readonly acceptAwsCustomerAgreementAndIpLicense: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
 
   /**
    * Fill this in if you want to receive alarm emails when:

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/service-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/service-tier.ts
@@ -20,7 +20,7 @@ import {
   X509CertificatePem,
 } from 'aws-rfdk';
 import {
-  AwsThinkboxEulaAcceptance,
+  AwsCustomerAgreementAndIpLicenseAcceptance,
   DatabaseConnection,
   RenderQueue,
   Repository,
@@ -85,9 +85,9 @@ export interface ServiceTierProps extends cdk.StackProps {
   readonly deadlineVersion?: string;
 
   /**
-   * Whether the AWS Thinkbox End-User License Agreement is accepted or not
+   * Whether the AWS Customer Agreement and AWS Intellectual Property License are agreed to.
    */
-  readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance;
+  readonly userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance;
 
   /**
    * Whether to enable Deadline Secrets Management.
@@ -182,7 +182,7 @@ export class ServiceTier extends cdk.Stack {
 
     const images = new ThinkboxDockerImages(this, 'Images', {
       version: this.version,
-      userAwsThinkboxEulaAcceptance: props.acceptAwsThinkboxEula,
+      userAwsCustomerAgreementAndIpLicenseAcceptance: props.userAwsCustomerAgreementAndIpLicenseAcceptance,
     });
 
     const serverCert = new X509CertificatePem(this, 'RQCert', {

--- a/examples/deadline/EC2-Image-Builder/python/README.md
+++ b/examples/deadline/EC2-Image-Builder/python/README.md
@@ -35,10 +35,13 @@ These instructions assume that your working directory is `examples/deadline/EC2-
     pip install ../../../../dist/python/aws-rfdk-<version>.tar.gz
     ```
 
-4.  You must read and accept the [AWS Thinkbox End-User License Agreement (EULA)](https://www.awsthinkbox.com/end-user-license-agreement) to deploy and run Deadline. To do so, change the value of the `accept_aws_thinkbox_eula` in `package/config.py` like this:
+4.  By downloading or using the Deadline software, you agree to the [AWS Customer Agreement](https://aws.amazon.com/agreement/)
+    and [AWS Intellectual Property License](https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+    is AWS Content as defined in those Agreements.
+    To accept these terms, change the value of `accept_aws_customer_agreement_and_ip_license` in `package/config.py`:
 
     ```py
-    self.accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA
+    self.accept_aws_customer_agreement_and_ip_license: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
     ```
 
 5. Change the value of the `deadline_version` variable in `package/config.py` to specify the desired version of Deadline to be deployed to your render farm. RFDK is compatible with Deadline versions 10.1.9.x and later. To see the available versions of Deadline, consult the [Deadline release notes](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html). It is recommended to use the latest version of Deadline available when building your farm, but to pin this version when the farm is ready for production use. For example, to pin to the `10.1.13` release of Deadline, use `10.1.13.2`.

--- a/examples/deadline/EC2-Image-Builder/python/package/app.py
+++ b/examples/deadline/EC2-Image-Builder/python/package/app.py
@@ -30,7 +30,7 @@ def main():
 
     farm_props = base_farm_stack.BaseFarmStackProps(
         deadline_version=config.deadline_version,
-        accept_aws_thinkbox_eula=config.accept_aws_thinkbox_eula
+        accept_aws_customer_agreement_and_ip_license=config.accept_aws_customer_agreement_and_ip_license
     )
     farm_stack = base_farm_stack.BaseFarmStack(app, 'BaseFarmStack', props=farm_props, env=env)
 

--- a/examples/deadline/EC2-Image-Builder/python/package/config.py
+++ b/examples/deadline/EC2-Image-Builder/python/package/config.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from aws_rfdk.deadline import AwsThinkboxEulaAcceptance
+from aws_rfdk.deadline import AwsCustomerAgreementAndIpLicenseAcceptance
 
 class AppConfig:
     """
@@ -10,12 +10,11 @@ class AppConfig:
     TODO: Fill these in with your own values.
     """
     def __init__(self):
-        # Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA for
-        # Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before using the
-        # AWS Thinkbox Deadline container images.
-        #
-        # See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
-        self.accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA
+        # By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+        # and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+        # is AWS Content as defined in those Agreements.
+        # To accept these terms, change the value here to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
+        self.accept_aws_customer_agreement_and_ip_license: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
 
         # The version of Deadline to install on the AMI. This can be either a partial version that will use the latest patch, such as
         # '10.1' or '10.1.13', or a full version that will be pinned to a specific patch release, such as '10.1.13.1'.

--- a/examples/deadline/EC2-Image-Builder/python/package/lib/base_farm_stack.py
+++ b/examples/deadline/EC2-Image-Builder/python/package/lib/base_farm_stack.py
@@ -12,7 +12,7 @@ from aws_cdk.aws_ec2 import (
     Vpc,
 )
 from aws_rfdk.deadline import (
-    AwsThinkboxEulaAcceptance,
+    AwsCustomerAgreementAndIpLicenseAcceptance,
     RenderQueue,
     Repository,
     RepositoryRemovalPolicies,
@@ -26,8 +26,8 @@ from constructs import (
 
 @dataclass
 class BaseFarmStackProps(StackProps):
-    # Whether the AWS Thinkbox End-User License Agreement is accepted or not
-    accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance
+    # Whether the AWS Customer Agreement and AWS Intellectual Property License are agreed to.
+    accept_aws_customer_agreement_and_ip_license: AwsCustomerAgreementAndIpLicenseAcceptance
 
     # Version of Deadline to use
     deadline_version: str
@@ -61,7 +61,7 @@ class BaseFarmStack(Stack):
             self,
             'Images',
             version=version,
-            user_aws_thinkbox_eula_acceptance=props.accept_aws_thinkbox_eula,
+            user_aws_customer_agreement_and_ip_license_acceptance=props.accept_aws_customer_agreement_and_ip_license,
         )
 
         repository = Repository(

--- a/examples/deadline/EC2-Image-Builder/ts/README.md
+++ b/examples/deadline/EC2-Image-Builder/ts/README.md
@@ -13,10 +13,13 @@ These instructions assume that your working directory is `examples/deadline/EC2-
 ---
 1. This sample app on the `mainline` branch may contain features that have not yet been officially released, and may not be available in the `aws-rfdk` package installed through npm from npmjs. To work from an example of the latest release, please switch to the `release` branch. If you would like to try out unreleased features, you can stay on `mainline` and follow the instructions for building and using the `aws-rfdk` from your local repository.
 
-2.  You must read and accept the [AWS Thinkbox End-User License Agreement (EULA)](https://www.awsthinkbox.com/end-user-license-agreement) to deploy and run Deadline. To do so, change the value of the `acceptAwsThinkboxEula` in `bin/config.ts` like this:
+2.  By downloading or using the Deadline software, you agree to the [AWS Customer Agreement](https://aws.amazon.com/agreement/)
+    and [AWS Intellectual Property License](https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+    is AWS Content as defined in those Agreements.
+    To accept these terms, change the value of `acceptAwsCustomerAgreementAndIpLicense` in `bin/config.ts`:
 
     ```ts
-    public readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA;
+    public readonly acceptAwsCustomerAgreementAndIpLicense: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
     ```
 
 3.  Change the value of the `deadlineVersion` variable in `bin/config.ts` to specify the desired version of Deadline to be deployed to your render farm. RFDK is compatible with Deadline versions 10.1.9.x and later. To see the available versions of Deadline, consult the [Deadline release notes](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html). It is recommended to use the latest version of Deadline available when building your farm, but to pin this version when the farm is ready for production use. For example, to pin to the `10.1.13` release of Deadline, use `10.1.13.2`.

--- a/examples/deadline/EC2-Image-Builder/ts/bin/app.ts
+++ b/examples/deadline/EC2-Image-Builder/ts/bin/app.ts
@@ -22,7 +22,7 @@ const app = new cdk.App();
 const baseFarm = new BaseFarmStack(app, 'BaseFarmStack', {
   env,
   deadlineVersion: config.deadlineVersion,
-  acceptAwsThinkboxEula: config.acceptAwsThinkboxEula,
+  userAwsCustomerAgreementAndIpLicenseAcceptance: config.acceptAwsCustomerAgreementAndIpLicense,
 });
 
 new ComputeStack(app, 'ComputeStack', {

--- a/examples/deadline/EC2-Image-Builder/ts/bin/config.ts
+++ b/examples/deadline/EC2-Image-Builder/ts/bin/config.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AwsThinkboxEulaAcceptance } from 'aws-rfdk/deadline';
+import { AwsCustomerAgreementAndIpLicenseAcceptance } from 'aws-rfdk/deadline';
 
 /**
  * Configuration values for the sample app.
@@ -12,13 +12,12 @@ import { AwsThinkboxEulaAcceptance } from 'aws-rfdk/deadline';
  */
 class AppConfig {
   /**
-   * Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA for
-   * Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before using the
-   * AWS Thinkbox Deadline container images.
-   *
-   * See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
+   * By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+   * and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+   * is AWS Content as defined in those Agreements.
+   * To accept these terms, change the value here to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
    */
-  public readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA;
+  public readonly acceptAwsCustomerAgreementAndIpLicense: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
 
   /**
    * The version of Deadline to install on the AMI. This can be either a partial version that will use the latest patch, such as

--- a/examples/deadline/EC2-Image-Builder/ts/lib/base-farm-stack.ts
+++ b/examples/deadline/EC2-Image-Builder/ts/lib/base-farm-stack.ts
@@ -12,7 +12,7 @@ import {
   StackProps
 } from 'aws-cdk-lib';
 import {
-  AwsThinkboxEulaAcceptance,
+  AwsCustomerAgreementAndIpLicenseAcceptance,
   RenderQueue,
   Repository,
   ThinkboxDockerImages,
@@ -22,9 +22,9 @@ import { Construct } from 'constructs';
 
 export interface FarmProps extends StackProps {
   /**
-   * Whether the AWS Thinkbox End-User License Agreement is accepted or not
+   * Whether the AWS Customer Agreement and AWS Intellectual Property License are agreed to.
    */
-  readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance;
+  readonly userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance;
 
   /**
    * Version of Deadline to use.
@@ -50,7 +50,7 @@ export class BaseFarmStack extends Stack {
 
     const images = new ThinkboxDockerImages(this, 'Images', {
       version: version,
-      userAwsThinkboxEulaAcceptance: props.acceptAwsThinkboxEula,
+      userAwsCustomerAgreementAndIpLicenseAcceptance: props.userAwsCustomerAgreementAndIpLicenseAcceptance,
     });
 
     const repository = new Repository(this, 'Repository', {

--- a/examples/deadline/Local-Zone/python/README.md
+++ b/examples/deadline/Local-Zone/python/README.md
@@ -35,10 +35,13 @@ These instructions assume that your working directory is `examples/deadline/Loca
     pip install ../../../../dist/python/aws-rfdk-<version>.tar.gz
     ```
 
-4.  You must read and accept the [AWS Thinkbox End-User License Agreement (EULA)](https://www.awsthinkbox.com/end-user-license-agreement) to deploy and run Deadline. To do so, change the value of the `accept_aws_thinkbox_eula` in `package/lib/config.py` like this:
+4.  By downloading or using the Deadline software, you agree to the [AWS Customer Agreement](https://aws.amazon.com/agreement/)
+    and [AWS Intellectual Property License](https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+    is AWS Content as defined in those Agreements.
+    To accept these terms, change the value of `accept_aws_customer_agreement_and_ip_license` in `package/config.py`:
 
     ```py
-    self.accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA
+    self.accept_aws_customer_agreement_and_ip_license: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
     ```
 
 5. Change the value of the `deadline_version` variable in `package/config.py` to specify the desired version of Deadline to be deployed to your render farm. RFDK is compatible with Deadline versions 10.1.9.x and later. To see the available versions of Deadline, consult the [Deadline release notes](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html). It is recommended to use the latest version of Deadline available when building your farm, but to pin this version when the farm is ready for production use. For example, to pin to the latest `10.1.15.x` release of Deadline, use:

--- a/examples/deadline/Local-Zone/python/package/app.py
+++ b/examples/deadline/Local-Zone/python/package/app.py
@@ -70,7 +70,7 @@ def main():
         root_ca=security.root_ca,
         dns_zone=network.dns_zone,
         deadline_version=config.config.deadline_version,
-        accept_aws_thinkbox_eula=config.config.accept_aws_thinkbox_eula
+        user_aws_customer_agreement_and_ip_license_acceptance=config.config.accept_aws_customer_agreement_and_ip_license
     )
     service = service_tier.ServiceTier(app, 'ServiceTier', props=service_props, env=env)
 

--- a/examples/deadline/Local-Zone/python/package/lib/config.py
+++ b/examples/deadline/Local-Zone/python/package/lib/config.py
@@ -8,7 +8,7 @@ from typing import (
 )
 
 from aws_rfdk.deadline import (
-    AwsThinkboxEulaAcceptance,
+    AwsCustomerAgreementAndIpLicenseAcceptance,
 )
 
 
@@ -19,12 +19,11 @@ class AppConfig:
     TODO: Fill these in with your own values.
     """
     def __init__(self):
-        # Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA
-        # for Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before
-        # using the AWS Thinkbox Deadline container images.
-        #
-        # See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
-        self.accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA
+        # By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+        # and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+        # is AWS Content as defined in those Agreements.
+        # To accept these terms, change the value here to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
+        self.accept_aws_customer_agreement_and_ip_license: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
 
         # The standard availability zones that the render farm will deploy into. It is recommended to use at least
         # two and they must be from the same region. The default values being provided are two of the four standard

--- a/examples/deadline/Local-Zone/python/package/lib/service_tier.py
+++ b/examples/deadline/Local-Zone/python/package/lib/service_tier.py
@@ -27,7 +27,7 @@ from aws_rfdk import (
     X509CertificatePem
 )
 from aws_rfdk.deadline import (
-    AwsThinkboxEulaAcceptance,
+    AwsCustomerAgreementAndIpLicenseAcceptance,
     RenderQueue,
     RenderQueueHostNameProps,
     RenderQueueTrafficEncryptionProps,
@@ -48,8 +48,8 @@ class ServiceTierProps(StackProps):
     """
     # The VPC to deploy service tier resources into.
     vpc: IVpc
-    # Whether the AWS Thinkbox End-User License Agreement is accepted or not
-    accept_aws_thinkbox_eula: AwsThinkboxEulaAcceptance
+    # Whether the AWS Customer Agreement and AWS Intellectual Property License are agreed to.
+    user_aws_customer_agreement_and_ip_license_acceptance: AwsCustomerAgreementAndIpLicenseAcceptance
     # The availability zones that components in this stack will be deployed into. These should all be in the same
     # region and only be standard availability zones, as some constucts use services that aren't available in
     # local zones yet.
@@ -107,7 +107,7 @@ class ServiceTier(Stack):
             self,
             'Images',
             version=self.version,
-            user_aws_thinkbox_eula_acceptance=props.accept_aws_thinkbox_eula
+            user_aws_customer_agreement_and_ip_license_acceptance=props.user_aws_customer_agreement_and_ip_license_acceptance
         )
 
         server_cert = X509CertificatePem(

--- a/examples/deadline/Local-Zone/ts/README.md
+++ b/examples/deadline/Local-Zone/ts/README.md
@@ -13,10 +13,13 @@ These instructions assume that your working directory is `examples/deadline/Loca
 ---
 1. This sample app on the `mainline` branch may contain features that have not yet been officially released, and may not be available in the `aws-rfdk` package installed through npm from npmjs. To work from an example of the latest release, please switch to the `release` branch. If you would like to try out unreleased features, you can stay on `mainline` and follow the instructions for building and using the `aws-rfdk` from your local repository.
 
-2.  You must read and accept the [AWS Thinkbox End-User License Agreement (EULA)](https://www.awsthinkbox.com/end-user-license-agreement) to deploy and run Deadline. To do so, change the value of the `acceptAwsThinkboxEula` in `bin/config.ts` like this:
+2.  By downloading or using the Deadline software, you agree to the [AWS Customer Agreement](https://aws.amazon.com/agreement/)
+    and [AWS Intellectual Property License](https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+    is AWS Content as defined in those Agreements.
+    To accept these terms, change the value of `acceptAwsCustomerAgreementAndIpLicense` in `bin/config.ts`:
 
     ```ts
-    public readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA;
+    public readonly acceptAwsCustomerAgreementAndIpLicense: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
     ```
 
 3. Change the value of the `deadlineVersion` variable in `bin/config.ts` to specify the desired version of Deadline to be deployed to your render farm. RFDK is compatible with Deadline versions 10.1.9.x and later. To see the available versions of Deadline, consult the [Deadline release notes](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html). It is recommended to use the latest version of Deadline available when building your farm, but to pin this version when the farm is ready for production use. For example, to pin to the latest `10.1.15.x` release of Deadline, use:

--- a/examples/deadline/Local-Zone/ts/bin/app.ts
+++ b/examples/deadline/Local-Zone/ts/bin/app.ts
@@ -45,7 +45,7 @@ const service = new ServiceTier(app, 'ServiceTier', {
   deadlineVersion: config.deadlineVersion,
   rootCa: security.rootCa,
   dnsZone: network.dnsZone,
-  acceptAwsThinkboxEula: config.acceptAwsThinkboxEula,
+  userAwsCustomerAgreementAndIpLicenseAcceptance: config.acceptAwsCustomerAgreementAndIpLicense,
 });
 
 new ComputeTier(app, 'ComputeTier', {

--- a/examples/deadline/Local-Zone/ts/bin/config.ts
+++ b/examples/deadline/Local-Zone/ts/bin/config.ts
@@ -4,7 +4,7 @@
  */
 
 import 'source-map-support/register';
-import { AwsThinkboxEulaAcceptance } from 'aws-rfdk/deadline';
+import { AwsCustomerAgreementAndIpLicenseAcceptance } from 'aws-rfdk/deadline';
 
 /**
  * Configuration values for the sample app.
@@ -13,13 +13,12 @@ import { AwsThinkboxEulaAcceptance } from 'aws-rfdk/deadline';
  */
 class AppConfig {
   /**
-   * Change this value to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA if you wish to accept the EULA for
-   * Deadline and proceed with Deadline deployment. Users must explicitly accept the AWS Thinkbox EULA before using the
-   * AWS Thinkbox Deadline container images.
-   *
-   * See https://www.awsthinkbox.com/end-user-license-agreement for the terms of the agreement.
+   * By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+   * and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+   * is AWS Content as defined in those Agreements.
+   * To accept these terms, change the value here to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE
    */
-  public readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA;
+  public readonly acceptAwsCustomerAgreementAndIpLicense: AwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
 
   /**
    * The standard availability zones that the render farm will deploy into. It is recommended to use at least

--- a/examples/deadline/Local-Zone/ts/lib/service-tier.ts
+++ b/examples/deadline/Local-Zone/ts/lib/service-tier.ts
@@ -25,7 +25,7 @@ import {
   X509CertificatePem,
 } from 'aws-rfdk';
 import {
-  AwsThinkboxEulaAcceptance,
+  AwsCustomerAgreementAndIpLicenseAcceptance,
   RenderQueue,
   Repository,
   ThinkboxDockerImages,
@@ -43,9 +43,9 @@ export interface ServiceTierProps extends StackProps {
   readonly vpc: IVpc;
 
   /**
-   * Whether the AWS Thinkbox End-User License Agreement is accepted or not
+   * Whether the AWS Customer Agreement and AWS Intellectual Property License are agreed to.
    */
-  readonly acceptAwsThinkboxEula: AwsThinkboxEulaAcceptance;
+  readonly userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance;
 
   /**
    * The availability zones that components in this stack will be deployed into. These should all be in the same
@@ -114,7 +114,7 @@ export class ServiceTier extends Stack {
 
     const images = new ThinkboxDockerImages(this, 'Images', {
       version: this.version,
-      userAwsThinkboxEulaAcceptance: props.acceptAwsThinkboxEula,
+      userAwsCustomerAgreementAndIpLicenseAcceptance: props.userAwsCustomerAgreementAndIpLicenseAcceptance,
     });
 
     const serverCert = new X509CertificatePem(this, 'RQCert', {

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -199,11 +199,11 @@ The following example outlines how to construct a `RenderQueue`:
 const version = new VersionQuery(stack, 'Version', {
   version: '1.2.3.4',
 });
-const images = new ThinkboxDockerImages(stack, 'Images', {
-  version: version,
-  // Change this to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA to accept the terms
-  // of the AWS Thinkbox End User License Agreement
-  userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA,
+const images = new ThinkboxDockerImages(stack, 'Image', {
+  version,
+  // Change this to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to accept the terms
+  // of the AWS Customer Agreement and AWS Intellectual Property License.
+  userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE,
 });
 const repository = new Repository(stack, 'Repository', { /* ...*/});
 
@@ -566,10 +566,11 @@ simplifies using these images.
 
 ---
 
-_**Note:** Deadline is licensed under the terms of the
-[AWS Thinkbox End User License Agreement](https://www.awsthinkbox.com/end-user-license-agreement). Users of
-`ThinkboxDockerImages` must explicitly signify their acceptance of the terms of the AWS Thinkbox EULA through
-`userAwsThinkboxEulaAcceptance` property. By default, `userAwsThinkboxEulaAcceptance` is set to rejection._
+_**Note:** By downloading or using the Deadline software, you agree to the [AWS Customer Agreement](https://aws.amazon.com/agreement/)
+  and [AWS Intellectual Property License](https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+  is AWS Content as defined in those Agreements. Users of `ThinkboxDockerImages` must explicitly signify their acceptance of these terms
+  through the `userAwsCustomerAgreementAndIpLicenseAcceptance` property. By default, `userAwsCustomerAgreementAndIpLicenseAcceptance` is
+  set to reject these terms._
 
 ---
 
@@ -578,10 +579,10 @@ To use it, simply create one:
 
 ```ts
 // This will provide Docker container images for the latest Deadline release
-const images = new ThinkboxDockerImages(scope, 'Images', {
-  // Change this to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA to accept the terms
-  // of the AWS Thinkbox End User License Agreement
-  userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA,
+const images = new ThinkboxDockerImages(stack, 'Image', {
+  // Change this to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to accept the terms
+  // of the AWS Customer Agreement and AWS Intellectual Property License.
+  userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE,
 });
 ```
 
@@ -594,12 +595,13 @@ const version = new VersionQuery(scope, 'Version', {
 });
 
 // This will provide Docker container images for the specified version of Deadline
-const images = new ThinkboxDockerImages(scope, 'Images', {
-  version: version,
-  // Change this to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA to accept the terms
-  // of the AWS Thinkbox End User License Agreement
-  userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA,
+const images = new ThinkboxDockerImages(stack, 'Image', {
+  version,
+  // Change this to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to accept the terms
+  // of the AWS Customer Agreement and AWS Intellectual Property License.
+  userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE,
 });
+
 ```
 
 To use these images, you can use the expressive methods or provide the instance directly to downstream constructs:
@@ -648,12 +650,13 @@ The following example outlines how to construct `UsageBasedLicensing`:
 
 ```ts
 const version = new VersionQuery(stack, 'Version', '1.2.3.4');
-const images = new ThinkboxDockerImages(stack, 'Images', {
-  version: version,
-  // Change this to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA to accept the terms
-  // of the AWS Thinkbox End User License Agreement
-  userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA,
+const images = new ThinkboxDockerImages(stack, 'Image', {
+  version,
+  // Change this to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to accept the terms
+  // of the AWS Customer Agreement and AWS Intellectual Property License.
+  userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE,
 });
+
 
 const ubl = new UsageBasedLicensing(stack, 'UsageBasedLicensing', {
   vpc: vpc,

--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -276,7 +276,7 @@ export interface ConfigureSpotEventPluginProps {
  * ```ts
  * import { App, Stack, Vpc } from '@aws-rfdk/core';
  * import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
- * import { AwsThinkboxEulaAcceptance, ConfigureSpotEventPlugin, RenderQueue, Repository, SpotEventPluginFleet, ThinkboxDockerImages, VersionQuery } from '@aws-rfdk/deadline';
+ * import { AwsCustomerAgreementAndIpLicenseAcceptance, ConfigureSpotEventPlugin, RenderQueue, Repository, SpotEventPluginFleet, ThinkboxDockerImages, VersionQuery } from '@aws-rfdk/deadline';
  * const app = new App();
  * const stack = new Stack(app, 'Stack');
  * const vpc = new Vpc(stack, 'Vpc');
@@ -285,9 +285,9 @@ export interface ConfigureSpotEventPluginProps {
  * });
  * const images = new ThinkboxDockerImages(stack, 'Image', {
  *   version,
- *   // Change this to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA to accept the terms
- *   // of the AWS Thinkbox End User License Agreement
- *   userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA,
+ *   // Change this to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to accept the terms
+ *   // of the AWS Customer Agreement and AWS Intellectual Property License.
+ *   userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE,
  * });
  * const repository = new Repository(stack, 'Repository', {
  *   vpc,

--- a/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
@@ -33,23 +33,24 @@ import {
 } from '.';
 
 /**
- * Choices for signifying the user's stance on the terms of the AWS Thinkbox End-User License Agreement (EULA).
- * See: https://www.awsthinkbox.com/end-user-license-agreement
+ * The ThinkboxDockerImages will install Deadline onto one or more EC2 instances.
+ *
+ * By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+ * and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+ * is AWS Content as defined in those Agreements.
+ *
+ * This enum is used to signify acceptance or rejection of these terms.
  */
-export enum AwsThinkboxEulaAcceptance {
+export enum AwsCustomerAgreementAndIpLicenseAcceptance {
   /**
-   * The user signifies their explicit rejection of the tems of the AWS Thinkbox EULA.
-   *
-   * See: https://www.awsthinkbox.com/end-user-license-agreement
+   * The user signifies their explicit rejection of the terms.
    */
-  USER_REJECTS_AWS_THINKBOX_EULA = 0,
+  USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE = 0,
 
   /**
-   * The user signifies their explicit acceptance of the terms of the AWS Thinkbox EULA.
-   *
-   * See: https://www.awsthinkbox.com/end-user-license-agreement
+   * The user signifies their explicit acceptance of the terms.
    */
-  USER_ACCEPTS_AWS_THINKBOX_EULA = 1,
+  USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE = 1,
 }
 
 /**
@@ -63,12 +64,16 @@ export interface ThinkboxDockerImagesProps {
   readonly version?: IVersion;
 
   /**
-   * Deadline is licensed under the terms of the AWS Thinkbox End-User License Agreement (see: https://www.awsthinkbox.com/end-user-license-agreement).
-   * Users of ThinkboxDockerImages must explicitly signify their acceptance of the terms of the AWS Thinkbox EULA through this
-   * property before the {@link ThinkboxDockerImages} will be allowed to deploy Deadline.
+   * The ThinkboxDockerImages will install Deadline onto one or more EC2 instances.
+   *
+   * By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+   * and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+   * is AWS Content as defined in those Agreements.
+   *
+   * Use this property to indicate whether you accept or reject these terms.
    */
-  // Developer note: It is a legal requirement that the default be USER_REJECTS_AWS_THINKBOX_EULA.
-  readonly userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance;
+  // Developer note: It is a legal requirement that the default be USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE.
+  readonly userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance;
 }
 
 /**
@@ -101,7 +106,7 @@ export interface ThinkboxDockerImagesProps {
  *
  * ```ts
  * import { App, Stack, Vpc } from '@aws-rfdk/core';
- * import { AwsThinkboxEulaAcceptance, RenderQueue, Repository, ThinkboxDockerImages, VersionQuery } from '@aws-rfdk/deadline';
+ * import { AwsCustomerAgreementAndIpLicenseAcceptance, RenderQueue, Repository, ThinkboxDockerImages, VersionQuery } from '@aws-rfdk/deadline';
  * const app = new App();
  * const stack = new Stack(app, 'Stack');
  * const vpc = new Vpc(stack, 'Vpc');
@@ -110,9 +115,9 @@ export interface ThinkboxDockerImagesProps {
  * });
  * const images = new ThinkboxDockerImages(stack, 'Image', {
  *   version,
- *   // Change this to AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA to accept the terms
- *   // of the AWS Thinkbox End User License Agreement
- *   userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA,
+ *   // Change this to AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to accept the terms
+ *   // of the AWS Customer Agreement and AWS Intellectual Property License.
+ *   userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE,
  * });
  * const repository = new Repository(stack, 'Repository', {
  *   vpc,
@@ -127,27 +132,21 @@ export interface ThinkboxDockerImagesProps {
  */
 export class ThinkboxDockerImages extends Construct {
   /**
-   * The AWS Thinkbox licensing message that is presented to the user if they create an instance of
-   * this class without explicitly accepting the AWS Thinkbox EULA.
+   * The Deadline licensing message that is presented to the user if they create an instance of
+   * this class without explicitly accepting the AWS Content Agreement and AWS Intellectual Property License.
    *
    * Note to developers: The text of this string is a legal requirement, and must not be altered
-   * witout approval.
+   * without approval.
    */
-  private static readonly AWS_THINKBOX_EULA_MESSAGE: string = `
+  private static readonly AWS_CONTENT_NOTICE: string = `
 The ThinkboxDockerImages will install Deadline onto one or more EC2 instances.
 
-Deadline is provided by AWS Thinkbox under the AWS Thinkbox End User License
-Agreement (EULA). By installing Deadline, you are agreeing to the terms of this
-license. Follow the link below to read the terms of the AWS Thinkbox EULA.
+By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+is AWS Content as defined in those Agreements.
 
-https://www.awsthinkbox.com/end-user-license-agreement
-
-By using the ThinkboxDockerImages to install Deadline you agree to the terms of
-the AWS Thinkbox EULA.
-
-Please set the userAwsThinkboxEulaAcceptance property to
-USER_ACCEPTS_AWS_THINKBOX_EULA to signify your acceptance of the terms of the
-AWS Thinkbox EULA.
+Please set the userAcceptsAwsCustomerAgreementAndIpLicense property to
+USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to signify your acceptance of these terms.
 `;
 
   /**
@@ -179,14 +178,14 @@ AWS Thinkbox EULA.
   private readonly ecrBaseURI: string;
 
   /**
-   * Whether the user has accepted the AWS Thinkbox EULA
+   * Whether the user has accepted the terms of the AWS Content Agreement and AWS Intellectual Property License.
    */
-  private readonly userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance;
+  private readonly userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance;
 
   constructor(scope: Construct, id: string, props: ThinkboxDockerImagesProps) {
     super(scope, id);
 
-    this.userAwsThinkboxEulaAcceptance = props.userAwsThinkboxEulaAcceptance;
+    this.userAwsCustomerAgreementAndIpLicenseAcceptance = props.userAwsCustomerAgreementAndIpLicenseAcceptance;
     this.version = props?.version;
 
     const lambdaCode = Code.fromAsset(path.join(__dirname, '..', '..', 'lambdas', 'nodejs'));
@@ -223,9 +222,10 @@ AWS Thinkbox EULA.
       validate(): string[] {
         const errors: string[] = [];
 
-        // Users must accept the AWS Thinkbox EULA to use the container images
-        if (thisConstruct.userAwsThinkboxEulaAcceptance !== AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA) {
-          errors.push(ThinkboxDockerImages.AWS_THINKBOX_EULA_MESSAGE);
+        // Users must accept the AWS Customer Agreement and AWS Intellectual Property License to use the container images
+        if (thisConstruct.userAwsCustomerAgreementAndIpLicenseAcceptance !==
+            AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE) {
+          errors.push(ThinkboxDockerImages.AWS_CONTENT_NOTICE);
         }
 
         // Using the output of VersionQuery across stacks can cause issues. CloudFormation stack outputs cannot change if

--- a/packages/aws-rfdk/lib/deadline/test/thinkbox-docker-images.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/thinkbox-docker-images.test.ts
@@ -21,7 +21,7 @@ import {
 } from 'aws-cdk-lib/aws-ecs';
 
 import {
-  AwsThinkboxEulaAcceptance,
+  AwsCustomerAgreementAndIpLicenseAcceptance,
   IVersion,
   RenderQueueImages,
   ThinkboxDockerImages,
@@ -34,43 +34,37 @@ describe('ThinkboxDockerRecipes', () => {
   let app: App;
   let stack: Stack;
   let images: ThinkboxDockerImages;
-  let userAwsThinkboxEulaAcceptance: AwsThinkboxEulaAcceptance;
+  let userAwsCustomerAgreementAndIpLicenseAcceptance: AwsCustomerAgreementAndIpLicenseAcceptance;
 
   describe('defaults', () => {
     beforeEach(() => {
       // GIVEN
       app = new App();
       stack = new Stack(app, 'Stack');
-      userAwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_ACCEPTS_AWS_THINKBOX_EULA;
+      userAwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
 
       // WHEN
       images = new ThinkboxDockerImages(stack, 'Images', {
-        userAwsThinkboxEulaAcceptance,
+        userAwsCustomerAgreementAndIpLicenseAcceptance,
       });
     });
 
-    test('fails validation when EULA is not accepted', () =>{
+    test('fails validation when terms are not accepted', () =>{
       // GIVEN
       const newStack = new Stack(app, 'NewStack');
       const expectedError = `
 The ThinkboxDockerImages will install Deadline onto one or more EC2 instances.
 
-Deadline is provided by AWS Thinkbox under the AWS Thinkbox End User License
-Agreement (EULA). By installing Deadline, you are agreeing to the terms of this
-license. Follow the link below to read the terms of the AWS Thinkbox EULA.
+By downloading or using the Deadline software, you agree to the AWS Customer Agreement (https://aws.amazon.com/agreement/)
+and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
+is AWS Content as defined in those Agreements.
 
-https://www.awsthinkbox.com/end-user-license-agreement
-
-By using the ThinkboxDockerImages to install Deadline you agree to the terms of
-the AWS Thinkbox EULA.
-
-Please set the userAwsThinkboxEulaAcceptance property to
-USER_ACCEPTS_AWS_THINKBOX_EULA to signify your acceptance of the terms of the
-AWS Thinkbox EULA.
+Please set the userAcceptsAwsCustomerAgreementAndIpLicense property to
+USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to signify your acceptance of these terms.
 `;
-      userAwsThinkboxEulaAcceptance = AwsThinkboxEulaAcceptance.USER_REJECTS_AWS_THINKBOX_EULA;
+      userAwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;
       new ThinkboxDockerImages(newStack, 'Images', {
-        userAwsThinkboxEulaAcceptance,
+        userAwsCustomerAgreementAndIpLicenseAcceptance,
       });
 
       // WHEN
@@ -180,7 +174,7 @@ AWS Thinkbox EULA.
       // WHEN
       images = new ThinkboxDockerImages(stack, 'Images', {
         version,
-        userAwsThinkboxEulaAcceptance,
+        userAwsCustomerAgreementAndIpLicenseAcceptance,
       });
     });
 
@@ -231,7 +225,7 @@ AWS Thinkbox EULA.
       const newStack = new Stack(app, 'NewStack');
       new ThinkboxDockerImages(newStack, 'Images', {
         version,
-        userAwsThinkboxEulaAcceptance,
+        userAwsCustomerAgreementAndIpLicenseAcceptance,
       });
 
       // WHEN


### PR DESCRIPTION
BREAKING CHANGE: The `userAwsThinkboxEulaAcceptance` property of the `ThinkboxDockerImages`
construct has been removed and replaced with `userAwsCustomerAgreementAndIpLicenseAcceptance`.
The licensing terms of Deadline have been retroactively changed with the
release of Deadline 10.1.23, and these new terms must be agreed to by a
code change in your applications.

---

Note: The BREAKING CHANGE text as it appears in the commit will appear in the release notes / ChangeLog.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
