### PR TITLE
ci: update region denylist for lambda layers

### DIFF
--- a/lambda-layers/bin/publish.ts
+++ b/lambda-layers/bin/publish.ts
@@ -40,6 +40,7 @@ async function publishLayerToRegion(
   })
   if (await isDescriptionUpdated(descriptionText, lambda, layerName)) {
     try {
+      console.log(`Publishing to: ${region}`);
       const publishResult = await lambda.publishLayerVersion({
         LayerName: layerName,
         Content: {
@@ -98,6 +99,9 @@ getRegions().then(regions => {
       licenseText,
       region,
       runtimes,
-    );
+    ).catch(e => {
+      console.error(`Failed publishing in ${region}, which may be due to the REGION_DENY_LIST needing updating. Error: ${e}`);
+      throw e;
+    });
   }
 });

--- a/lambda-layers/lib/get-regions.ts
+++ b/lambda-layers/lib/get-regions.ts
@@ -6,12 +6,20 @@
 import { SSM } from 'aws-sdk';
 
 // These regions need to be enabled for the AWS account being used for publishing, so we skip them
+// See https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html
 const REGION_DENY_LIST = [
   'af-south-1',
   'ap-east-1',
+  'ap-south-2',
   'ap-southeast-3',
+  'ap-southeast-4',
+  'ca-west-1',
   'eu-south-1',
+  'eu-south-2',
+  'eu-central-2',
+  'il-central-1',
   'me-south-1',
+  'me-central-1',
 ];
 
 function isValidRegion(region: string): boolean {


### PR DESCRIPTION
## Problem
Lambda layers were failing to publish with:

```
UnrecognizedClientException: The security token included in the request is invalid
```

It turns out this error was caused by lambda layers trying to be added to new AWS regions, which are deactivated by default. See a list of new regions here: https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html

## Solution
Updated the deny list of regions to attempt publishing lambda layers to, as new regions have been added since the last RFDK release. Added a log statement so it's clear which region has failed.

## Testing
- recreated the error attempting to publish to my account
- successfully published and wrote lambda layers to my account

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
