### PR TITLE
test: add test_marker checks to integ scripts

### DIFF
--- a/integ/scripts/bash/cleanup.sh
+++ b/integ/scripts/bash/cleanup.sh
@@ -12,13 +12,7 @@ shopt -s globstar
 
 INTEG_ROOT="$(pwd)"
 
-for COMPONENT in **/cdk.json; do
-    # In case the yarn install was done inside this integ package, there are some example cdk.json files in the aws-cdk
-    # package we want to avoid.
-    if [[ $COMPONENT == *"node_modules"* ]]; then
-        continue
-    fi
-
+for COMPONENT in **/test_marker; do
     COMPONENT_ROOT="$(dirname "$COMPONENT")"
     rm -f "${COMPONENT_ROOT}/cdk.context.json"
     rm -rf "${COMPONENT_ROOT}/cdk.out"

--- a/integ/scripts/bash/deploy-all.sh
+++ b/integ/scripts/bash/deploy-all.sh
@@ -39,7 +39,7 @@ npx cdk deploy "*" --require-approval=never
 
 cd "$INTEG_ROOT"
 
-for COMPONENT in **/cdk.json; do
+for COMPONENT in **/test_marker; do
     COMPONENT_ROOT="$(dirname "$COMPONENT")"
     COMPONENT_NAME=$(basename "$COMPONENT_ROOT")
     # Use a pattern match to exclude the infrastructure app from the results

--- a/integ/scripts/bash/report-test-results.sh
+++ b/integ/scripts/bash/report-test-results.sh
@@ -146,7 +146,7 @@ report_results () {
 }
 
 # Report test results for each test component
-for COMPONENT in **/cdk.json; do
+for COMPONENT in **/test_marker; do
     COMPONENT_ROOT="$(dirname "$COMPONENT")"
     COMPONENT_NAME=$(basename "$COMPONENT_ROOT")
     # Use a pattern match to exclude the infrastructure app from the results

--- a/integ/scripts/bash/tear-down.sh
+++ b/integ/scripts/bash/tear-down.sh
@@ -34,12 +34,7 @@ source $BASH_SCRIPTS/set-test-variables.sh
 # the others. Disable the exit on error option
 set +e
 
-for COMPONENT in **/cdk.json; do
-    # In case the yarn install was done inside this integ package, there are some example cdk.json files in the aws-cdk
-    # package we want to avoid.
-    if [[ $COMPONENT == *"node_modules"* ]]; then
-        continue
-    fi
+for COMPONENT in **/test_marker; do
     COMPONENT_ROOT="$(dirname "$COMPONENT")"
     COMPONENT_NAME=$(basename "$COMPONENT_ROOT")
     # Use a pattern match to exclude the infrastructure app from the results


### PR DESCRIPTION
## Summary
I added a 'test_marker' sentinel file to our integration component directories, but missed updating a few other scripts that expected the old `cdk.json` file, causing unexpected behviour with tests. I've updated all of the scripts in the `integ` directory.

## Testing
Ran the cleanup script, confirming it cleaned up each component directory with a `test_marker` file in it.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
