### PR TITLE
feat(deadline): DocumentDB engine version support upgraded upto v5.0

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
@@ -46,7 +46,7 @@ export interface DocDBConnectionOptions {
 
   /**
    * The Document DB Cluster this connection is for.
-   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6, 4.0, 5.0.
    */
   readonly database: IDatabaseCluster;
 
@@ -63,7 +63,7 @@ export interface DocDBConnectionOptions {
 export interface MongoDbInstanceConnectionOptions {
   /**
    * The MongoDB database to connect to.
-   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6, 4.0, 5.0.
    */
   readonly database: IMongoDb;
 
@@ -85,7 +85,7 @@ export interface MongoDbInstanceConnectionOptions {
 export abstract class DatabaseConnection {
   /**
    * Creates a DatabaseConnection which allows Deadline to connect to Amazon DocumentDB.
-   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6, 4.0, 5.0.
    *
    * Resources Deployed
    * ------------------------
@@ -97,7 +97,7 @@ export abstract class DatabaseConnection {
 
   /**
    * Creates a DatabaseConnection which allows Deadline to connect to MongoDB.
-   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6.
+   * Note: Deadline officially supports only databases that are compatible with MongoDB 3.6, 4.0, 5.0.
    *
    * Resources Deployed
    * ------------------------
@@ -188,7 +188,7 @@ class DocDBDatabaseConnection extends DatabaseConnection {
     super();
 
     if (!this.isCompatibleDocDBVersion()) {
-      Annotations.of(props.database).addError('engineVersion must be 3.6.0 to be compatible with Deadline');
+      Annotations.of(props.database).addError('engineVersion must be one of 3.6.0, 4.0.0 or 5.0.0 to be compatible with Deadline');
     }
 
     this.containerEnvironment = {
@@ -326,7 +326,7 @@ class DocDBDatabaseConnection extends DatabaseConnection {
   }
 
   /**
-   * Deadline is only compatible with MongoDB 3.6. This function attempts to determine whether
+   * Deadline is compatible with MongoDB 3.6, 4.0 and 5.0. This function attempts to determine whether
    * the given DocDB version is compatible.
    */
   protected isCompatibleDocDBVersion(): boolean {
@@ -335,7 +335,7 @@ class DocDBDatabaseConnection extends DatabaseConnection {
     // checking the value of the engineVersion property of that object.
     if (this.props.database.node.defaultChild) {
       const cluster = this.props.database.node.defaultChild! as CfnDBCluster;
-      return cluster.engineVersion?.startsWith('3.6') ?? false;
+      return ( cluster.engineVersion?.startsWith('3.6') || cluster.engineVersion?.startsWith('4.0') || cluster.engineVersion?.startsWith('5.0') )?? false;
     }
 
     return true; // No information, assume it's compatible.

--- a/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
@@ -436,38 +436,7 @@ describe('DocumentDB Version Checks', () => {
     // THEN
     Annotations.fromStack(stack).hasError(
       `/${database.node.path}`,
-      'engineVersion must be 3.6.0 to be compatible with Deadline',
-    );
-  });
-
-  test('engineVersion not 3.6.0', () => {
-    // GIVEN
-    const database = new DatabaseCluster(stack, 'DbCluster', {
-      masterUser: {
-        username: 'master',
-      },
-      instanceType: InstanceType.of(
-        InstanceClass.R5,
-        InstanceSize.XLARGE,
-      ),
-      vpc,
-      vpcSubnets: {
-        onePerAz: true,
-        subnetType: SubnetType.PRIVATE_WITH_EGRESS,
-      },
-      backup: {
-        retention: Duration.days(15),
-      },
-      engineVersion: '4.0.0',
-    });
-
-    // WHEN
-    DatabaseConnection.forDocDB({database, login: database.secret!});
-
-    // THEN
-    Annotations.fromStack(stack).hasError(
-      `/${database.node.path}`,
-      'engineVersion must be 3.6.0 to be compatible with Deadline',
+      'engineVersion must be one of 3.6.0, 4.0.0 or 5.0.0 to be compatible with Deadline',
     );
   });
 });


### PR DESCRIPTION
**Problem**
Only documentDB engine version 3.6 was supported before current Deadline release 10.3.1.3. With the MongoDB and DocumentDB version upgrades to 5.0 all versions (3.6, 4.0, 5.0) are supported with Deadline. We need to relax constraints on engine version 3.6 that exist in RFDK 

**Solution**
Upgraded engine version support to all versions prefix with 3.6, 4.0 or 5.0 as per the compatibility now. Updated relevant documentation in the code as well. Removed a Unit Test case testing the engine version constraint to 3.6. Since there are no other versions of DocumentDB available we need not add this test case with a different parameter.

**Testing**
1. yarn build:

```
aws-rfdk: =============================== Coverage summary ===============================
aws-rfdk: Statements   : 97.93% ( 3316/3386 )
aws-rfdk: Branches     : 95.08% ( 1045/1099 )
aws-rfdk: Functions    : 96.98% ( 514/530 )
aws-rfdk: Lines        : 98.09% ( 3196/3258 )
aws-rfdk: ================================================================================
aws-rfdk: Test Suites: 62 passed, 62 total
aws-rfdk: Tests:       1277 passed, 1277 total
aws-rfdk: Snapshots:   0 total
aws-rfdk: Time:        240.366 s
```

2. Deployed the All-In-Infrastructure-SEP stack in my AWS account with default engine version set to 3.6, confirmed it spun up and tore down successfully.

3. Manually updated the default version of DocDB to 5.0 and deployed the All-In-Infrastructure-SEP stack with the updated engine version to validate it works fine.

4. Ran the integration tests using my AWS account as well. Validated that they run fine.

```
Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        35.8 s, estimated 44 s
Ran all test suites matching /deadline_01_repository.test/i.
Test results written to: .e2etemp/deadline_01_repository/test-report.json
```