### PR TITLE
feat(deadline): allow minor version upgrades in Repository construct

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/bin/app.ts
@@ -41,10 +41,6 @@ import { ComputeTier } from '../lib/compute-tier';
     console.log('EC2 key pair name not specified. You will not have SSH access to the render farm.');
   }
 
-  if (config.deadlineClientLinuxAmiMap === {['region']: 'ami-id'}) {
-    throw new Error('Deadline Client Linux AMI map is required but was not specified.');
-  }
-
   if (!config.enableSecretsManagement && config.secretsManagementSecretArn) {
     console.warn('Deadline Secrets Management is disabled, so the admin credentials specified in the provided secret will not be used.');
   }

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/installDeadlineRepository.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/installDeadlineRepository.sh
@@ -88,8 +88,8 @@ if test -f "$REPOSITORY_FILE_PATH"; then
         SplitVersion=(${Version//./ })
         SplitRepoVersion=(${DEADLINE_REPOSITORY_VERSION//./ })
 
-        if [[ ${SplitVersion[0]} != ${SplitRepoVersion[0]} ]] || [[ ${SplitVersion[1]} != ${SplitRepoVersion[1]} ]]; then
-            echo "ERROR: Repository pre-exists but configured Repository Version (${Version}) has a different Major or Minor Version than the provided installer (${DEADLINE_REPOSITORY_VERSION})."
+        if [[ ${SplitVersion[0]} != ${SplitRepoVersion[0]} ]]; then
+            echo "ERROR: Repository pre-exists but configured Repository Version (${Version}) has a different Major Version than the provided installer (${DEADLINE_REPOSITORY_VERSION})."
             exit 1
         fi
     fi


### PR DESCRIPTION
### Summary

Deadline 10.2.0.10 is [released](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/release-notes.html). The `Repository` construct has a check when upgrading Deadline versions to ensure the major and minor versions do not change. This prevents customers from upgrading to Deadline 10.2.

This change removes the minor version part of the check. It also removes an unused and incorrect check in the example app's `bin/app.ts` file for the worker AMI map being empty. We have a default AMI set in the config anyway, so it's basically dead code

### Testing
- First, I deployed the All-In-AWS-Infrastructure-Basic example app with an older Deadline version (10.1.23.6), tried to upgrade to Deadline 10.2.0.10, and got a failure from the `Repository` construct as expected:
     ```
    ERROR: Repository pre-exists but configured Repository Version (10.1.23.6) has a different Major Version than the provided installer (10.2.0.10).
    ```
- After rebuilding RFDK with my changes, I deployed the example app again successfully. Also verified the components are working as expected by inspecting their logs for errors, and I found none. 
    - Since the Worker Fleet ASG is not automatically refreshed with the new 10.2.0.10 AMI, I manually terminated the old worker and let the ASG spin up a new one
- Ran the integration tests (see section below for details)

<details><summary>Repository cloud-init logs</summary>

```
Cloud-init v. 19.3-46.amzn2 running 'modules:final' at Tue, 13 Dec 2022 23:37:36 +0000. Up 25.61 seconds.
Completed 3.4 KiB/3.4 KiB (27.7 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/f3261b0f6923b012a8fce5cd6984211bc48b9977844b3fa44229234dc6f21d43.sh to tmp/f3261b0f6923b012a8fce5cd6984211bc48b9977844b3fa44229234dc6f21d43.sh
+ echo 'Starting CloudWatch installation and configuration script.'
Starting CloudWatch installation and configuration script.
+ SKIP_VERIFICATION=false
+ INSTALL_AGENT=false
+ OPTIND=1
+ getopts is opt
+ case $opt in
+ INSTALL_AGENT=true
+ getopts is opt
+ shift 1
+ (( 2 != 2 ))
+ REGION=us-west-2
+ SSM_PARAMETER_NAME=CFN-RepositoryStringParameter767222D9-Mih57jKBzrho
+ true
+ install_agent us-west-2
+ region=us-west-2
+ grep amazon-cloudwatch-agent
+ rpm -qa
++ mktemp -d
+ TMPDIR=/tmp/tmp.7LR3p08Dbi
+ pushd /tmp/tmp.7LR3p08Dbi
+ aws s3api get-object --region us-west-2 --bucket amazoncloudwatch-agent-us-west-2 --key amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm amazon-cloudwatch-agent.rpm
{
    "AcceptRanges": "bytes", 
    "ContentType": "application/octet-stream", 
    "LastModified": "Thu, 01 Sep 2022 15:51:51 GMT", 
    "ContentLength": 49701120, 
    "ETag": "\"823cdc9a7792124a4003b285d36d14ad\"", 
    "Metadata": {}
}
+ '[' false = false ']'
+ aws s3api get-object --region us-west-2 --bucket amazoncloudwatch-agent-us-west-2 --key assets/amazon-cloudwatch-agent.gpg amazon-cloudwatch-agent.gpg
{
    "AcceptRanges": "bytes", 
    "ContentType": "application/octet-stream", 
    "LastModified": "Mon, 25 Feb 2019 07:39:50 GMT", 
    "ContentLength": 943, 
    "ETag": "\"9004b4b372182fe86b03498c9ddfe9b9\"", 
    "Metadata": {}
}
++ gpg --no-default-keyring --keyring ./keyring.gpg --import amazon-cloudwatch-agent.gpg
+ GPG_IMPORT_OUT='gpg: directory `/root/.gnupg'\'' created
gpg: new configuration file `/root/.gnupg/gpg.conf'\'' created
gpg: WARNING: options in `/root/.gnupg/gpg.conf'\'' are not yet active during this run
gpg: keyring `/root/.gnupg/secring.gpg'\'' created
gpg: keyring `./keyring.gpg'\'' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 3B789C72: public key "Amazon CloudWatch Agent" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)'
++ awk '{print $2}'
++ echo 'gpg: directory `/root/.gnupg'\'' created
gpg: new configuration file `/root/.gnupg/gpg.conf'\'' created
gpg: WARNING: options in `/root/.gnupg/gpg.conf'\'' are not yet active during this run
gpg: keyring `/root/.gnupg/secring.gpg'\'' created
gpg: keyring `./keyring.gpg'\'' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 3B789C72: public key "Amazon CloudWatch Agent" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)'
++ grep -Eow 'key [0-9A-F]+'
+ GPG_KEY=3B789C72
++ gpg --no-default-keyring --keyring ./keyring.gpg --fingerprint 3B789C72
+ GPG_FINGERPRINT_OUT='pub   2048R/3B789C72 2017-11-14
      Key fingerprint = 9376 16F3 450B 7D80 6CBD  9725 D581 6730 3B78 9C72
uid                  Amazon CloudWatch Agent'
++ grep -Eo 'fingerprint=[0-9A-F]{40}'
++ echo 'pub   2048R/3B789C72 2017-11-14
      Key fingerprint = 9376 16F3 450B 7D80 6CBD  9725 D581 6730 3B78 9C72
uid                  Amazon CloudWatch Agent'
++ tr -d '[:blank:]'
+ GPG_FINGERPRINT=fingerprint=937616F3450B7D806CBD9725D58167303B789C72
+ test fingerprint=937616F3450B7D806CBD9725D58167303B789C72 '!=' fingerprint=937616F3450B7D806CBD9725D58167303B789C72
+ aws s3api get-object --region us-west-2 --bucket amazoncloudwatch-agent-us-west-2 --key amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm.sig amazon-cloudwatch-agent.rpm.sig
{
    "AcceptRanges": "bytes", 
    "ContentType": "application/octet-stream", 
    "LastModified": "Thu, 01 Sep 2022 15:51:51 GMT", 
    "ContentLength": 287, 
    "ETag": "\"7218ac20f7e275ba3490075853663f07\"", 
    "Metadata": {}
}
+ gpg --no-default-keyring --keyring ./keyring.gpg --verify amazon-cloudwatch-agent.rpm.sig amazon-cloudwatch-agent.rpm
gpg: Signature made Mon Aug 22 15:32:41 2022 UTC using RSA key ID 3B789C72
gpg: Good signature from "Amazon CloudWatch Agent"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 9376 16F3 450B 7D80 6CBD  9725 D581 6730 3B78 9C72
+ sudo rpm -U ./amazon-cloudwatch-agent.rpm
create group cwagent, result: 0
create user cwagent, result: 0
create group aoc, result: 0
create user aoc, result: 0
+ popd
/
+ rm -rf /tmp/tmp.7LR3p08Dbi
+ /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c ssm:CFN-RepositoryStringParameter767222D9-Mih57jKBzrho -s
****** processing amazon-cloudwatch-agent ******
/opt/aws/amazon-cloudwatch-agent/bin/config-downloader --output-dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d --download-source ssm:CFN-RepositoryStringParameter767222D9-Mih57jKBzrho --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml --multi-config append
I! Trying to detect region from ec2
D! [EC2] Found active network interface
Region: us-west-2
credsConfig: map[]
Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/ssm_CFN-RepositoryStringParameter767222D9-Mih57jKBzrho.tmp
Start configuration validation...
/opt/aws/amazon-cloudwatch-agent/bin/config-translator --input /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json --input-dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d --output /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml --multi-config append
2022/12/13 23:37:47 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json ...
/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json does not exist or cannot read. Skipping it.
2022/12/13 23:37:47 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/ssm_CFN-RepositoryStringParameter767222D9-Mih57jKBzrho.tmp ...
2022/12/13 23:37:47 I! Valid Json input schema.
I! Detecting run_as_user...
I! Trying to detect region from ec2
D! [EC2] Found active network interface
No csm configuration found.
No metric configuration found.
Configuration validation first phase succeeded
/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
Configuration validation second phase succeeded
Configuration validation succeeded
amazon-cloudwatch-agent has already been stopped
Created symlink from /etc/systemd/system/multi-user.target.wants/amazon-cloudwatch-agent.service to /etc/systemd/system/amazon-cloudwatch-agent.service.
Redirecting to /bin/systemctl restart amazon-cloudwatch-agent.service
+ echo 'Script completed successfully.'
Script completed successfully.
Completed 7.0 KiB/7.0 KiB (57.6 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/df4591e2346578a80738105aa20aab9c8cee38098d62b4b9a595681c14b8e716.zip to tmp/df4591e2346578a80738105aa20aab9c8cee38098d62b4b9a595681c14b8e716.zip
/tmp/tmp.JCYBjX8mON /
Archive:  /tmp/df4591e2346578a80738105aa20aab9c8cee38098d62b4b9a595681c14b8e716.zip
  inflating: ec2-certificates.crt    
  inflating: metadataUtilities.sh    
  inflating: mountEfs.sh             
+ test 4 -lt 3
++ dirname ./mountEfs.sh
+ SCRIPT_DIR=.
+ source ./metadataUtilities.sh
+ authenticate_identity_document
+ which openssl
+++ dirname ./metadataUtilities.sh
++ cd .
++ pwd
+ SCRIPT_DIRECTORY=/tmp/tmp.JCYBjX8mON
++ get_metadata_token
++ curl -X PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 30'
+ TOKEN=AQAEAHLfMdAe6F19pIL74R0WYu-0Z5GgQIm4MFmjR0w2H8ZderazRA==
++ mktemp
+ CERT_FILE=/tmp/tmp.d9ovY1iZKT
+ echo '-----BEGIN PKCS7-----'
+ curl -H 'X-aws-ec2-metadata-token: AQAEAHLfMdAe6F19pIL74R0WYu-0Z5GgQIm4MFmjR0w2H8ZderazRA==' -v http://169.254.169.254/latest/dynamic/instance-identity/pkcs7
+ echo ''
+ echo '-----END PKCS7-----'
++ mktemp
+ DOCUMENT_FILE=/tmp/tmp.N7SgubfCSv
+ curl -H 'X-aws-ec2-metadata-token: AQAEAHLfMdAe6F19pIL74R0WYu-0Z5GgQIm4MFmjR0w2H8ZderazRA==' -v http://169.254.169.254/latest/dynamic/instance-identity/document
+ echo 'Verifying identity document authenticity'
Verifying identity document authenticity
+ openssl smime -verify -in /tmp/tmp.d9ovY1iZKT -inform PEM -content /tmp/tmp.N7SgubfCSv -certfile /tmp/tmp.JCYBjX8mON/ec2-certificates.crt -noverify
Verification successful
++ get_metadata_token
++ curl -X PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 30'
+ METADATA_TOKEN=AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==
++ get_region AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==
++ TOKEN=AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==
+++ get_identity_document AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==
+++ TOKEN=AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==
+++ curl -s -H 'X-aws-ec2-metadata-token: AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==' -v http://169.254.169.254/latest/dynamic/instance-identity/document
++ IDENTITY_DOC='{
  "accountId" : "162923712518",
  "architecture" : "x86_64",
  "availabilityZone" : "us-west-2a",
  "billingProducts" : null,
  "devpayProductCodes" : null,
  "marketplaceProductCodes" : null,
  "imageId" : "ami-08e4eaf54ff5ee95e",
  "instanceId" : "i-0c073ea765aa5a5b8",
  "instanceType" : "t3.large",
  "kernelId" : null,
  "pendingTime" : "2022-12-13T23:36:40Z",
  "privateIp" : "10.0.2.112",
  "ramdiskId" : null,
  "region" : "us-west-2",
  "version" : "2017-09-30"
}'
++ grep region
++ tr , '\n'
++ awk '{print $3}'
++ tr -d '[",
{}
]'
++ echo '{' '"accountId"' : '"162923712518",' '"architecture"' : '"x86_64",' '"availabilityZone"' : '"us-west-2a",' '"billingProducts"' : null, '"devpayProductCodes"' : null, '"marketplaceProductCodes"' : null, '"imageId"' : '"ami-08e4eaf54ff5ee95e",' '"instanceId"' : '"i-0c073ea765aa5a5b8",' '"instanceType"' : '"t3.large",' '"kernelId"' : null, '"pendingTime"' : '"2022-12-13T23:36:40Z",' '"privateIp"' : '"10.0.2.112",' '"ramdiskId"' : null, '"region"' : '"us-west-2",' '"version"' : '"2017-09-30"' '}'
+ AWS_REGION=us-west-2
++ get_availability_zone AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==
++ TOKEN=AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==
++ curl -H 'X-aws-ec2-metadata-token: AQAEAHLfMdBHmXzpgXlG1NMGXM16PktwHz66XEj5YRmZLnOMASmafQ==' -v http://169.254.169.254/latest/meta-data/placement/availability-zone
+ AVAILABILITY_ZONE_NAME=us-west-2a
+ FILESYSTEM_ID=fs-05ed5d5afb3f01067
+ MOUNT_PATH=/mnt/efs/fs1
+ RESOLVE_MOUNTPOINT_IP_VIA_API=false
+ MOUNT_OPTIONS=rw,iam,accesspoint=fsap-049a84cdefb8b1d53,fsc
+ mkdir -p /mnt/efs/fs1
+ AMAZON_EFS_PACKAGE=amazon-efs-utils
+ which yum
/usr/bin/yum
+ PACKAGE_MANAGER=yum
+ NFS_UTILS_PACAKGE=nfs-utils
+ [[ false == \t\r\u\e ]]
++ wc -l
++ tail -c 1 /etc/fstab
+ test 1 -eq 0
+ use_amazon_efs_mount
+ test -f /sbin/mount.efs
+ yum install -y amazon-efs-utils
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Resolving Dependencies
--> Running transaction check
---> Package amazon-efs-utils.noarch 0:1.34.1-1.amzn2 will be installed
--> Processing Dependency: stunnel5 for package: amazon-efs-utils-1.34.1-1.amzn2.noarch
--> Running transaction check
---> Package stunnel5.x86_64 0:5.58-1.amzn2.0.1 will be installed
--> Finished Dependency Resolution
Dependencies Resolved
================================================================================
 Package               Arch        Version                Repository       Size
================================================================================
Installing:
 amazon-efs-utils      noarch      1.34.1-1.amzn2         amzn2-core       53 k
Installing for dependencies:
 stunnel5              x86_64      5.58-1.amzn2.0.1       amzn2-core      165 k
Transaction Summary
================================================================================
Install  1 Package (+1 Dependent package)
Total download size: 218 k
Installed size: 517 k
Downloading packages:
--------------------------------------------------------------------------------
Total                                              1.6 MB/s | 218 kB  00:00     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Warning: RPMDB altered outside of yum.
  Installing : stunnel5-5.58-1.amzn2.0.1.x86_64                             1/2 
  Installing : amazon-efs-utils-1.34.1-1.amzn2.noarch                       2/2 
  Verifying  : stunnel5-5.58-1.amzn2.0.1.x86_64                             1/2 
  Verifying  : amazon-efs-utils-1.34.1-1.amzn2.noarch                       2/2 
Installed:
  amazon-efs-utils.noarch 0:1.34.1-1.amzn2                                      
Dependency Installed:
  stunnel5.x86_64 0:5.58-1.amzn2.0.1                                            
Complete!
+ return 0
+ echo 'fs-05ed5d5afb3f01067:/ /mnt/efs/fs1 efs defaults,tls,_netdev,rw,iam,accesspoint=fsap-049a84cdefb8b1d53,fsc'
+ tee -a /etc/fstab
fs-05ed5d5afb3f01067:/ /mnt/efs/fs1 efs defaults,tls,_netdev,rw,iam,accesspoint=fsap-049a84cdefb8b1d53,fsc
+ MOUNT_TYPE=efs
+ TRIES=0
+ MAX_TRIES=20
+ test 0 -lt 20
+ mount -a -t efs
+ cat /proc/mounts
+ grep /mnt/efs/fs1
127.0.0.1:/ /mnt/efs/fs1 nfs4 rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,noresvport,proto=tcp,port=20482,timeo=600,retrans=2,sec=sys,clientaddr=127.0.0.1,fsc,local_lock=none,addr=127.0.0.1 0 0
+ exit 0
/
Completed 8.2 KiB/8.2 KiB (63.7 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/f49e96a9cb03a95f7eea91c9a60154e33d683728fba4753691d317cab5462cd4.sh to tmp/f49e96a9cb03a95f7eea91c9a60154e33d683728fba4753691d317cab5462cd4.sh
+ MIN_DEADLINE_VERSION_REPO_NO_ROOT=10.1.18
+ USAGE='Usage: /tmp/f49e96a9cb03a95f7eea91c9a60154e33d683728fba4753691d317cab5462cd4.sh -i <installer-s3-path> -p <local-installer-path> -v <deadline-version>
This script downloads the deadline repository installer and executes it.
Required arguments:
  -i s3 path for the deadline repository installer.
  -p Path where deadline repository needs to be installed.
  -v Deadline Repository Version being installed.
Optional arguments
  -s Deadline Repository settings file to import.
  -o The UID[:GID] that this script will chown the Repository files for. If GID is not specified, it defults to be the same as UID.
  -c Secrets management admin credentials ARN. If this parameter is specified, secrets management will be enabled.
  -r Region where stacks are deployed. Required to get secret management credentials.'
+ getopts i:p:v:s:o:c:r: opt
+ case $opt in
+ S3PATH=s3://thinkbox-installers/Deadline/10.2.0.10/Linux/DeadlineRepository-10.2.0.10-linux-x64-installer.run
+ getopts i:p:v:s:o:c:r: opt
+ case $opt in
+ PREFIX=/mnt/efs/fs1
+ getopts i:p:v:s:o:c:r: opt
+ case $opt in
+ DEADLINE_REPOSITORY_VERSION=10.2.0.10
+ getopts i:p:v:s:o:c:r: opt
+ case $opt in
+ AWS_REGION=us-west-2
+ getopts i:p:v:s:o:c:r: opt
+ case $opt in
+ SECRET_MANAGEMENT_ARN=arn:aws:secretsmanager:us-west-2:162923712518:secret:SMAdminUser8903035B-DnRXauQ2kYr7-jQPl8Y
+ getopts i:p:v:s:o:c:r: opt
+ '[' -z x ']'
+ '[' -z x ']'
+ '[' -z x ']'
+ REPOSITORY_FILE_PATH=/mnt/efs/fs1/settings/repository.ini
+ CONNECTION_FILE_PATH=/mnt/efs/fs1/settings/connection.ini
+ declare -A INSTALLER_DB_ARGS
+ configure_database_installation_args
+ SET_X_IS_SET=ehuxB
+ test -f /mnt/efs/fs1/settings/repository.ini
+ echo 'File /mnt/efs/fs1/settings/repository.ini exists. Validating Database Connection'
File /mnt/efs/fs1/settings/repository.ini exists. Validating Database Connection
+ INSTALLER_DB_HOSTNAME=docdbcluster37494708-hc90fr7enf8n.cluster-cwhgrjlsgvgv.us-west-2.docdb.amazonaws.com
+ INSTALLER_DB_PORT=27017
+ source /mnt/efs/fs1/settings/connection.ini
+ '[' docdbcluster37494708-hc90fr7enf8n.cluster-cwhgrjlsgvgv.us-west-2.docdb.amazonaws.com '!=' docdbcluster37494708-hc90fr7enf8n.cluster-cwhgrjlsgvgv.us-west-2.docdb.amazonaws.com ']'
+ '[' 27017 '!=' 27017 ']'
+ echo 'Database Connection is valid.  Validating Deadline Version.'
Database Connection is valid.  Validating Deadline Version.
+ source /mnt/efs/fs1/settings/repository.ini
+ [[ 10.1.23.6 = \1\0\.\2\.\0\.\1\0 ]]
+ SplitVersion=(${Version//./ })
+ SplitRepoVersion=(${DEADLINE_REPOSITORY_VERSION//./ })
+ [[ 10 != 10 ]]
+ REPO_INSTALLER=/tmp/repo_installer.run
+ aws s3 cp s3://thinkbox-installers/Deadline/10.2.0.10/Linux/DeadlineRepository-10.2.0.10-linux-x64-installer.run /tmp/repo_installer.run
...a bunch of download progress logs...
download: s3://thinkbox-installers/Deadline/10.2.0.10/Linux/DeadlineRepository-10.2.0.10-linux-x64-installer.run to tmp/repo_installer.run
+ chmod +x /tmp/repo_installer.run
+ set +x
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Resolving Dependencies
--> Running transaction check
---> Package jq.x86_64 0:1.5-1.amzn2.0.2 will be installed
--> Processing Dependency: libonig.so.2()(64bit) for package: jq-1.5-1.amzn2.0.2.x86_64
--> Running transaction check
---> Package oniguruma.x86_64 0:5.9.6-1.amzn2.0.4 will be installed
--> Finished Dependency Resolution
Dependencies Resolved
================================================================================
 Package         Arch         Version                    Repository        Size
================================================================================
Installing:
 jq              x86_64       1.5-1.amzn2.0.2            amzn2-core       154 k
Installing for dependencies:
 oniguruma       x86_64       5.9.6-1.amzn2.0.4          amzn2-core       127 k
Transaction Summary
================================================================================
Install  1 Package (+1 Dependent package)
Total download size: 281 k
Installed size: 890 k
Downloading packages:
--------------------------------------------------------------------------------
Total                                              2.1 MB/s | 281 kB  00:00     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : oniguruma-5.9.6-1.amzn2.0.4.x86_64                           1/2 
  Installing : jq-1.5-1.amzn2.0.2.x86_64                                    2/2 
  Verifying  : jq-1.5-1.amzn2.0.2.x86_64                                    1/2 
  Verifying  : oniguruma-5.9.6-1.amzn2.0.4.x86_64                           2/2 
Installed:
  jq.x86_64 0:1.5-1.amzn2.0.2                                                   
Dependency Installed:
  oniguruma.x86_64 0:5.9.6-1.amzn2.0.4                                          
Complete!
Secrets management is enabled. Credentials are stored in secret: arn:aws:secretsmanager:us-west-2:162923712518:secret:SMAdminUser8903035B-DnRXauQ2kYr7-jQPl8Y
An error occurred while trying to create an admin user in the database.
+ echo 'Script completed successfully.'
Script completed successfully.
ci-info: no authorized ssh keys fingerprints found for user ec2-user.
Cloud-init v. 19.3-46.amzn2 finished at Tue, 13 Dec 2022 23:42:18 +0000. Datasource DataSourceEc2.  Up 308.31 seconds
```

</details>

<details><summary>Repository Installer logs</summary>

**Note:** The error message about creating an admin user in the database is a non-issue. This admin user for Deadline Secrets Management already exists from my 10.1.23.6 install.

```
Log started 12/13/2022 at 23:38:07
Preferred installation mode : unattended
Trying to init installer in mode unattended
Mode unattended successfully initialized
This can take a few minutes
Preparing to Install
Preparing to Install
Unpacking files
Unpacking files
Unpacking files
Unpacking files
Unpacking files
Unpacking files
Unpacking files
Unpacking files
Executing chmod -R 755 "/mnt/efs/fs1/bin"
Script exit code: 0
Script output:
 
Script stderr:
 
Executing chmod 1755 "/mnt/efs/fs1"
Script exit code: 0
Script output:
 
Script stderr:
 
Updating database settings
Executing /tmp/repoinstalltemp/deadlinecommand.exe -UpdateDocumentDBSettings "/mnt/efs/fs1" "docdbcluster37494708-hc90fr7enf8n.cluster-cwhgrjlsgvgv.us-west-2.docdb.amazonaws.com" "deadline10db" "27017" "0" "adminuser" "" "" "/mnt/efs/fs1/settings/doc-db-ca.pem"
Script exit code: 0
Script output:
 Creating default config file:/root/Thinkbox/Deadline10/deadline.ini
Script stderr:
 Please Enter DB User's Password for user adminuser of database deadline10db at docdbcluster37494708-hc90fr7enf8n.cluster-cwhgrjlsgvgv.us-west-2.docdb.amazonaws.com:27017: 
Updating script menus
Executing /tmp/repoinstalltemp/deadlinecommand.exe RunCommandForRepository Direct "/mnt/efs/fs1" UpdateScriptMenus "/mnt/efs/fs1/settings/defaultScriptMenus.menu"
Script exit code: 0
Script output:
 
Script stderr:
 
Updating environment
Executing /tmp/repoinstalltemp/deadlinecommand.exe RunCommandForRepository Direct "/mnt/efs/fs1" UpdateEnvironmentSettings "/mnt/efs/fs1/settings/Environments"
Script exit code: 0
Script output:
 
Script stderr:
 
Updating second environment
Executing /tmp/repoinstalltemp/deadlinecommand.exe RunCommandForRepository Direct "/mnt/efs/fs1" UpdateEnvironmentSettings "/mnt/efs/fs1/settings/Environments2" --second
Script exit code: 0
Script output:
 
Script stderr:
 
Executing /tmp/repoinstalltemp/deadlinecommand.exe RunCommandForRepository Direct "/mnt/efs/fs1" SetMinimumDeadlineVersion 0.0.0.0 10.0.0.0
Script exit code: 0
Script output:
 Minimum version set to 0.0.0.0 10.0.0.0Deadline.Configuration.DeadlineMinimumVersion
Script stderr:
 
Creating initial admin user and master key...
Executing /tmp/repoinstalltemp/deadlinecommand.exe RunCommandForRepository Direct "/mnt/efs/fs1;" secrets CreateInitialAdmin "admin" "defaultKey" --password stdin
Script exit code: 1
Script output:
 Error: [SecretsManagement] Existing users found in database.
Script stderr:
 Please enter your Admin password: 
An error occurred while trying to create an admin user in the database.
An error occurred while trying to create an admin user in the database.
Running secrets migration command...
Executing /tmp/repoinstalltemp/deadlinecommand.exe RunCommandForRepository Direct "/mnt/efs/fs1;" secrets MigrateSecrets "admin" "defaultKey" --password stdin
Script exit code: 0
Script output:
 Secrets successfully migrated.
Script stderr:
 Please enter your Admin password: 
Populating Asset Server Default Settings
Executing /tmp/repoinstalltemp/deadlinecommand.exe RunCommandForRepository Direct "/mnt/efs/fs1" PopulateAssetServerDefaultSettings false "/mnt/efs/fs1/settings/AssetServerDefaultGlobalWhitelistPatterns"
Script exit code: 0
Script output:
 
Script stderr:
 
Removing temporary files
Creating Shortcut for Uninstall Deadline Repository 10
Creating Uninstaller
Creating uninstaller 25%
Creating uninstaller 50%
Creating uninstaller 75%
Creating uninstaller 100%
Installation completed
Log finished 12/13/2022 at 23:41:16
Exiting with code 0
```

</details>

<details><summary>RenderQueue logs</summary>

**Note:** The error message about granting access of master key (defaultKey) is a non-issue. The admin Deadline Secrets Management user already has access from my previous 10.1.23.6 install.

```
configuring: [direct-repo-connection]
Creating default config file:/home/ec2-user/Thinkbox/Deadline10/deadline.ini
configuring: [rcs-tls]
configuring: [rcs-secrets-management]
Assigned role (Server) to D0-16-4D-92-A0-3A-07-9E-87-75-6D-D3-18-1E-D0-16-EC-00-0F-05-4E-FE-78-B0-4D-1C-1F-F3-EE-3B-34-BF.
Failed to configure 1 identities for the following reasons:
ERROR: Granting Access of master key (defaultKey) to D0-16-4D-92-A0-3A-07-9E-87-75-6D-D3-18-1E-D0-16-EC-00-0F-05-4E-FE-78-B0-4D-1C-1F-F3-EE-3B-34-BF was UNSUCCESSFUL. (Master key is already granted to the Server. (userId=D0-16-4D-92-A0-3A-07-9E-87-75-6D-D3-18-1E-D0-16-EC-00-0F-05-4E-FE-78-B0-4D-1C-1F-F3-EE-3B-34-BF, masterKeyId=defaultKey))
Successfully configured Deadline Secrets Management
Replica Set Read Preference={ Mode : Primary }
Feature UpdateAPI: DataControllerUpdateServer starting up with updateInterval=30 seconds
[SecretsManagementKeyRotationService] Started up with checkInterval=60 seconds
Deadline Remote Connection Server 10.2 [v10.2.0.10 Release (3b87216c7)]
Connected to "/opt/Thinkbox/DeadlineRepository10"
Turning off Kestrel logging
DEBUG: The RCS is capable of sending responses compressed with :br
Using ASP.Net Core server.
Listening for https requests on 0.0.0.0 port 4433 loopbackOnly False...
```

</details>

<details><summary>UBL logs</summary>

```
configuring: [client-rq-connection]
Creating default config file:/home/ec2-user/Thinkbox/Deadline10/deadline.ini
Connecting to Render Queue...
Repository Version: 10.2.0.10 (3b87216c7)
Integration Version: 10.2.0.10 (3b87216c7)
Successfully connected to Render Queue
configuring: [ubl-certificates]
Fetching X.509 certificates from arn:aws:secretsmanager:us-west-2:162923712518:secret:UblCertificatesZip-kdqp4f
Archive:  /app/config/certificates.zip
 extracting: /app/config/ubl_certs/redshift.pfx  
 extracting: /app/config/ubl_certs/deadline.pfx  
 extracting: /app/config/ubl_certs/arnold.pfx  
 extracting: /app/config/ubl_certs/maya.pfx  
 extracting: /app/config/ubl_certs/max.pfx  
 extracting: /app/config/ubl_certs/cinema4d.pfx  
configuring: [ubl-limits]
Set limit "maya"
Set limit "arnold"
License Forwarder Thread - License Forwarder thread initializing...
License Forwarder Thread - License Forwarder thread listening on port 17004
License Forwarder - Web Forwarder not started, certificate not found at '/app/config/ubl_certs/10.0.8.203.pfx'.
License Forwarder - Starting validation check...
License Forwarder - Validation check completed.
```

</details>

<details><summary>Worker logs</summary>

```
﻿2022-12-14 00:20:26:  BEGIN - ip-10-0-17-168\ec2-user
2022-12-14 00:20:26:  Operating System: Linux
2022-12-14 00:20:26:  CPU Architecture: x86_64
2022-12-14 00:20:26:  CPUs: 2
2022-12-14 00:20:26:  Video Card: Cirrus Logic GD 5446
2022-12-14 00:20:26:  Deadline Worker 10.2 [v10.2.0.10 Release (3b87216c7)]
2022-12-14 00:20:27:  Scanning for auto configuration
2022-12-14 00:20:30:  Auto Configuration: No auto configuration for Repository Path could be detected, using local configuration
2022-12-14 00:20:30:  Connecting to repository
2022-12-14 00:20:30:  Connecting to Deadline RCS 10.2 [v10.2.0.10 Release (3b87216c7)]
2022-12-14 00:20:30:  Info Thread - Created.
2022-12-14 00:20:35:  '/home/ec2-user/Thinkbox/Deadline10/pythonAPIs/TG9mZBDmdw25DenZtlRkw==' already exists. Skipping extraction of PythonSync.
2022-12-14 00:20:35:  '/home/ec2-user/Thinkbox/Deadline10/pythonAPIs/TG9mZBDmdw25DenZtlRkw==' already exists. Skipping extraction of PythonSync.
2022-12-14 00:20:35:  INFO: On Worker Started
2022-12-14 00:20:35:  Auto Configuration: Picking configuration based on: ip-10-0-17-168.us-west-2.compute.internal / 10.0.17.168
2022-12-14 00:20:35:  Auto Configuration: No auto configuration could be detected, using local configuration
2022-12-14 00:20:35:  Purging old logs and temp files
2022-12-14 00:20:35:  Another pending job scan process is already in progress
2022-12-14 00:20:36:  Skipping repository repair because it is not required at this time
2022-12-14 00:20:36:  Skipping house cleaning because it is not required at this time
2022-12-14 00:20:44:  Skipping pending job scan because it is not required at this time
```

</details>

<details><summary>Worker cloud-init logs</summary>

```
Cloud-init v. 19.3-46.amzn2 running 'modules:final' at Wed, 14 Dec 2022 00:19:19 +0000. Up 44.76 seconds.
Completed 1.8 KiB/1.8 KiB (10.5 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/3e16ffda458a50d2a032ef783202a85bf4677f19b92a38d3605d6cd750879f75.sh to tmp/3e16ffda458a50d2a032ef783202a85bf4677f19b92a38d3605d6cd750879f75.sh
+ HEALTH_CHECK_PORT=63415
+ MINIMUM_SUPPORTED_DEADLINE_VERSION=10.1.9.2
+ '[' -f /etc/profile.d/deadlineclient.sh ']'
+ source /etc/profile.d/deadlineclient.sh
++ DEADLINEBIN=/opt/Thinkbox/Deadline10/bin
++ export DEADLINE_PATH=/opt/Thinkbox/Deadline10/bin
++ DEADLINE_PATH=/opt/Thinkbox/Deadline10/bin
+ '[' -z /opt/Thinkbox/Deadline10/bin ']'
+ DEADLINE_COMMAND=/opt/Thinkbox/Deadline10/bin/deadlinecommand
+ '[' '!' -f /opt/Thinkbox/Deadline10/bin/deadlinecommand ']'
++ grep -oP '[v]\K\d+\.\d+\.\d+\.\d+\b'
++ /opt/Thinkbox/Deadline10/bin/deadlinecommand -Version
+ DEADLINE_VERSION=10.2.0.10
+ '[' -z 10.2.0.10 ']'
+ isVersionLessThan 10.2.0.10 10.1.9.2
+ python -c 'import sys;sys.exit(0 if tuple(map(int, sys.argv[-2].split('\''.'\''))) < tuple(map(int, sys.argv[-1].split('\''.'\''))) else 1)' 10.2.0.10 10.1.9.2
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting ResourceTrackerVersion V2
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting LauncherHealthCheckPort 63415
+ echo 'Script completed successfully.'
Script completed successfully.
preCloudWatchAgent
Completed 3.4 KiB/3.4 KiB (23.2 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/f3261b0f6923b012a8fce5cd6984211bc48b9977844b3fa44229234dc6f21d43.sh to tmp/f3261b0f6923b012a8fce5cd6984211bc48b9977844b3fa44229234dc6f21d43.sh
+ echo 'Starting CloudWatch installation and configuration script.'
Starting CloudWatch installation and configuration script.
+ SKIP_VERIFICATION=false
+ INSTALL_AGENT=false
+ OPTIND=1
+ getopts is opt
+ case $opt in
+ INSTALL_AGENT=true
+ getopts is opt
+ shift 1
+ (( 2 != 2 ))
+ REGION=us-west-2
+ SSM_PARAMETER_NAME=CFN-WorkerFleetStringParameterCAEB09F6-SzLnu2LB4Bfe
+ true
+ install_agent us-west-2
+ region=us-west-2
+ grep amazon-cloudwatch-agent
+ rpm -qa
amazon-cloudwatch-agent-1.247355.0b252062-1.x86_64
+ return
+ /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c ssm:CFN-WorkerFleetStringParameterCAEB09F6-SzLnu2LB4Bfe -s
****** processing amazon-cloudwatch-agent ******
/opt/aws/amazon-cloudwatch-agent/bin/config-downloader --output-dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d --download-source ssm:CFN-WorkerFleetStringParameterCAEB09F6-SzLnu2LB4Bfe --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml --multi-config append
I! Trying to detect region from ec2
D! [EC2] Found active network interface
Region: us-west-2
credsConfig: map[]
Successfully fetched the config and saved in /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/ssm_CFN-WorkerFleetStringParameterCAEB09F6-SzLnu2LB4Bfe.tmp
Start configuration validation...
/opt/aws/amazon-cloudwatch-agent/bin/config-translator --input /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json --input-dir /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d --output /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml --mode ec2 --config /opt/aws/amazon-cloudwatch-agent/etc/common-config.toml --multi-config append
2022/12/14 00:19:27 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json ...
/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json does not exist or cannot read. Skipping it.
2022/12/14 00:19:27 Reading json config file path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/ssm_CFN-WorkerFleetStringParameterCAEB09F6-SzLnu2LB4Bfe.tmp ...
2022/12/14 00:19:27 I! Valid Json input schema.
I! Detecting run_as_user...
I! Trying to detect region from ec2
D! [EC2] Found active network interface
No csm configuration found.
No metric configuration found.
Configuration validation first phase succeeded
/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -schematest -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml
Configuration validation second phase succeeded
Configuration validation succeeded
amazon-cloudwatch-agent has already been stopped
Created symlink from /etc/systemd/system/multi-user.target.wants/amazon-cloudwatch-agent.service to /etc/systemd/system/amazon-cloudwatch-agent.service.
Redirecting to /bin/systemctl restart amazon-cloudwatch-agent.service
+ echo 'Script completed successfully.'
Script completed successfully.
preRenderQueueConfiguration
Completed 9.9 KiB/9.9 KiB (75.8 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/b61797635329f0b0ec0b710b31d49f0e41c1936849266d8a9aed82e1616c9077.py to tmp/b61797635329f0b0ec0b710b31d49f0e41c1936849266d8a9aed82e1616c9077.py
Configuring Deadline to connect to the Render Queue using HTTPS Traffic
Testing Deadline connection...
Deadline connection configured correctly
preWorkerConfiguration
Completed 1.2 KiB/1.2 KiB (7.1 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/a10d67420c8758e35d8dae5fa406c7acb92b1bd40924167d5564aa0037b4a980.py to tmp/a10d67420c8758e35d8dae5fa406c7acb92b1bd40924167d5564aa0037b4a980.py
Completed 4.5 KiB/4.5 KiB (36.2 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/1cfdffe73bb016717ba1f43d64fe528af27b3784f524a97bb36533a6e6d057ff.sh to tmp/1cfdffe73bb016717ba1f43d64fe528af27b3784f524a97bb36533a6e6d057ff.sh
+ WORKER_GROUPS=(${1//,/ })
+ WORKER_POOLS=(${2//,/ })
+ WORKER_REGION=
+ MINIMUM_SUPPORTED_DEADLINE_VERSION=10.1.9.2
+ WORKER_LISTENING_PORT=56032
+ WORKER_LISTENING_PORT_CONFIG_SCRIPT=/tmp/a10d67420c8758e35d8dae5fa406c7acb92b1bd40924167d5564aa0037b4a980.py
+ '[' -f /etc/profile.d/deadlineclient.sh ']'
+ source /etc/profile.d/deadlineclient.sh
++ DEADLINEBIN=/opt/Thinkbox/Deadline10/bin
++ export DEADLINE_PATH=/opt/Thinkbox/Deadline10/bin
++ DEADLINE_PATH=/opt/Thinkbox/Deadline10/bin
+ '[' -z /opt/Thinkbox/Deadline10/bin ']'
+ DEADLINE_COMMAND=/opt/Thinkbox/Deadline10/bin/deadlinecommand
+ '[' '!' -f /opt/Thinkbox/Deadline10/bin/deadlinecommand ']'
++ /opt/Thinkbox/Deadline10/bin/deadlinecommand -Version
++ grep -oP '[v]\K\d+\.\d+\.\d+\.\d+\b'
+ DEADLINE_VERSION=10.2.0.10
+ '[' -z 10.2.0.10 ']'
+ isVersionLessThan 10.2.0.10 10.1.9.2
+ python -c 'import sys;sys.exit(0 if tuple(map(int, sys.argv[-2].split('\''.'\''))) < tuple(map(int, sys.argv[-1].split('\''.'\''))) else 1)' 10.2.0.10 10.1.9.2
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting LaunchSlaveAtStartup True
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting KeepWorkerRunning True
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting RestartStalledSlave True
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting AutoUpdateOverride False
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting UseS3BackedCache False
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -SetIniFileSetting S3BackedCacheUrl ''
+ '[' -z '' ']'
+ echo 'INFO: WORKER_REGION not provided'
INFO: WORKER_REGION not provided
++ hostname -s
+ WORKER_NAME_PREFIX=ip-10-0-17-168
+ WORKER_NAMES=()
+ shopt -s dotglob
+ for file in '/var/lib/Thinkbox/Deadline10/slaves/*'
+ file='*'
+ workerSuffix='*'
+ [[ -z * ]]
+ [[ * = \* ]]
+ WORKER_NAMES+=("$WORKER_NAME_PREFIX")
+ shopt -u dotglob
+ '[' 0 -gt 0 ']'
+ '[' 0 -gt 0 ']'
+ port_offset=0
+ for worker_name in '"${WORKER_NAMES[@]}"'
+ /opt/Thinkbox/Deadline10/bin/deadlinecommand -ExecuteScriptNoGui /tmp/a10d67420c8758e35d8dae5fa406c7acb92b1bd40924167d5564aa0037b4a980.py -n ip-10-0-17-168 -p 56032
Successfully set ip-10-0-17-168 to listen on port 56032
+ port_offset=1
+ service --status-all
+ grep -q 'Deadline 10 Launcher'
+ DEADLINE_LAUNCHER=/opt/Thinkbox/Deadline10/bin/deadlinelauncher
+ /opt/Thinkbox/Deadline10/bin/deadlinelauncher -shutdownall
Shutting down existing Workers before shutting down Launcher
Shutting down existing Pulse before shutting down Launcher
Shutting down existing Balancer before shutting down Launcher
Shutting down existing Monitor before shutting down Launcher
Shutting down existing Remote Connection Server before shutting down Launcher
Shutting down existing License Forwarder before shutting down Launcher
Shutting down existing Web Service before shutting down Launcher
Shutting down existing Launcher
+ sudo killall -w deadlineworker
deadlineworker: no process found
+ true
+ /opt/Thinkbox/Deadline10/bin/deadlinelauncher -nogui
daemon was not added to the CommandLineParser.
daemon was not added to the CommandLineParser.
Auto Configuration: Picking configuration based on: ip-10-0-17-168.us-west-2.compute.internal / 10.0.17.168
Auto Configuration: No auto configuration could be detected, using local configuration
[Info] Auto-upgrade is blocked by root/administrator via /root/Thinkbox/Deadline10/secure.ini.
Local python API (Python 3): Updating
'/root/Thinkbox/Deadline10/pythonAPIs/TG9mZBDmdw25DenZtlRkw==' already exists. Skipping extraction of PythonSync.
Local python API (Python 3): Update complete
PythonSync Fallback (Python 3): Attempting to decompress pythonsync3 from /root/Thinkbox/Deadline10/cache/RosnaYBGFrCtDMXsB2iWQNAcLPU/pythonsync3/pythonsync3.zip to /opt/Thinkbox/Deadline10/bin/pythonsync3
PythonSync Fallback (Python 3):pythonsync3 decompression successful
Local python API (Python 2): Updating
'/root/Thinkbox/Deadline10/pythonAPIs/CSBAA0VGN3AuwCL6e5Iz4Q==' already exists. Skipping extraction of PythonSync.
Local python API (Python 2): Update complete
PythonSync Fallback (Python 2): Attempting to decompress pythonsync from /root/Thinkbox/Deadline10/cache/RosnaYBGFrCtDMXsB2iWQNAcLPU/pythonsync/pythonsync.zip to /opt/Thinkbox/Deadline10/bin/pythonsync
PythonSync Fallback (Python 2):pythonsync decompression successful
Launcher Thread - Launcher thread initializing...
Launcher Thread - opening remote TCP listening port 17000
Launcher Thread - creating local listening TCP socket on an available port...
Launcher Thread - local TCP port bound to: [::1]:33737
Launcher Thread -  updating local listening port in launcher file: 33737
Launcher Thread - Launcher thread listening on port 17000
Launcher Health Check Thread - Initializing...
Turning off Kestrel logging
Launcher Health Check Thread - Listening on port 63415
Launcher Health Check Thread - Health check thread is running
upgraded was not added to the CommandLineParser.
upgradefailed was not added to the CommandLineParser.
service was not added to the CommandLineParser.
daemon was not added to the CommandLineParser.
Launcher Thread - ::1 has connected
Launcher Thread - Received command: ForceStopSlave
Launcher Thread - Responded with: Success
Launcher Thread - ::1 has connected
Launcher Thread - Received command: StopPulse
No Pulse to shutdown
Launcher Thread - Responded with: Success
Launcher Thread - ::1 has connected
Launcher Thread - Received command: StopBalancer
No Balancer to shutdown
Launcher Thread - Responded with: Success
Launcher Thread - ::1 has connected
Launcher Thread - Received command: StopMonitor
No Monitor to shutdown
Launcher Thread - Responded with: Success
Launcher Thread - ::1 has connected
Launcher Thread - Received command: StopRemoteConnectionServer
No Remote Connection Server to shutdown
Launcher Thread - Responded with: Success
Launcher Thread - Remote Administration is now disabled
[Info] Auto-upgrade is blocked by root/administrator via /root/Thinkbox/Deadline10/secure.ini.
Launcher Thread - Automatic Updates is now disabled
Launcher Thread - ::1 has connected
Launcher Thread - Received command: StopLicenseForwarder
Launcher Scheduling - Error querying idle time: ./xidle: error while loading shared libraries: libX11.so.6: cannot open shared object file: No such file or directory
No License Forwarder to shutdown
Launcher Thread - Responded with: Success
Launcher Thread - ::1 has connected
Launcher Thread - Received command: StopWebService
No Web Service to shutdown
Launcher Thread - Responded with: Success
Launcher Thread - ::1 has connected
Launcher Thread - Received command: StopLauncher
Shutting down
Launcher Health Check Thread - Shutting down...
Launcher Thread - OnConnect: Listener Socket has been closed.
Launcher Thread - OnConnect: Listener Socket has been closed.
Launcher Health Check Thread - No longer listening on port 63415
Launcher Health Check Thread - Shutdown complete
Launcher Thread - Responded with: Success
Error occurred while purging logs: Object reference not set to an instance of an object. (System.NullReferenceException)
Exception Details
NullReferenceException -- Object reference not set to an instance of an object.
Exception.TargetSite: Void PurgeLogs(System.TimeSpan)
Exception.Data: ( )
Exception.Source: deadline
Exception.HResult: -2147467261
  Exception.StackTrace: 
   at Deadline.Applications.DeadlineApplicationManager.PurgeLogs(TimeSpan timeSpan)
+ echo 'Script completed successfully.'
Script completed successfully.
postWorkerLaunch
Completed 174 Bytes/174 Bytes (1.2 KiB/s) with 1 file(s) remaining
download: s3://cdk-hnb659fds-assets-162923712518-us-west-2/d03f8ab5f81a6e760a35c16a0318c9fb50d0f1c5e7a0e4e6a99ea4da52c64de0.sh to tmp/d03f8ab5f81a6e760a35c16a0318c9fb50d0f1c5e7a0e4e6a99ea4da52c64de0.sh
ValidationError: Stack arn:aws:cloudformation:us-west-2:162923712518:stack/ComputeTier/51782b70-7b30-11ed-a97f-0ad7a18305f5 is in UPDATE_COMPLETE state and cannot be signaled
Failed to send Cloudformation Signal
```

</details>

<details><summary>Integration Test Results</summary>

All integration tests passed, expect for a couple failures in the Repository tests:

```
      cloud-init-output LogStream tests
        ✕ DL-1-5: cloud-init-output is initialized (1 ms)
        ✕ DL-1-6: cloud-init-output does not contain INSTALLER_DB_ARGS (1 ms)
```

After investigating, I found that the failure is not due to a breaking change in RFDK, but rather a faulty test. I'm pretty sure this is just a race condition between the expected logs being published to the log stream and when the jest test queries the log stream. In the interest of time, I reran the tests locally by doing the same things the jest test does, just on my local machine:

DL-1-5 ([source code](https://github.com/aws/aws-rfdk/blob/adbbaa4378d97f05e4c0cf4bc696d53ac0fb89fe/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts#L244-L259))
- Got the LogGroupName from the Repository testing stack outputs (stack name was in the stack deploy logs in .e2etemp) in the CloudFormation console
- Got the cloud-init log stream name from the CloudWatch Console
- Plugged both values into the same AWS SDK calls the jest tests make
```
> const cloudwatch = require("@aws-sdk/client-cloudwatch-logs");
> let logs = new cloudwatch.CloudWatchLogs();
> let cloudInitLogs = await logs.getLogEvents({ logGroupName: '/RFDKInteg-DL-ComponentTier1671036911132448856-StorageStruct1/Repository', logStreamName: 'cloud-init-output-i-0b75048204a4f5488' });
> cloudInitLogs.events.filter(e => e.message.match(/Cloud-init v. /)).length > 0;
true
```

DL-1-6 ([source code](https://github.com/aws/aws-rfdk/blob/adbbaa4378d97f05e4c0cf4bc696d53ac0fb89fe/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts#L261-L277))
- Same thing as above, just ran a different filter to reflect what the jest test does
```
> cloudInitLogs.events.filter(e => e.message.match(/\w*(?<!declare -A )INSTALLER_DB_ARGS/)).length === 0;
true
```

</details>

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
