### PR TITLE
test: add special case for repo installer integ test for Deadline 10.3.1

### DIFF
--- a/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
+++ b/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
@@ -179,9 +179,12 @@ describe.each(testCases)('Deadline Repository tests (%s)', (_, id) => {
       **********************************************************************************************************/
       let expectedVersion: string;
       switch (deadlineVersion) {
-        // Special case for Deadline 10.1.18.5 since it appears as 10.1.18.4 due to known issues in Deadline's build pipeline
+        // Special cases for Deadline version that appear different due to known issues in Deadline's build pipeline
         case '10.1.18.5':
           expectedVersion = '10.1.18.4';
+          break;
+        case '10.3.1.4':
+          expectedVersion = '10.3.1.3';
           break;
 
         default:


### PR DESCRIPTION
## Summary
Integ tests are failing for the Deadline Repository version check test, as a recent patch to Deadline to 10.3.1.4 has a bug in the pipeline that reports the installer as 10.3.1.3. I added another special case to get the test passing.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
