### PR TITLE
chore: require IMDSv2 on integration tests

### DIFF
--- a/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
+++ b/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
@@ -4,6 +4,8 @@
  */
 
 import { App, Stack, Aspects } from 'aws-cdk-lib';
+import { AutoScalingGroupRequireImdsv2Aspect } from 'aws-cdk-lib/aws-autoscaling';
+import { InstanceRequireImdsv2Aspect, LaunchTemplateRequireImdsv2Aspect } from 'aws-cdk-lib/aws-ec2';
 import {
   Stage,
   ThinkboxDockerRecipes,
@@ -53,3 +55,7 @@ new RepositoryTestingTier(app, 'RFDKInteg-DL-TestingTier' + integStackTag, { env
 Aspects.of(app).add(new SSMInstancePolicyAspect());
 // Adds log retention retry to all functions
 Aspects.of(app).add(new LogRetentionRetryAspect());
+// Require IMDSv2 on EC2
+Aspects.of(app).add(new AutoScalingGroupRequireImdsv2Aspect());
+Aspects.of(app).add(new InstanceRequireImdsv2Aspect({ suppressLaunchTemplateWarning: true }));
+Aspects.of(app).add(new LaunchTemplateRequireImdsv2Aspect());

--- a/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
+++ b/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
@@ -4,6 +4,8 @@
  */
 
 import { App, Stack, Aspects } from 'aws-cdk-lib';
+import { AutoScalingGroupRequireImdsv2Aspect } from 'aws-cdk-lib/aws-autoscaling';
+import { InstanceRequireImdsv2Aspect, LaunchTemplateRequireImdsv2Aspect } from 'aws-cdk-lib/aws-ec2';
 import {
   Stage,
   ThinkboxDockerRecipes,
@@ -64,3 +66,7 @@ new RenderQueueTestingTier(app, 'RFDKInteg-RQ-TestingTier' + integStackTag, { en
 Aspects.of(app).add(new SSMInstancePolicyAspect());
 // Adds log retention retry to all functions
 Aspects.of(app).add(new LogRetentionRetryAspect());
+// Require IMDSv2 on EC2
+Aspects.of(app).add(new AutoScalingGroupRequireImdsv2Aspect());
+Aspects.of(app).add(new InstanceRequireImdsv2Aspect({ suppressLaunchTemplateWarning: true }));
+Aspects.of(app).add(new LaunchTemplateRequireImdsv2Aspect());

--- a/integ/components/deadline/deadline_03_workerFleetHttp/bin/deadline_03_workerFleetHttp.ts
+++ b/integ/components/deadline/deadline_03_workerFleetHttp/bin/deadline_03_workerFleetHttp.ts
@@ -4,6 +4,8 @@
  */
 
 import { App, Stack, Aspects } from 'aws-cdk-lib';
+import { AutoScalingGroupRequireImdsv2Aspect } from 'aws-cdk-lib/aws-autoscaling';
+import { InstanceRequireImdsv2Aspect, LaunchTemplateRequireImdsv2Aspect } from 'aws-cdk-lib/aws-ec2';
 import {
   Stage,
   ThinkboxDockerRecipes,
@@ -68,3 +70,7 @@ new WorkerFleetTestingTier(app, 'RFDKInteg-WF-TestingTier' + integStackTag, {env
 Aspects.of(app).add(new SSMInstancePolicyAspect());
 // Adds log retention retry to all functions
 Aspects.of(app).add(new LogRetentionRetryAspect());
+// Require IMDSv2 on EC2
+Aspects.of(app).add(new AutoScalingGroupRequireImdsv2Aspect());
+Aspects.of(app).add(new InstanceRequireImdsv2Aspect({ suppressLaunchTemplateWarning: true }));
+Aspects.of(app).add(new LaunchTemplateRequireImdsv2Aspect());

--- a/integ/components/deadline/deadline_04_workerFleetHttps/bin/deadline_04_workerFleetHttps.ts
+++ b/integ/components/deadline/deadline_04_workerFleetHttps/bin/deadline_04_workerFleetHttps.ts
@@ -4,6 +4,8 @@
  */
 
 import { App, Stack, Aspects } from 'aws-cdk-lib';
+import { AutoScalingGroupRequireImdsv2Aspect } from 'aws-cdk-lib/aws-autoscaling';
+import { InstanceRequireImdsv2Aspect, LaunchTemplateRequireImdsv2Aspect } from 'aws-cdk-lib/aws-ec2';
 import {
   Stage,
   ThinkboxDockerRecipes,
@@ -68,3 +70,7 @@ new WorkerFleetTestingTier(app, 'RFDKInteg-WFS-TestingTier' + integStackTag, {en
 Aspects.of(app).add(new SSMInstancePolicyAspect());
 // Adds log retention retry to all functions
 Aspects.of(app).add(new LogRetentionRetryAspect());
+// Require IMDSv2 on EC2
+Aspects.of(app).add(new AutoScalingGroupRequireImdsv2Aspect());
+Aspects.of(app).add(new InstanceRequireImdsv2Aspect({ suppressLaunchTemplateWarning: true }));
+Aspects.of(app).add(new LaunchTemplateRequireImdsv2Aspect());

--- a/integ/components/deadline/deadline_05_secretsManagement/bin/deadline_05_secretsManagement.ts
+++ b/integ/components/deadline/deadline_05_secretsManagement/bin/deadline_05_secretsManagement.ts
@@ -7,6 +7,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SecretsManager, ResourceNotFoundException } from '@aws-sdk/client-secrets-manager';
 import { App, Stack, Aspects } from 'aws-cdk-lib';
+import { AutoScalingGroupRequireImdsv2Aspect } from 'aws-cdk-lib/aws-autoscaling';
+import { InstanceRequireImdsv2Aspect, LaunchTemplateRequireImdsv2Aspect } from 'aws-cdk-lib/aws-ec2';
 import {
   Stage,
   ThinkboxDockerRecipes,
@@ -82,6 +84,10 @@ async function main() {
   Aspects.of(app).add(new SSMInstancePolicyAspect());
   // Adds log retention retry to all functions
   Aspects.of(app).add(new LogRetentionRetryAspect());
+  // Require IMDSv2 on EC2
+  Aspects.of(app).add(new AutoScalingGroupRequireImdsv2Aspect());
+  Aspects.of(app).add(new InstanceRequireImdsv2Aspect({ suppressLaunchTemplateWarning: true }));
+  Aspects.of(app).add(new LaunchTemplateRequireImdsv2Aspect());
 }
 
 /**


### PR DESCRIPTION
## Description
We need to require IMDSv2 on our integration tests so we don't make IMDSv1 calls anymore.

## Testing
Ran all the RFDK integration tests and verified they all succeeded and no IMDSv1 calls are being made.

```
$ ./scripts/bash/rfdk-integ-e2e.sh
RFDK end-to-end integration tests started Thu May  4 19:36:42 UTC 2023
Loading config...
Setting test variables...
2023-05-04T19:36:43 [infrastructure] deployment started
2023-05-04T19:40:28 [infrastructure] deployment complete
2023-05-04T19:40:28 [deadline_01_repository] app deployment started
2023-05-04T19:40:28 [deadline_01_repository] synthesizing started
2023-05-04T19:40:55 [deadline_01_repository] synthesizing complete
2023-05-04T19:40:55 [deadline_01_repository] app deployment started
2023-05-04T19:40:55 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1683229003482196447] stack deployment started
2023-05-04T19:57:40 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1683229003482196447] stack deployment complete
2023-05-04T19:57:40 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1683229003482196447] stack deployment started
2023-05-04T20:01:35 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1683229003482196447] stack deployment complete
2023-05-04T20:01:35 [deadline_01_repository] app deployment complete
2023-05-04T20:01:35 [deadline_01_repository] running test suite started
2023-05-04T20:02:04 [deadline_01_repository] running test suite complete
2023-05-04T20:02:04 [deadline_01_repository] test suite passed
2023-05-04T20:02:04 [deadline_01_repository] app destroy started
2023-05-04T20:02:04 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1683229003482196447] stack destroy started
2023-05-04T20:05:02 [deadline_01_repository] -> [RFDKInteg-DL-TestingTier1683229003482196447] stack destroy complete
2023-05-04T20:05:02 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1683229003482196447] stack destroy started
2023-05-04T20:25:08 [deadline_01_repository] -> [RFDKInteg-DL-ComponentTier1683229003482196447] stack destroy complete
2023-05-04T20:25:08 [deadline_01_repository] app destroy complete
2023-05-04T20:25:08 [deadline_02_renderQueue] app deployment started
2023-05-04T20:25:08 [deadline_02_renderQueue] synthesizing started
2023-05-04T20:25:36 [deadline_02_renderQueue] synthesizing complete
2023-05-04T20:25:36 [deadline_02_renderQueue] app deployment started
2023-05-04T20:25:36 [deadline_02_renderQueue] -> [RFDKInteg-RQ-ComponentTier1683229003482196447] stack deployment started
2023-05-04T20:43:11 [deadline_02_renderQueue] -> [RFDKInteg-RQ-ComponentTier1683229003482196447] stack deployment complete
2023-05-04T20:43:11 [deadline_02_renderQueue] -> [RFDKInteg-RQ-TestingTier1683229003482196447] stack deployment started
2023-05-04T20:48:07 [deadline_02_renderQueue] -> [RFDKInteg-RQ-TestingTier1683229003482196447] stack deployment complete
2023-05-04T20:48:07 [deadline_02_renderQueue] app deployment complete
2023-05-04T20:48:07 [deadline_02_renderQueue] running test suite started
2023-05-04T20:48:51 [deadline_02_renderQueue] running test suite complete
2023-05-04T20:48:51 [deadline_02_renderQueue] test suite passed
2023-05-04T20:48:51 [deadline_02_renderQueue] app destroy started
2023-05-04T20:48:51 [deadline_02_renderQueue] -> [RFDKInteg-RQ-TestingTier1683229003482196447] stack destroy started
2023-05-04T20:49:23 [deadline_02_renderQueue] -> [RFDKInteg-RQ-TestingTier1683229003482196447] stack destroy complete
2023-05-04T20:49:23 [deadline_02_renderQueue] -> [RFDKInteg-RQ-ComponentTier1683229003482196447] stack destroy started
2023-05-04T21:08:52 [deadline_02_renderQueue] -> [RFDKInteg-RQ-ComponentTier1683229003482196447] stack destroy complete
2023-05-04T21:08:52 [deadline_02_renderQueue] app destroy complete
2023-05-04T21:08:52 [deadline_03_workerFleetHttp] app deployment started
2023-05-04T21:08:52 [deadline_03_workerFleetHttp] synthesizing started
2023-05-04T21:09:21 [deadline_03_workerFleetHttp] synthesizing complete
2023-05-04T21:09:21 [deadline_03_workerFleetHttp] app deployment started
2023-05-04T21:09:21 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF1-ComponentTier1683229003482196447] stack deployment started
2023-05-04T21:31:14 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF1-ComponentTier1683229003482196447] stack deployment complete
2023-05-04T21:31:14 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF2-ComponentTier1683229003482196447] stack deployment started
2023-05-04T21:59:00 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF2-ComponentTier1683229003482196447] stack deployment complete
2023-05-04T21:59:00 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF-TestingTier1683229003482196447] stack deployment started
2023-05-04T22:03:57 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF-TestingTier1683229003482196447] stack deployment complete
2023-05-04T22:03:57 [deadline_03_workerFleetHttp] app deployment complete
2023-05-04T22:03:57 [deadline_03_workerFleetHttp] running test suite started
2023-05-04T22:05:29 [deadline_03_workerFleetHttp] running test suite complete
2023-05-04T22:05:29 [deadline_03_workerFleetHttp] test suite passed
2023-05-04T22:05:29 [deadline_03_workerFleetHttp] app destroy started
2023-05-04T22:05:29 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF-TestingTier1683229003482196447] stack destroy started
2023-05-04T22:06:01 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF-TestingTier1683229003482196447] stack destroy complete
2023-05-04T22:06:01 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF2-ComponentTier1683229003482196447] stack destroy started
2023-05-04T22:27:12 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF2-ComponentTier1683229003482196447] stack destroy complete
2023-05-04T22:27:12 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF1-ComponentTier1683229003482196447] stack destroy started
2023-05-04T22:47:22 [deadline_03_workerFleetHttp] -> [RFDKInteg-WF1-ComponentTier1683229003482196447] stack destroy complete
2023-05-04T22:47:22 [deadline_03_workerFleetHttp] app destroy complete
2023-05-04T22:47:22 [deadline_04_workerFleetHttps] app deployment started
2023-05-04T22:47:22 [deadline_04_workerFleetHttps] synthesizing started
2023-05-04T22:47:56 [deadline_04_workerFleetHttps] synthesizing complete
2023-05-04T22:47:56 [deadline_04_workerFleetHttps] app deployment started
2023-05-04T22:47:56 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS1-ComponentTier1683229003482196447] stack deployment started
2023-05-04T23:10:39 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS1-ComponentTier1683229003482196447] stack deployment complete
2023-05-04T23:10:39 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS2-ComponentTier1683229003482196447] stack deployment started
2023-05-04T23:37:15 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS2-ComponentTier1683229003482196447] stack deployment complete
2023-05-04T23:37:15 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS-TestingTier1683229003482196447] stack deployment started
2023-05-04T23:42:11 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS-TestingTier1683229003482196447] stack deployment complete
2023-05-04T23:42:11 [deadline_04_workerFleetHttps] app deployment complete
2023-05-04T23:42:11 [deadline_04_workerFleetHttps] running test suite started
2023-05-04T23:43:51 [deadline_04_workerFleetHttps] running test suite complete
2023-05-04T23:43:51 [deadline_04_workerFleetHttps] test suite passed
2023-05-04T23:43:51 [deadline_04_workerFleetHttps] app destroy started
2023-05-04T23:43:51 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS-TestingTier1683229003482196447] stack destroy started
2023-05-04T23:44:33 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS-TestingTier1683229003482196447] stack destroy complete
2023-05-04T23:44:33 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS2-ComponentTier1683229003482196447] stack destroy started
2023-05-05T00:06:18 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS2-ComponentTier1683229003482196447] stack destroy complete
2023-05-05T00:06:18 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS1-ComponentTier1683229003482196447] stack destroy started
2023-05-05T00:28:55 [deadline_04_workerFleetHttps] -> [RFDKInteg-WFS1-ComponentTier1683229003482196447] stack destroy complete
2023-05-05T00:28:55 [deadline_04_workerFleetHttps] app destroy complete
2023-05-05T00:28:55 [deadline_05_secretsManagement] app deployment started
2023-05-05T00:28:55 [deadline_05_secretsManagement] synthesizing started
2023-05-05T00:29:24 [deadline_05_secretsManagement] synthesizing complete
2023-05-05T00:29:24 [deadline_05_secretsManagement] app deployment started
2023-05-05T00:29:24 [deadline_05_secretsManagement] -> [RFDKInteg-SM-ComponentTier1683229003482196447] stack deployment started
2023-05-05T00:57:37 [deadline_05_secretsManagement] -> [RFDKInteg-SM-ComponentTier1683229003482196447] stack deployment complete
2023-05-05T00:57:37 [deadline_05_secretsManagement] -> [RFDKInteg-SM-TestingTier1683229003482196447] stack deployment started
2023-05-05T01:03:13 [deadline_05_secretsManagement] -> [RFDKInteg-SM-TestingTier1683229003482196447] stack deployment complete
2023-05-05T01:03:13 [deadline_05_secretsManagement] app deployment complete
2023-05-05T01:03:13 [deadline_05_secretsManagement] running test suite started
2023-05-05T01:03:55 [deadline_05_secretsManagement] running test suite complete
2023-05-05T01:03:55 [deadline_05_secretsManagement] test suite passed
2023-05-05T01:03:55 [deadline_05_secretsManagement] app destroy started
2023-05-05T01:03:55 [deadline_05_secretsManagement] -> [RFDKInteg-SM-TestingTier1683229003482196447] stack destroy started
2023-05-05T01:06:54 [deadline_05_secretsManagement] -> [RFDKInteg-SM-TestingTier1683229003482196447] stack destroy complete
2023-05-05T01:06:54 [deadline_05_secretsManagement] -> [RFDKInteg-SM-ComponentTier1683229003482196447] stack destroy started
2023-05-05T01:28:09 [deadline_05_secretsManagement] -> [RFDKInteg-SM-ComponentTier1683229003482196447] stack destroy complete
2023-05-05T01:28:09 [deadline_05_secretsManagement] app destroy complete
2023-05-05T01:28:09 [infrastructure] destroy started
2023-05-05T01:30:17 [infrastructure] destroy complete
Complete!
Pretest setup runtime: 0m 1s
Infrastructure stack deploy runtime: 3m 45s
Infrastructure stack cleanup runtime: 2m 8s

============================================================
[deadline_01_repository]: TEST REPORT
============================================================

Exit code: 0

----------------------------------------------
[deadline_01_repository]: Test output
----------------------------------------------

$ jest deadline_01_repository.test --json --outputFile=/local/home/jericht/repositories/github/aws-rfdk/integ/.e2etemp/deadline_01_repository/test-report.json
ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
PASS components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts (27.671 s)
  Deadline Repository tests (RFDK-created DB and EFS)
    DocumentDB tests
      ✓ DL-1-1: Deadline DB is initialized (2161 ms)
    EFS tests
      ✓ DL-1-2: EFS is initialized (1 ms)
      ✓ DL-1-3: repository.ini version matches Deadline installer (1 ms)
    CloudWatch LogGroup tests
      ✓ DL-1-4: CloudWatch LogGroup contains two LogStreams
      cloud-init-output LogStream tests
        ✓ DL-1-5: cloud-init-output is initialized
        ✓ DL-1-6: cloud-init-output does not contain INSTALLER_DB_ARGS (1 ms)
      DeadlineRepositoryInstallationLogs LogStream tests
        ✓ DL-1-7: DeadlineRepositoryInstallationLogs is initialized (1 ms)
  Deadline Repository tests (User-created DB and EFS)
    DocumentDB tests
      ✓ DL-2-1: Deadline DB is initialized (2133 ms)
    EFS tests
      ✓ DL-2-2: EFS is initialized
      ✓ DL-2-3: repository.ini version matches Deadline installer (1 ms)
    CloudWatch LogGroup tests
      ✓ DL-2-4: CloudWatch LogGroup contains two LogStreams
      cloud-init-output LogStream tests
        ✓ DL-2-5: cloud-init-output is initialized (1 ms)
        ✓ DL-2-6: cloud-init-output does not contain INSTALLER_DB_ARGS
      DeadlineRepositoryInstallationLogs LogStream tests
        ✓ DL-2-7: DeadlineRepositoryInstallationLogs is initialized (1 ms)
  Deadline Repository tests (User-created MongoDB)
    DocumentDB tests
      ✓ DL-3-1: Deadline DB is initialized (2135 ms)
    EFS tests
      ✓ DL-3-2: EFS is initialized (7 ms)
      ✓ DL-3-3: repository.ini version matches Deadline installer (6 ms)
    CloudWatch LogGroup tests
      ✓ DL-3-4: CloudWatch LogGroup contains two LogStreams (7 ms)
      cloud-init-output LogStream tests
        ✓ DL-3-5: cloud-init-output is initialized
        ✓ DL-3-6: cloud-init-output does not contain INSTALLER_DB_ARGS (1 ms)
      DeadlineRepositoryInstallationLogs LogStream tests
        ✓ DL-3-7: DeadlineRepositoryInstallationLogs is initialized (1 ms)

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        27.728 s
Ran all test suites matching /deadline_01_repository.test/i.
Test results written to: .e2etemp/deadline_01_repository/test-report.json

Results for test component deadline_01_repository:
  -Tests ran:     21
  -Tests passed:  21
  -Tests failed:  0
  -Deploy runtime:     1m 36s
  -Test suite runtime: 0m 28s
  -Cleanup runtime:    -17m -24s

============================================================
[deadline_02_renderQueue]: TEST REPORT
============================================================

Exit code: 0

----------------------------------------------
[deadline_02_renderQueue]: Test output
----------------------------------------------

$ jest deadline_02_renderQueue.test --json --outputFile=/local/home/jericht/repositories/github/aws-rfdk/integ/.e2etemp/deadline_02_renderQueue/test-report.json
ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
PASS components/deadline/deadline_02_renderQueue/test/deadline_02_renderQueue.test.ts (42.956 s)
  Deadline RenderQueue tests (HTTP mode)
    Connection tests
      ✓ RQ-1-1: Farm render queue endpoint can be queried (1136 ms)
    deadlinecommand tests
      ✓ RQ-1-2: Farm can accept Deadline commands (2128 ms)
      ✓ RQ-1-3: Farm can fetch settings file from repository (2133 ms)
      ✓ RQ-1-4: Farm can accept sample Deadline job (4164 ms)
      ✓ RQ-1-5: RCS not running as root (2116 ms)
  Deadline RenderQueue tests (HTTPS mode (TLS))
    Connection tests
      ✓ RQ-2-1: Farm render queue endpoint can be queried (1107 ms)
    deadlinecommand tests
      ✓ RQ-2-2: Farm can accept Deadline commands (2122 ms)
      ✓ RQ-2-3: Farm can fetch settings file from repository (2127 ms)
      ✓ RQ-2-4: Farm can accept sample Deadline job (4121 ms)
      ✓ RQ-2-5: RCS not running as root (2095 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        43.01 s
Ran all test suites matching /deadline_02_renderQueue.test/i.
Test results written to: .e2etemp/deadline_02_renderQueue/test-report.json

Results for test component deadline_02_renderQueue:
  -Tests ran:     10
  -Tests passed:  10
  -Tests failed:  0
  -Deploy runtime:     48m 8s
  -Test suite runtime: 0m 43s
  -Cleanup runtime:    -5m -7s

============================================================
[deadline_03_workerFleetHttp]: TEST REPORT
============================================================

Exit code: 0

----------------------------------------------
[deadline_03_workerFleetHttp]: Test output
----------------------------------------------

$ jest deadline_03_workerFleetHttp.test --json --outputFile=/local/home/jericht/repositories/github/aws-rfdk/integ/.e2etemp/deadline_03_workerFleetHttp/test-report.json
ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
PASS components/deadline/deadline_03_workerFleetHttp/test/deadline_03_workerFleetHttp.test.ts (91.275 s)
  Deadline WorkerFleet tests (Linux Worker HTTP mode)
    Worker node tests
      ✓ WF-1-1: Workers can be attached to the Render Queue (2134 ms)
      ✓ WF-1-2: Workers can be added to groups, pools and regions (6231 ms)
      ✓ WF-1-3: Workers can be assigned jobs submitted to a group (15427 ms)
      ✓ WF-1-4: Workers can be assigned jobs submitted to a pool (13378 ms)
  Deadline WorkerFleet tests (Windows Worker HTTP mode)
    Worker node tests
      ✓ WF-2-1: Workers can be attached to the Render Queue (2103 ms)
      ✓ WF-2-2: Workers can be added to groups, pools and regions (7164 ms)
      ✓ WF-2-3: Workers can be assigned jobs submitted to a group (16437 ms)
      ✓ WF-2-4: Workers can be assigned jobs submitted to a pool (13309 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        91.329 s, estimated 97 s
Ran all test suites matching /deadline_03_workerFleetHttp.test/i.
Test results written to: .e2etemp/deadline_03_workerFleetHttp/test-report.json

Results for test component deadline_03_workerFleetHttp:
  -Tests ran:     8
  -Tests passed:  8
  -Tests failed:  0
  -Deploy runtime:     3m 58s
  -Test suite runtime: 1m 31s
  -Cleanup runtime:    -26m -59s

============================================================
[deadline_04_workerFleetHttps]: TEST REPORT
============================================================

Exit code: 0

----------------------------------------------
[deadline_04_workerFleetHttps]: Test output
----------------------------------------------

$ jest deadline_04_workerFleetHttps.test --json --outputFile=/local/home/jericht/repositories/github/aws-rfdk/integ/.e2etemp/deadline_04_workerFleetHttps/test-report.json
ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
PASS components/deadline/deadline_04_workerFleetHttps/test/deadline_04_workerFleetHttps.test.ts (97.636 s)
  Deadline WorkerFleetHttps tests (Linux Worker HTTPS (TLS) mode)
    Worker node tests
      ✓ WFS-1-1: Workers can be attached to the Render Queue (2134 ms)
      ✓ WFS-1-2: Workers can be added to groups, pools and regions (6287 ms)
      ✓ WFS-1-3: Workers can be assigned jobs submitted to a group (14554 ms)
      ✓ WFS-1-4: Workers can be assigned jobs submitted to a pool (15528 ms)
  Deadline WorkerFleetHttps tests (Windows Worker HTTPS (TLS) mode)
    Worker node tests
      ✓ WFS-2-1: Workers can be attached to the Render Queue (2126 ms)
      ✓ WFS-2-2: Workers can be added to groups, pools and regions (6254 ms)
      ✓ WFS-2-3: Workers can be assigned jobs submitted to a group (14456 ms)
      ✓ WFS-2-4: Workers can be assigned jobs submitted to a pool (13441 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        97.744 s
Ran all test suites matching /deadline_04_workerFleetHttps.test/i.
Test results written to: .e2etemp/deadline_04_workerFleetHttps/test-report.json

Results for test component deadline_04_workerFleetHttps:
  -Tests ran:     8
  -Tests passed:  8
  -Tests failed:  0
  -Deploy runtime:     42m 13s
  -Test suite runtime: 1m 37s
  -Cleanup runtime:    -2m -17s

============================================================
[deadline_05_secretsManagement]: TEST REPORT
============================================================

Exit code: 0

----------------------------------------------
[deadline_05_secretsManagement]: Test output
----------------------------------------------

$ jest deadline_05_secretsManagement.test --json --outputFile=/local/home/jericht/repositories/github/aws-rfdk/integ/.e2etemp/deadline_05_secretsManagement/test-report.json
ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
PASS components/deadline/deadline_05_secretsManagement/test/deadline_05_secretsManagement.test.ts (41.423 s)
  Deadline Secrets Management tests
    ✓ SM-1-1: Deadline Repository configures Secrets Management (4295 ms)
    ✓ SM-1-2: Deadline Render Queue has a Server role (5192 ms)
    ✓ SM-1-3: Deadline Usage Based Licensing has an identity registration setting (4289 ms)
    ✓ SM-1-4: Deadline Worker Instance Fleet has an identity registration setting (4299 ms)
    ✓ SM-1-5: Deadline Spot Event Plugin Fleet has an identity registration setting (4286 ms)
    ✓ SM-1-6: Deadline Usage Based Licensing is automatically registered as a Client (4259 ms)
    ✓ SM-1-7: Deadline Worker Instance Fleet is automatically registered as a Client (4184 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        41.479 s
Ran all test suites matching /deadline_05_secretsManagement.test/i.
Test results written to: .e2etemp/deadline_05_secretsManagement/test-report.json

Results for test component deadline_05_secretsManagement:
  -Tests ran:     7
  -Tests passed:  7
  -Tests failed:  0
  -Deploy runtime:     3m 14s
  -Test suite runtime: 0m 41s
  -Cleanup runtime:    -4m -41s
Cleaning up folders...
$ ./scripts/bash/cleanup.sh
Exiting...
Done in 21215.75s.
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
