### PR TITLE
chore(deps): pin json5 to ^2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
       "precommit": "git add ."
     }
   },
+  "resolutions-json5": "json5 <= 2.2.1 has a security vulnerability, and is a transitive dep of several packages. Remove the resolution when able.",
+  "resolutions": {
+    "json5": "^2.2.2"
+  },
   "devDependencies": {
     "@aws-sdk/client-ssm": "^3.234.0",
     "@aws-sdk/client-cloudformation": "^3.222.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7372,17 +7372,10 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
-  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.1.2, json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@^1.0.1, json5@^2.1.2, json5@^2.2.1, json5@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonc-parser@3.2.0:
   version "3.2.0"


### PR DESCRIPTION
json5 <= 2.2.1 has a vulnerability that "could allow an attacker to set arbitrary and unexpected keys on the object returned from JSON5.parse"

CVE: CVE-2022-46175
GHSA ID: GHSA-9c47-m6qq-7p4h

json5 is a transitive dependency for the RFDK and the direct dependencies have not yet updated, so we force the resolution.

Before patch:
```
% yarn why json5
yarn why v1.22.19
[1/4] Why do we have the module "json5"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "json5@2.2.1"
info Has been hoisted to "json5"
info Reasons this module exists
   - "workspace-aggregator-18361a6c-6752-408a-ace8-e8f8794fc06a" depends on it
   - Hoisted from "_project_#@babel#core#json5"
   - Hoisted from "_project_#ts-jest#json5"
   - Hoisted from "_project_#jest#@jest#core#@jest#reporters#istanbul-lib-instrument#@babel#core#json5"
   - Hoisted from "_project_#jest#@jest#core#@jest#transform#babel-plugin-istanbul#istanbul-lib-instrument#@babel#core#json5"
info Disk size without dependencies: "288KB"
info Disk size with unique dependencies: "288KB"
info Disk size with transitive dependencies: "288KB"
info Number of shared dependencies: 0
=> Found "tsconfig-paths#json5@1.0.2"
info This module exists because "_project_#aws-rfdk#eslint-plugin-import#tsconfig-paths" depends on it.
info Disk size without dependencies: "112KB"
info Disk size with unique dependencies: "244KB"
info Disk size with transitive dependencies: "244KB"
info Number of shared dependencies: 1
Done in 0.90s.
```

After patch:
```
% yarn why json5
yarn why v1.22.19
[1/4] Why do we have the module "json5"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "json5@2.2.3"
info Reasons this module exists
   - "_project_#@babel#core" depends on it
   - Hoisted from "_project_#@babel#core#json5"
   - Hoisted from "_project_#ts-jest#json5"
   - Hoisted from "_project_#aws-rfdk#eslint-plugin-import#tsconfig-paths#json5"
   - Hoisted from "_project_#jest#@jest#core#@jest#reporters#istanbul-lib-instrument#@babel#core#json5"
   - Hoisted from "_project_#jest#@jest#core#@jest#transform#babel-plugin-istanbul#istanbul-lib-instrument#@babel#core#json5"
info Disk size without dependencies: "292KB"
info Disk size with unique dependencies: "292KB"
info Disk size with transitive dependencies: "292KB"
info Number of shared dependencies: 0
Done in 0.98s.
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
