### PR TITLE
chore(deps): bump aws-sdk from 2.1334.0 to 2.1391.0 and pin xml2js >=…

### DIFF
--- a/lambda-layers/package.json
+++ b/lambda-layers/package.json
@@ -33,6 +33,6 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "aws-sdk": "^2.1334.0"
+    "aws-sdk": "^2.1391.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^27.5.2",
     "@types/node": "^18.6.2",
     "aws-cdk-lib": "2.70.0",
-    "aws-sdk": "^2.1334.0",
+    "aws-sdk": "^2.1391.0",
     "constructs": "^10.0.0",
     "fs-extra": "^11.1.0",
     "jest": "^27.5.1",

--- a/packages/aws-rfdk/package.json
+++ b/packages/aws-rfdk/package.json
@@ -70,7 +70,7 @@
     "@types/jest": "^27.5.2",
     "@types/sinon": "^10.0.13",
     "aws-cdk-lib": "2.70.0",
-    "aws-sdk": "^2.1334.0",
+    "aws-sdk": "^2.1391.0",
     "aws-sdk-mock": "5.5.0",
     "awslint": "2.68.0",
     "constructs": "^10.0.0",
@@ -90,6 +90,10 @@
     "sinon": "^15.0.3",
     "ts-jest": "^29.0.5",
     "typescript": "~4.9.5"
+  },
+  "resolutions-aws-sdk-mock-aws-sdk": "xml2js < 0.5.0 has a security vulnerability, and is a transitive dep of aws-sdk-mock. Upgrading aws-sdk-mock gives TS compile errors. Remove the resolution when able.",
+  "resolutions": {
+    "aws-sdk-mock/aws-sdk": "^2.1391.0"
   },
   "dependencies": {
     "aws-cdk-lib": "2.70.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2760,7 +2760,14 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
   integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
 
-"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.8.3":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
+  integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
   integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
@@ -2803,9 +2810,9 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@sinonjs/samsam@^6.0.2":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.1.tgz#627f7f4cbdb56e6419fa2c1a3e4751ce4f6a00b1"
-  integrity sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.3.tgz#4e30bcd4700336363302a7d72cbec9b9ab87b104"
+  integrity sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==
   dependencies:
     "@sinonjs/commons" "^1.6.0"
     lodash.get "^4.4.2"
@@ -3605,10 +3612,10 @@ aws-sdk-mock@5.5.0:
     sinon "^11.1.1"
     traverse "^0.6.6"
 
-aws-sdk@^2.1334.0, aws-sdk@^2.928.0:
-  version "2.1334.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1334.0.tgz#011e0b8c54d26f559e4608c91b9be81701d6c505"
-  integrity sha512-nJuV8QYY39sI1Q7u7Dsd2XcxDkUG/Z5oGosc41LrTBAHQjPib3rXV06zaL9jS+4yQ9Ko7qon2f/0ZVVuUPJjDA==
+aws-sdk@^2.1391.0, aws-sdk@^2.928.0:
+  version "2.1391.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1391.0.tgz#e7e08ee1475f01173bcf873857d592809e1a0107"
+  integrity sha512-aftZHbS9xbCdGLpNFeNJCfxqihbStjvCI5nS06/LJVJrCiwLILIJZAfY6I+QkEROI7ELATL+k1PEfA6u/hRrXQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -3619,7 +3626,7 @@ aws-sdk@^2.1334.0, aws-sdk@^2.928.0:
     url "0.10.3"
     util "^0.12.4"
     uuid "8.0.0"
-    xml2js "0.4.19"
+    xml2js "0.5.0"
 
 awslint@2.68.0:
   version "2.68.0"
@@ -10303,13 +10310,13 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+xml2js@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
   dependencies:
     sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
+    xmlbuilder "~11.0.0"
 
 xml@^1.0.1:
   version "1.0.1"
@@ -10321,10 +10328,10 @@ xmlbuilder@^15.1.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
-xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Problem

The `xml2js` dependency is outdated and needs updating.

## Solution

`xml2js` is a transitive dependency and is required by `aws-sdk` and `aws-sdk-mock`. To upgrade `xml2js`, I've bumped the version of `aws-sdk` from `2.1334.0` &rarr; `2.1391.0`, which now depends on `xml2js` version `0.5.0`.

I attempted to update `aws-sdk-mock`, but ran into TypeScript compilation errors. Instead I used yarn transitive dependency override feature (`"resolutions"` in `package.json`) to force `xml2js` version `0.5.0`.

## Testing

*   Ran `yarn build` which succeeded
*   Ran the integration tests in the `integ` directory and they passed

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
