### PR TITLE
chore: use 'yarn run' for buildspec.yaml

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -10,10 +10,10 @@ phases:
       - yarn install --frozen-lockfile
   build:
     commands:
-      - yarn build
+      - yarn run build
   post_build:
     commands:
-      - "[ -f .BUILD_COMPLETED ] && yarn pack"
+      - "[ -f .BUILD_COMPLETED ] && yarn run pack"
 artifacts:
   files:
     - "**/*"


### PR DESCRIPTION
## Background
In a [previous change](https://github.com/aws/aws-rfdk/pull/1110) to update to Node 18, we missed adding the `run` keyword to the `yarn` commands in the `buildspec.yaml` file, leading to pipeline failures.

Specifically the `yarn pack` command was causing failures, as we need to run `yarn run pack` to run our `pack.sh` script.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
