### PR TITLE
fix(core): add point in time recovery to X509Certificate DynamoDB tables

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -167,6 +167,7 @@ abstract class X509CertificateBase extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
       encryption: TableEncryption.AWS_MANAGED,
       billingMode: BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true,
     });
 
     this.passphrase = new Secret(this, 'Passphrase', {

--- a/packages/aws-rfdk/lib/core/test/x509-certificate.test.ts
+++ b/packages/aws-rfdk/lib/core/test/x509-certificate.test.ts
@@ -117,6 +117,12 @@ test('Generate cert', () => {
       },
     },
   });
+  // Expect Table to have point in time recovery set to true
+  Template.fromStack(stack).hasResourceProperties('AWS::DynamoDB::Table', {
+    PointInTimeRecoverySpecification: {
+      PointInTimeRecoveryEnabled: true,
+    },
+  });
 
   // Should not be any errors.
   Annotations.fromStack(stack).hasNoInfo(`/${cert.node.path}`, Match.anyValue());


### PR DESCRIPTION
### Problem
Certificate tables did not have point in time recovery enabled.

### Solution
Set the pointInTimeRecovery property to true

### Testing
Modified an existing unit test to verify that the created certificate table template has the PointInTimeRecoveryEnabled property set to true.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
