### PR TITLE
test: add unique discriminator to testing-tier props

### DIFF
--- a/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
+++ b/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
@@ -49,7 +49,7 @@ const structs: Array<StorageStruct> = [
   }),
 ];
 
-new RepositoryTestingTier(app, 'RFDKInteg-DL-TestingTier' + integStackTag, { env, integStackTag, structs });
+new RepositoryTestingTier(app, 'RFDKInteg-DL-TestingTier' + integStackTag, { env, integStackTag, structs, discriminator: 'DL' });
 
 // Adds IAM Policy to Instance and ASG Roles
 Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
+++ b/integ/components/deadline/deadline_02_renderQueue/bin/deadline_02_renderQueue.ts
@@ -60,7 +60,7 @@ const structs: Array<RenderStruct> = [
   }),
 ];
 
-new RenderQueueTestingTier(app, 'RFDKInteg-RQ-TestingTier' + integStackTag, { env, integStackTag, structs });
+new RenderQueueTestingTier(app, 'RFDKInteg-RQ-TestingTier' + integStackTag, { env, integStackTag, structs, discriminator: 'RQ' });
 
 // Adds IAM Policy to Instance and ASG Roles
 Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_03_workerFleetHttp/bin/deadline_03_workerFleetHttp.ts
+++ b/integ/components/deadline/deadline_03_workerFleetHttp/bin/deadline_03_workerFleetHttp.ts
@@ -64,7 +64,7 @@ oss.forEach( (os, index) => {
   }));
 });
 
-new WorkerFleetTestingTier(app, 'RFDKInteg-WF-TestingTier' + integStackTag, {env, integStackTag, structs});
+new WorkerFleetTestingTier(app, 'RFDKInteg-WF-TestingTier' + integStackTag, {env, integStackTag, structs, discriminator: 'WF'});
 
 // Adds IAM Policy to Instance and ASG Roles
 Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_04_workerFleetHttps/bin/deadline_04_workerFleetHttps.ts
+++ b/integ/components/deadline/deadline_04_workerFleetHttps/bin/deadline_04_workerFleetHttps.ts
@@ -64,7 +64,7 @@ oss.forEach( (os, index) => {
   }));
 });
 
-new WorkerFleetTestingTier(app, 'RFDKInteg-WFS-TestingTier' + integStackTag, {env, integStackTag, structs});
+new WorkerFleetTestingTier(app, 'RFDKInteg-WFS-TestingTier' + integStackTag, {env, integStackTag, structs, discriminator: 'WFS'});
 
 // Adds IAM Policy to Instance and ASG Roles
 Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_05_secretsManagement/bin/deadline_05_secretsManagement.ts
+++ b/integ/components/deadline/deadline_05_secretsManagement/bin/deadline_05_secretsManagement.ts
@@ -78,6 +78,7 @@ async function main() {
     integStackTag,
     renderStruct,
     storageStruct,
+    discriminator: 'SM',
   });
 
   // Adds IAM Policy to Instance and ASG Roles

--- a/integ/lib/testing-tier.ts
+++ b/integ/lib/testing-tier.ts
@@ -39,6 +39,10 @@ export interface TestingTierProps extends StackProps {
    * The unique suffix given to all stacks in the testing app
    */
   readonly integStackTag: string;
+  /**
+   * The unique discriminator for constructs created in the testing app
+   */
+  readonly discriminator: string;
 }
 
 /**
@@ -75,7 +79,7 @@ export abstract class TestingTier extends Stack {
 
     // Create an instance that can be used for testing; SSM commands are communicated to the
     // host instance to run test scripts installed during setup of the instance
-    this.testInstance = new BastionHostLinux(this, 'Bastion', {
+    this.testInstance = new BastionHostLinux(this, 'Bastion' + props.discriminator + props.integStackTag, {
       vpc: this.vpc,
       subnetSelection: { subnetGroupName: NetworkTier.subnetConfig.testRunner.name },
       instanceType: new InstanceType('t3.small'),


### PR DESCRIPTION
## Problem
Integration tests were failing to deploy the Bastion instance in the testing tier, since the name is not unique. Changes in https://github.com/aws/aws-rfdk/pull/1165 enabled a feature flag that append a unique hash to the construct name, but base the hash on the CFN node a step down from the full stack name, resulting in the same hash for every test stack.

## Solution
Append a 'discriminator' tag to the Bastion name, which helps keep the name unique between instances of the testing-tier. I also appended the "integStackTag" so multiple deployments won't cause resource conflicts.

## Testing
Built locally, confirming no linting errors.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
