### PR TITLE
fix(core): fix rate limit errors when deploying cloudwatch log groups 

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -17,6 +17,7 @@ import {
   Code,
   Runtime,
   SingletonFunction,
+  CfnFunction,
 } from 'aws-cdk-lib/aws-lambda';
 import {
   ILogGroup,
@@ -24,6 +25,7 @@ import {
   LogRetention,
   RetentionDays,
 } from 'aws-cdk-lib/aws-logs';
+import { Stack } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 
 /**
@@ -111,10 +113,25 @@ export class ExportingLogGroup extends Construct {
       threshold: 1,
     });
 
+    // Define log retention retry options to reduce the risk of the rate exceed error
+    // as the default create log group TPS is only 5. Make sure to set the timeout of log retention function
+    // to be greater than total retry time. That's because if the function that is used for a custom resource
+    // doesn't exit properly, it'd end up in retries and may take cloud formation an hour to realize that
+    // the custom resource failed.
     const logRetention = new LogRetention(this, 'LogRetention', {
       logGroupName: props.logGroupName,
       retention: retentionInDays,
+      logRetentionRetryOptions: {
+        base: Duration.millis(200),
+        maxRetries: 7,
+      },
     });
+    const logRetentionFunctionLogicalId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
+    const logRetentionFunction = Stack.of(this).node.tryFindChild(logRetentionFunctionLogicalId);
+    if (logRetentionFunction) {
+      const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
+      cfnFunction.addPropertyOverride('Timeout', 30);
+    }
 
     this.logGroup = LogGroup.fromLogGroupArn(scope, `${props.logGroupName}LogGroup`, logRetention.logGroupArn);
     this.logGroup.grant(exportLogsFunction, 'logs:CreateExportTask');

--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -126,12 +126,11 @@ export class ExportingLogGroup extends Construct {
         maxRetries: 7,
       },
     });
-    const logRetentionFunctionLogicalId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
-    const logRetentionFunction = Stack.of(this).node.tryFindChild(logRetentionFunctionLogicalId);
-    if (logRetentionFunction) {
-      const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
-      cfnFunction.addPropertyOverride('Timeout', 30);
-    }
+    // referenced from cdk code: https://github.com/aws/aws-cdk/blob/main/packages/@aws-cdk/aws-logs/lib/log-retention.ts#L123
+    const logRetentionFunctionConstructId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
+    const logRetentionFunction = Stack.of(this).node.tryFindChild(logRetentionFunctionConstructId)!;
+    const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
+    cfnFunction.addPropertyOverride('Timeout', 30);
 
     this.logGroup = LogGroup.fromLogGroupArn(scope, `${props.logGroupName}LogGroup`, logRetention.logGroupArn);
     this.logGroup.grant(exportLogsFunction, 'logs:CreateExportTask');

--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -126,9 +126,9 @@ export class ExportingLogGroup extends Construct {
         maxRetries: 7,
       },
     });
-    // referenced from cdk code: https://github.com/aws/aws-cdk/blob/main/packages/@aws-cdk/aws-logs/lib/log-retention.ts#L123
+    // referenced from cdk code: https://github.com/aws/aws-cdk/blob/v2.33.0/packages/@aws-cdk/aws-logs/lib/log-retention.ts#L116
     const logRetentionFunctionConstructId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
-    const logRetentionFunction = Stack.of(this).node.tryFindChild(logRetentionFunctionConstructId)!;
+    const logRetentionFunction = Stack.of(this).node.findChild(logRetentionFunctionConstructId);
     const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
     cfnFunction.addPropertyOverride('Timeout', 30);
 

--- a/packages/aws-rfdk/lib/core/lib/log-group-factory.ts
+++ b/packages/aws-rfdk/lib/core/lib/log-group-factory.ts
@@ -76,9 +76,9 @@ export class LogGroupFactory {
             maxRetries: 7,
           },
         }).logGroupArn);
-    // referenced from cdk code: https://github.com/aws/aws-cdk/blob/main/packages/@aws-cdk/aws-logs/lib/log-retention.ts#L123
+    // referenced from cdk code: https://github.com/aws/aws-cdk/blob/v2.33.0/packages/@aws-cdk/aws-logs/lib/log-retention.ts#L116
     const logRetentionFunctionConstructId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
-    const logRetentionFunction = Stack.of(scope).node.tryFindChild(logRetentionFunctionConstructId)!;
+    const logRetentionFunction = Stack.of(scope).node.findChild(logRetentionFunctionConstructId);
     const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
     cfnFunction.addPropertyOverride('Timeout', 30);
 

--- a/packages/aws-rfdk/lib/core/lib/log-group-factory.ts
+++ b/packages/aws-rfdk/lib/core/lib/log-group-factory.ts
@@ -76,21 +76,11 @@ export class LogGroupFactory {
             maxRetries: 7,
           },
         }).logGroupArn);
-<<<<<<< HEAD
-
-    const logRetentionFunctionLogicalId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
-    const logRetentionFunction = Stack.of(scope).node.tryFindChild(logRetentionFunctionLogicalId);
-    if (logRetentionFunction) {
-      const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
-      cfnFunction.addPropertyOverride('Timeout', 30);
-    }
-=======
     // referenced from cdk code: https://github.com/aws/aws-cdk/blob/main/packages/@aws-cdk/aws-logs/lib/log-retention.ts#L123
     const logRetentionFunctionConstructId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
     const logRetentionFunction = Stack.of(scope).node.tryFindChild(logRetentionFunctionConstructId)!;
     const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
     cfnFunction.addPropertyOverride('Timeout', 30);
->>>>>>> 5e33236 (fix(core): fix rate limit errors when deploying cloudwatch log groups)
 
     return logGroup;
   }

--- a/packages/aws-rfdk/lib/core/lib/log-group-factory.ts
+++ b/packages/aws-rfdk/lib/core/lib/log-group-factory.ts
@@ -76,6 +76,7 @@ export class LogGroupFactory {
             maxRetries: 7,
           },
         }).logGroupArn);
+<<<<<<< HEAD
 
     const logRetentionFunctionLogicalId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
     const logRetentionFunction = Stack.of(scope).node.tryFindChild(logRetentionFunctionLogicalId);
@@ -83,6 +84,13 @@ export class LogGroupFactory {
       const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
       cfnFunction.addPropertyOverride('Timeout', 30);
     }
+=======
+    // referenced from cdk code: https://github.com/aws/aws-cdk/blob/main/packages/@aws-cdk/aws-logs/lib/log-retention.ts#L123
+    const logRetentionFunctionConstructId = 'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a';
+    const logRetentionFunction = Stack.of(scope).node.tryFindChild(logRetentionFunctionConstructId)!;
+    const cfnFunction = logRetentionFunction.node.defaultChild as CfnFunction;
+    cfnFunction.addPropertyOverride('Timeout', 30);
+>>>>>>> 5e33236 (fix(core): fix rate limit errors when deploying cloudwatch log groups)
 
     return logGroup;
   }

--- a/packages/aws-rfdk/lib/core/test/exporting-log-group.test.ts
+++ b/packages/aws-rfdk/lib/core/test/exporting-log-group.test.ts
@@ -31,6 +31,10 @@ test('default exporting log group is created correctly', () => {
       ],
     },
     LogGroupName: 'logGroup',
+    SdkRetry: {
+      maxRetries: 7,
+      base: 200,
+    },
     RetentionInDays: 3,
   });
   Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
@@ -147,6 +151,10 @@ test('custom set retention is created correctly', () => {
       ],
     },
     LogGroupName: 'logGroup',
+    SdkRetry: {
+      maxRetries: 7,
+      base: 200,
+    },
     RetentionInDays: 7,
   });
   Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);

--- a/packages/aws-rfdk/lib/core/test/log-group-factory.test.ts
+++ b/packages/aws-rfdk/lib/core/test/log-group-factory.test.ts
@@ -21,8 +21,24 @@ describe('log group', () => {
     // THEN
     Template.fromStack(stack).hasResourceProperties('Custom::LogRetention', {
       LogGroupName: 'testLogGroup',
+      SdkRetry: {
+        maxRetries: 7,
+        base: 200,
+      },
       RetentionInDays: 3,
     });
+
+    expect(Object.keys(Template.fromStack(stack).findResources('AWS::Lambda::Function', {
+      Properties: {
+        Role: {
+          'Fn::GetAtt': [
+            'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB',
+            'Arn',
+          ],
+        },
+        Timeout: 30,
+      },
+    })).length).toEqual(1);
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function',  Match.not({
       Role: {
         'Fn::GetAtt': [
@@ -44,8 +60,25 @@ describe('log group', () => {
     // THEN
     Template.fromStack(stack).hasResourceProperties('Custom::LogRetention', {
       LogGroupName: 'prefix-testLogGroup',
+      SdkRetry: {
+        maxRetries: 7,
+        base: 200,
+      },
       RetentionInDays: 3,
     });
+
+    expect(Object.keys(Template.fromStack(stack).findResources('AWS::Lambda::Function', {
+      Properties: {
+        Role: {
+          'Fn::GetAtt': [
+            'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB',
+            'Arn',
+          ],
+        },
+        Timeout: 30,
+      },
+    })).length).toEqual(1);
+
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function',  Match.not({
       Role: {
         'Fn::GetAtt': [
@@ -67,8 +100,25 @@ describe('log group', () => {
     // THEN
     Template.fromStack(stack).hasResourceProperties('Custom::LogRetention', {
       LogGroupName: 'testLogGroup',
+      SdkRetry: {
+        maxRetries: 7,
+        base: 200,
+      },
       RetentionInDays: 7,
     });
+
+    expect(Object.keys(Template.fromStack(stack).findResources('AWS::Lambda::Function', {
+      Properties: {
+        Role: {
+          'Fn::GetAtt': [
+            'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB',
+            'Arn',
+          ],
+        },
+        Timeout: 30,
+      },
+    })).length).toEqual(1);
+
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function',  Match.not({
       Role: {
         'Fn::GetAtt': [
@@ -92,8 +142,24 @@ describe('exporting log group', () => {
     // THEN
     Template.fromStack(stack).hasResourceProperties('Custom::LogRetention', {
       LogGroupName: 'testLogGroup',
+      SdkRetry: {
+        maxRetries: 7,
+        base: 200,
+      },
       RetentionInDays: 3,
     });
+
+    expect(Object.keys(Template.fromStack(stack).findResources('AWS::Lambda::Function', {
+      Properties: {
+        Role: {
+          'Fn::GetAtt': [
+            'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB',
+            'Arn',
+          ],
+        },
+        Timeout: 30,
+      },
+    })).length).toEqual(1);
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function',  {
       Role: {
@@ -124,8 +190,24 @@ describe('exporting log group', () => {
     // THEN
     Template.fromStack(stack).hasResourceProperties('Custom::LogRetention', {
       LogGroupName: 'prefix-testLogGroup',
+      SdkRetry: {
+        maxRetries: 7,
+        base: 200,
+      },
       RetentionInDays: 3,
     });
+
+    expect(Object.keys(Template.fromStack(stack).findResources('AWS::Lambda::Function', {
+      Properties: {
+        Role: {
+          'Fn::GetAtt': [
+            'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB',
+            'Arn',
+          ],
+        },
+        Timeout: 30,
+      },
+    })).length).toEqual(1);
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function',  {
       Role: {
@@ -157,8 +239,24 @@ describe('exporting log group', () => {
     // THEN
     Template.fromStack(stack).hasResourceProperties('Custom::LogRetention', {
       LogGroupName: 'testLogGroup',
+      SdkRetry: {
+        maxRetries: 7,
+        base: 200,
+      },
       RetentionInDays: 7,
     });
+
+    expect(Object.keys(Template.fromStack(stack).findResources('AWS::Lambda::Function', {
+      Properties: {
+        Role: {
+          'Fn::GetAtt': [
+            'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB',
+            'Arn',
+          ],
+        },
+        Timeout: 30,
+      },
+    })).length).toEqual(1);
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function',  {
       Role: {


### PR DESCRIPTION
### Problem https://github.com/aws/aws-rfdk/issues/807
When the RFDK creates a CloudWatch Log group it does it via the CDK's [LogRetention ](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_logs.LogRetention.html)construct. The CloudWatch Logs APIs that the LogRetention construct calls have a very low TPS limit (5 TPS). The result is that when deploying multiple RFDK constructs one can encounter rate limit errors in the deployment -- this is particularly seen, randomly, with the RFDK's integration tests.

### Solution 

CDK's LogRetention construct provides a way - [logRetentionRetryOptions](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_logs.LogRetention.html#logretentionretryoptions) to configure the Javascript SDK that it's using to make the CloudWatch API calls. Using this, the RFDK should set higher max retries and retry delay. Currently default backoff retry base is 100ms and max retry count is 3, proposed value is 200ms and 7. This is a good combination as it achieves a lot of retries while the total function runtime is not too long. 

- Added retry option to all places where new LogRetention is created. 
- Extended log retention function timeout. Referencing https://github.com/aws/aws-cdk/blob/205e493e7bd6c5212f0ae374fdee28128ea49afe/packages/%40aws-cdk/aws-logs/lib/log-retention.ts#L122-L130

### Testing
* Created a CloudFormation app that iteratively initialize LogRetention constructs. Wrote a script to deploy constructs in parallel to reproduce the rate limit error. Verified proposed values for max retry count and retry delay prevent the error. 
* Added unit test to verify template is modified as expected.
* Build success.


*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
