### PR TITLE
chore: update build command to use yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,9 @@ The developers actively use Linux for development, but macOS and the Windows Sub
 
     ```bash
     # From the root directory of this repository
-    ./build.sh
+    yarn build
 
-    # Once you've run ./build.sh from the root directory at least once, then
+    # Once you've run "yarn build" from the root directory at least once, then
     # you can do subsequent build & test iterations from the RFDK package directory to save time.
     cd packages/aws-rfdk
     yarn build+test
@@ -155,7 +155,7 @@ yarn clean
 ./clean.sh
 
 # Rebuild
-./build.sh
+yarn build
 ```
 
 If that does not work, then you might try the following nuclear option. **WARNING** -- this will

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
@@ -22,7 +22,7 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```bash
     # Navigate to the root directory of the RFDK repository
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Enter the Docker container to run the pack scripts
     ./scripts/rfdk_build_environment.sh
     ./pack.sh

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
@@ -144,7 +144,7 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```bash
     # Navigate to the root directory of the RFDK repository (assumes you started in the example's directory)
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Navigate back to the example directory
     popd
     # Run the example's build

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/python/README.md
@@ -24,7 +24,7 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```bash
     # Navigate to the root directory of the RFDK repository
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Enter the Docker container to run thepack scripts
     ./scripts/rfdk_build_environment.sh
     ./pack.sh

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/README.md
@@ -47,7 +47,7 @@ These instructions assume that your working directory is `examples/deadline/All-
     ```bash
     # Navigate to the root directory of the RFDK repository (assumes you started in the example's directory)
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Navigate back to the example directory
     popd
     # Run the example's build

--- a/examples/deadline/EC2-Image-Builder/python/README.md
+++ b/examples/deadline/EC2-Image-Builder/python/README.md
@@ -24,7 +24,7 @@ These instructions assume that your working directory is `examples/deadline/EC2-
     ```bash
     # Navigate to the root directory of the RFDK repository
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Enter the Docker container to run the pack scripts
     ./scripts/rfdk_build_environment.sh
     ./pack.sh

--- a/examples/deadline/EC2-Image-Builder/ts/README.md
+++ b/examples/deadline/EC2-Image-Builder/ts/README.md
@@ -33,7 +33,7 @@ These instructions assume that your working directory is `examples/deadline/EC2-
     ```bash
     # Navigate to the root directory of the RFDK repository (assumes you started in the example's directory)
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Navigate back to the example directory
     popd
     # Run the example's build

--- a/examples/deadline/Local-Zone/python/README.md
+++ b/examples/deadline/Local-Zone/python/README.md
@@ -24,7 +24,7 @@ These instructions assume that your working directory is `examples/deadline/Loca
     ```bash
     # Navigate to the root directory of the RFDK repository
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Enter the Docker container to run the build and pack scripts
     ./scripts/rfdk_build_environment.sh
     ./pack.sh

--- a/examples/deadline/Local-Zone/ts/README.md
+++ b/examples/deadline/Local-Zone/ts/README.md
@@ -57,7 +57,7 @@ These instructions assume that your working directory is `examples/deadline/Loca
     ```bash
     # Navigate to the root directory of the RFDK repository (assumes you started in the example's directory)
     pushd ../../../..
-    ./build.sh
+    yarn build
     # Navigate back to the example directory
     popd
     # Run the example's build

--- a/integ/README.md
+++ b/integ/README.md
@@ -2,7 +2,7 @@
 
 To run all test suites:
 
-1. Build and install dependencies by running build.sh from the top-level RFDK directory
+1. Build and install dependencies by running `yarn build` from the top-level RFDK directory
 1. Configure AWS credentials. There are a few options for this:
     *   Configure credentials [using environment variables](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html)
     *   Run the integration tests on an [EC2 Instance with an IAM role](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-iam.html)

--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -53,7 +53,7 @@ PULL_AL_FROM_ECR_ARGS=(
 /bin/bash ${SCRIPT_DIR}/pull_amazonlinux_from_ecr.sh "${PULL_AL_FROM_ECR_ARGS[@]}"
 
 # Run integ tests
-/bin/bash ${ROOT_DIR}/build.sh
+(cd "${ROOT_DIR}" && yarn run build)
 pushd $TESTS_DIR
 yarn run e2e-automated
 popd


### PR DESCRIPTION
## Problem

Since upgrading to NodeJS 18 to build the RFDK, there are issues building using the `build.sh` script directly. While this has been updated in some places, there are still some references remaining

## Solution

Replace direct `build.sh` invocations with `yarn build`.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
