### PR TITLE
fix(core): fix API doc build error

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -4,7 +4,7 @@
  */
 
 import * as path from 'path';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Stack } from 'aws-cdk-lib';
 import { Alarm } from 'aws-cdk-lib/aws-cloudwatch';
 import {
   Rule,
@@ -25,7 +25,6 @@ import {
   LogRetention,
   RetentionDays,
 } from 'aws-cdk-lib/aws-logs';
-import { Stack } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 
 /**


### PR DESCRIPTION
### Problem
Incorrect import path caused API docs build failure in pipeline build.

### Solution
Fix import path https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.Stack.html

### Test
build success 

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
