### PR TITLE
chore: rename root project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-rfdk-project",
+  "name": "aws-rfdk",
   "version": "1.0.0",
   "license": "Apache-2.0",
   "author": {

--- a/scripts/rfdk_build_environment.sh
+++ b/scripts/rfdk_build_environment.sh
@@ -8,7 +8,7 @@
 # repository.
 
 # Make sure we're running from the root of the CDK repo
-if ! test -f package.json || ! grep '"name": "aws-rfdk-project",' package.json > /dev/null || ! grep '"private": true,' package.json > /dev/null
+if ! test -f package.json || ! grep '"name": "aws-rfdk",' package.json > /dev/null || ! grep '"private": true,' package.json > /dev/null
 then
     echo "Usage: Run from the root of the RFDK repository"
     exit 1


### PR DESCRIPTION
Just renaming the root package to match the internal package.json that we publish to reduce confusion by those not familiar with typescript `package.json` files.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
