### PR TITLE
chore: use yarn to build in pipeline

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -10,10 +10,10 @@ phases:
       - yarn install --frozen-lockfile
   build:
     commands:
-      - /bin/bash ./build.sh
+      - yarn build
   post_build:
     commands:
-      - "[ -f .BUILD_COMPLETED ] && /bin/bash ./pack.sh"
+      - "[ -f .BUILD_COMPLETED ] && yarn pack"
 artifacts:
   files:
     - "**/*"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "private": true,
   "scripts": {
     "build": "./build.sh",
+    "pack": "./pack.sh",
     "clean": "./scripts/clean-stale-files.sh && lerna run clean && bash ./clean.sh",
     "package": "lerna run package",
     "release": "standard-version"


### PR DESCRIPTION
Switched to using yarn for builds and for the pack command. This is needed for the upgrade to Node18.

Tested by running in the pipelines and making sure all steps passed.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
