### PR TITLE
chore: remove copyright years in license files and pkglint rule

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/integ/LICENSE
+++ b/integ/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/integ/NOTICE
+++ b/integ/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/lambda-layers/LICENSE
+++ b/lambda-layers/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lambda-layers/NOTICE
+++ b/lambda-layers/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/packages/aws-rfdk/LICENSE
+++ b/packages/aws-rfdk/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/aws-rfdk/NOTICE
+++ b/packages/aws-rfdk/NOTICE
@@ -1,2 +1,2 @@
 Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/tools/pkglint/lib/licensing.ts
+++ b/tools/pkglint/lib/licensing.ts
@@ -187,7 +187,7 @@ export const LICENSE =
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-${new Date().getFullYear()} Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -204,5 +204,5 @@ export const LICENSE =
 
 export const NOTICE =
 `Render Farm Deployment Kit on AWS (RFDK)
-Copyright 2018-${new Date().getFullYear()} Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 `;


### PR DESCRIPTION
This applies Amazon best practices to the license and avoids unnecessary updates every year


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
