### PR TITLE
fix(deadline): add usage-based licensing ports for new Cinema4d versions

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -131,7 +131,7 @@ export class UsageBasedLicense {
   public static forCinema4D(limit?: number): UsageBasedLicense {
     return new UsageBasedLicense({
       licenseName: 'cinema4d',
-      ports: [Port.tcp(5057), Port.tcp(7057)],
+      ports: [Port.tcp(5057), Port.tcp(5058), Port.tcp(7057), Port.tcp(7058)],
       limit,
     });
   }

--- a/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/usage-based-licensing.test.ts
@@ -569,7 +569,7 @@ describe('UsageBasedLicensing', () => {
     test.each([
       ['3dsMax', UsageBasedLicense.for3dsMax(10), [27002]],
       ['Arnold', UsageBasedLicense.forArnold(10), [5056, 7056]],
-      ['Cinema4D', UsageBasedLicense.forCinema4D(10), [5057, 7057]],
+      ['Cinema4D', UsageBasedLicense.forCinema4D(10), [5057, 5058, 7057, 7058]],
       ['Clarisse', UsageBasedLicense.forClarisse(10), [40500]],
       ['Houdini', UsageBasedLicense.forHoudini(10), [1715]],
       ['Katana', UsageBasedLicense.forKatana(10), [4151, 6101]],


### PR DESCRIPTION
Problem:
- It was reported by several customers newer versions of Cinema4d do not work with RFDK. 
```UsageBasedLicensing.for_cinema_4d() is supposed to set up UBL for cinema4d, but it is missing some ports. Cinema4d switched to ports from 5057 and 7057 to 5058 and 7058 so RFDK no longer works without manual configs in newer versions like C4D 2023.```

Solution:
- Add the additional ports as required. To keep backwards compatibility, prior ports are kept.

Testing:
- ./build.sh
- yarn build+test

```
=============================== Coverage summary ===============================
Statements   : 97.93% ( 3316/3386 )
Branches     : 95.07% ( 1043/1097 )
Functions    : 96.98% ( 514/530 )
Lines        : 98.09% ( 3196/3258 )
================================================================================

Test Suites: 62 passed, 62 total
Tests:       1278 passed, 1278 total
Snapshots:   0 total
Time:        47.823 s, estimated 67 s
```
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
