### PR TITLE
feat(deadline): adds UserData property to WorkerInstanceFleet

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -28,6 +28,7 @@ import {
   Port,
   SubnetSelection,
   SubnetType,
+  UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import {IApplicationLoadBalancerTarget} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import {
@@ -222,6 +223,15 @@ export interface WorkerInstanceFleetProps extends WorkerSettings {
    * @default The default devices of the provided ami will be used.
    */
   readonly blockDevices?: BlockDevice[];
+
+  /**
+   * The specific UserData to use.
+   *
+   * The UserData will be mutated by this construct and may be mutated afterwards as well.
+   *
+   * @default A UserData object appropriate for the MachineImage's Operating System is created.
+   */
+  readonly userData?: UserData;
 
   /**
    * An optional provider of user data commands to be injected at various points during the Worker configuration lifecycle.
@@ -455,6 +465,7 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
       role: props.role,
       spotPrice: props.spotPrice?.toString(),
       blockDevices: props.blockDevices,
+      userData: props.userData,
     });
 
     this.targetCapacity = parseInt((this.fleet.node.defaultChild as CfnAutoScalingGroup).maxSize, 10);

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -28,6 +28,7 @@ import {
   Peer,
   SecurityGroup,
   SubnetType,
+  UserData,
   Vpc,
 } from 'aws-cdk-lib/aws-ec2';
 import {
@@ -475,6 +476,25 @@ test.each([
     RetentionInDays: 3,
     LogGroupName: testPrefix + id,
   });
+});
+
+test('worker fleet uses given UserData', () => {
+  // GIVEN
+  const id  = 'workerFleet';
+  const userData = UserData.forLinux();
+
+  // WHEN
+  const workerFleet = new WorkerInstanceFleet(stack, id, {
+    vpc,
+    workerMachineImage: new GenericLinuxImage({
+      'us-east-1': '123',
+    }),
+    renderQueue,
+    userData,
+  });
+
+  // THEN
+  expect(workerFleet.fleet.userData).toBe(userData);
 });
 
 test('default linux worker fleet is created correctly custom subnet values', () => {

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.ts
@@ -273,5 +273,7 @@ test('decrypt private key', async () => {
   // THEN
   expect(decryptedKey).toEqual(expectedDecryptedKey);
   // Must have the decrypted private key
-  expect(decryptedKey).toContain('-----BEGIN RSA PRIVATE KEY-----');
+  // OpenSSL 1.0.x: -----BEGIN RSA PRIVATE KEY-----
+  // OpenSSL 1.1.x: -----BEGIN PRIVATE KEY-----
+  expect(decryptedKey).toMatch(/-----BEGIN (?:RSA )?PRIVATE KEY-----/);
 });


### PR DESCRIPTION
This PR adds the ability to provide your own UserData object to the deadline.WorkerInstanceFleet.

Implements: https://github.com/aws/aws-rfdk/issues/780

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
