### PR TITLE
fix(deadline): typo in license acceptance error messsage

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
@@ -145,7 +145,7 @@ By downloading or using the Deadline software, you agree to the AWS Customer Agr
 and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
 is AWS Content as defined in those Agreements.
 
-Please set the userAcceptsAwsCustomerAgreementAndIpLicense property to
+Please set the userAwsCustomerAgreementAndIpLicenseAcceptance property to
 USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to signify your acceptance of these terms.
 `;
 

--- a/packages/aws-rfdk/lib/deadline/test/thinkbox-docker-images.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/thinkbox-docker-images.test.ts
@@ -59,7 +59,7 @@ By downloading or using the Deadline software, you agree to the AWS Customer Agr
 and AWS Intellectual Property License (https://aws.amazon.com/legal/aws-ip-license-terms/). You acknowledge that Deadline
 is AWS Content as defined in those Agreements.
 
-Please set the userAcceptsAwsCustomerAgreementAndIpLicense property to
+Please set the userAwsCustomerAgreementAndIpLicenseAcceptance property to
 USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to signify your acceptance of these terms.
 `;
       userAwsCustomerAgreementAndIpLicenseAcceptance = AwsCustomerAgreementAndIpLicenseAcceptance.USER_REJECTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE;


### PR DESCRIPTION
I noticed a typo in the licensing message from the `ThinkboxDockerImages` construct. This fixes it.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
