### PR TITLE
fix(deadline): use new repository installer log path for Deadline 10.2.*

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -955,7 +955,7 @@ export class Repository extends Construct implements IRepository {
       '/var/log/cloud-init-output.log');
     cloudWatchConfigurationBuilder.addLogsCollectList(logGroup.logGroupName,
       'deadlineRepositoryInstallationLogs',
-      '/tmp/bitrock_installer.log');
+      this.version.isLessThan(Version.MINIMUM_VERSION_USING_NEW_INSTALLBUILDER_LOG) ? '/tmp/bitrock_installer.log' : '/tmp/installbuilder_installer.log');
 
     new CloudWatchAgent(this, 'RepositoryInstallerLogsConfig', {
       cloudWatchConfig: cloudWatchConfigurationBuilder.generateCloudWatchConfiguration(),

--- a/packages/aws-rfdk/lib/deadline/lib/version.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/version.ts
@@ -23,6 +23,11 @@ export class Version implements IPatchVersion {
   public static readonly MINIMUM_SECRETS_MANAGEMENT_VERSION = new Version([10, 1, 19, 0]);
 
   /**
+   * The minimum Deadline version which uses Install Builder instead of Bitrock Installer.
+   */
+  public static readonly MINIMUM_VERSION_USING_NEW_INSTALLBUILDER_LOG = new Version([10, 2, 0, 0]);
+
+  /**
    * This method parses the input string and returns the version object.
    *
    * @param version version string to parse

--- a/packages/aws-rfdk/lib/deadline/test/repository.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/repository.test.ts
@@ -72,12 +72,25 @@ let app: App;
 let stack: Stack;
 let vpc: IVpc;
 let version: IVersion;
+let installers: PlatformInstallers;
 
 function escapeTokenRegex(s: string): string {
   // A CDK Token looks like: ${Token[TOKEN.12]}
   // This contains the regex special characters: ., $, {, }, [, and ]
   // Escape those for use in a regex.
   return s.replace(/[.${}[\]]/g, '\\$&');
+}
+
+function create_version(version_array: number[]): IVersion {
+  class MockVersion extends Version implements IVersion {
+    readonly linuxInstallers: PlatformInstallers = installers;
+
+    public linuxFullVersionString() {
+      return this.toString();
+    }
+  }
+
+  return new MockVersion(version_array);
 }
 
 beforeEach(() => {
@@ -99,26 +112,18 @@ beforeEach(() => {
       },
     ],
   });
-
-  class MockVersion extends Version implements IVersion {
-    readonly linuxInstallers: PlatformInstallers = {
-      patchVersion: 0,
-      repository: {
-        objectKey: 'testInstaller',
-        s3Bucket: new Bucket(stack, 'LinuxInstallerBucket'),
-      },
-      client: {
-        objectKey: 'testClientInstaller',
-        s3Bucket: new Bucket(stack, 'LinuxClientInstallerBucket'),
-      },
-    };
-
-    public linuxFullVersionString() {
-      return this.toString();
-    }
-  }
-
-  version = new MockVersion([10,1,19,4]);
+  installers = {
+    patchVersion: 0,
+    repository: {
+      objectKey: 'testInstaller',
+      s3Bucket: new Bucket(stack, 'LinuxInstallerBucket'),
+    },
+    client: {
+      objectKey: 'testClientInstaller',
+      s3Bucket: new Bucket(stack, 'LinuxClientInstallerBucket'),
+    },
+  };
+  version = create_version([10,1,19,4]);
 });
 
 test('can create two repositories', () => {
@@ -403,11 +408,17 @@ test('default repository installer log group created correctly', () => {
   });
 });
 
-test('repository installer logs all required files', () => {
+test.each([
+  [[10,1,19,4]],
+  [[10,2,0,9]],
+])('repository installer logs all required files', (version_array: number[]) => {
+  // GIVEN
+  const repository_version = create_version(version_array);
+
   // WHEN
   new Repository(stack, 'repositoryInstaller', {
     vpc,
-    version,
+    version: repository_version,
   });
 
   // THEN
@@ -424,7 +435,9 @@ test('repository installer logs all required files', () => {
           {}, // log group name. checked in another test.
           '\",\"log_stream_name\":\"cloud-init-output-{instance_id}\",\"file_path\":\"/var/log/cloud-init-output.log\",\"timezone\":\"Local\"},{\"log_group_name\":\"',
           {}, // log group name again.
-          '\",\"log_stream_name\":\"deadlineRepositoryInstallationLogs-{instance_id}\",\"file_path\":\"/tmp/bitrock_installer.log\",\"timezone\":\"Local\"}]}},\"log_stream_name\":\"DefaultLogStream-{instance_id}\",\"force_flush_interval\":15}}',
+          '\",\"log_stream_name\":\"deadlineRepositoryInstallationLogs-{instance_id}\",\"file_path\":\"/tmp/'+
+          (repository_version.isLessThan(Version.MINIMUM_VERSION_USING_NEW_INSTALLBUILDER_LOG) ? 'bitrock' : 'installbuilder') +
+          '_installer.log\",\"timezone\":\"Local\"}]}},\"log_stream_name\":\"DefaultLogStream-{instance_id}\",\"force_flush_interval\":15}}',
         ],
       ],
     },


### PR DESCRIPTION
## Problem

With the release of Deadline `10.2.0.9`, the deadline repository installer log file location changed from `/tmp/bitrock_installer.log` to `/tmp/installbuilder_installer.log`. 

This introduced a bug which made it so that the log stream in the repository component, meant to stream the repository installation logs, would no longer stream to cloudwatch.

## Solution

Add a conditional check in the repository component which changes the path of the installer logs depending on the deadline version.

## Testing

- Build Succeeds
- Modified unit tests pass
- Ran e2e tests on multiple versions

### E2E Testing Details

Ran the end to end tests in the `integ` folder by running

`yarn e2e` in the `aws-rfdk/integ` directory.

These end to end tests were run using both deadline `10.1.23.6` (max version before installer log change) and `10.2.0.9` (min version after installer log change).

When running for `10.1.23.6`
  - Verified that the cloud formation stack template had the following line
     ```
     "\",\"log_stream_name\":\"deadlineRepositoryInstallationLogs-{instance_id}\",\"file_path\":\"/tmp/bitrock_installer.log\",\"timezone\":\"Local\"}]}},\"log_stream_name\":\"DefaultLogStream-{instance_id}\",\"force_flush_interval\":15}}"
     ```
  - Verified that the Repository log group has both of the following streams:
    - `deadlineRepositoryInstallationLogs-<instance-id>`
    - `cloud-init-output-<instance-id>`
  - Verified that the `deadlineRepositoryInstallationLogs-<instance-id>` log stream was streaming installation logs
  
  When running for `10.2.0.9`
  - Verified that the cloud formation stack template had the following line
     ```
     "\",\"log_stream_name\":\"deadlineRepositoryInstallationLogs-{instance_id}\",\"file_path\":\"/tmp/installbuilder_installer.log\",\"timezone\":\"Local\"}]}},\"log_stream_name\":\"DefaultLogStream-{instance_id}\",\"force_flush_interval\":15}}"
     ```
  - Verified that the Repository log group has both of the following streams:
    - `deadlineRepositoryInstallationLogs-<instance-id>`
    - `cloud-init-output-<instance-id>`
  - Verified that the `deadlineRepositoryInstallationLogs-<instance-id>` log stream was streaming installation logs


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
