### PR TITLE
feat(deadline): Allow passing Context to SEP config

### DIFF
--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -568,6 +568,7 @@ export class ConfigureSpotEventPlugin extends Construct {
       ValidUntil: fleet.validUntil?.date.toISOString(),
       // Need to convert from IResolvable to bypass TypeScript
       TagSpecifications: (spotFleetRequestTagsToken as unknown) as SpotFleetTagSpecification[],
+      Context: fleet.context,
     };
 
     const spotFleetRequestConfigurations = fleet.deadlineGroups.map(group => {

--- a/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
@@ -23,7 +23,6 @@ import {
   ISecurityGroup,
   IVpc,
   LaunchTemplate,
-  LaunchTemplateSpecialVersions,
   OperatingSystemType,
   Port,
   SecurityGroup,
@@ -206,6 +205,13 @@ export interface SpotEventPluginFleetProps {
    * @default - the Spot Fleet request remains until you cancel it.
    */
   readonly validUntil?: Expiration;
+
+  /**
+   * Reserved
+   *
+   * @default - No context string
+   */
+  readonly context?: string;
 
   /**
    * Properties for setting up the Deadline Worker's LogGroup
@@ -430,6 +436,13 @@ export class SpotEventPluginFleet extends Construct implements ISpotEventPluginF
   public readonly validUntil?: Expiration;
 
   /**
+   * Reserved
+   *
+   * @default - No context string
+   */
+  public readonly context?: string;
+
+  /**
    * The Block devices that will be attached to your workers.
    *
    * @default - The default devices of the provided ami will be used.
@@ -488,6 +501,7 @@ export class SpotEventPluginFleet extends Construct implements ISpotEventPluginF
     this.maxCapacity = props.maxCapacity;
     this.validUntil = props.validUntil;
     this.keyName = props.keyName;
+    this.context = props.context;
 
     const imageConfig = props.workerMachineImage.getImage(this);
     this.osType = imageConfig.osType;
@@ -563,7 +577,7 @@ export class SpotEventPluginFleet extends Construct implements ISpotEventPluginF
       this.subnets.subnetIds.forEach(subnetId => {
         launchTemplateConfigs.push({
           LaunchTemplateSpecification: {
-            Version: LaunchTemplateSpecialVersions.LATEST_VERSION,
+            Version: this.launchTemplate.versionNumber,
             LaunchTemplateId: this.launchTemplate.launchTemplateId,
             LaunchTemplateName: this.launchTemplate.launchTemplateName,
           },

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/conversion.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/conversion.ts
@@ -34,6 +34,7 @@ export function convertSpotFleetRequestConfiguration(spotFleetRequestConfigs: Sp
       Type: validateString(sfrConfigs.Type, `${group_name}.Type`),
       ValidUntil: validateStringOptional(sfrConfigs.ValidUntil, `${group_name}.ValidUntil`),
       TagSpecifications: convertTagSpecifications(sfrConfigs.TagSpecifications, `${group_name}.TagSpecifications`),
+      Context: validateStringOptional(sfrConfigs.Context, `${group_name}.Context`),
     };
     convertedSpotFleetRequestConfigs[group_name] = convertedSpotFleetRequestProps;
   }

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/types.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/types.ts
@@ -191,6 +191,13 @@ export interface SpotFleetRequestProps {
    * @default - the Spot Fleet request remains until you cancel it.
    */
   readonly ValidUntil?: string;
+
+  /**
+   * Reserved
+   *
+   * @default - No context string
+   */
+  readonly Context?: string;
 }
 
 /**


### PR DESCRIPTION
This change allows the reserved spot fleet `context` field to be passed to the spot event plugin configuration custom resource. One caveat that was introduced is the launch template must specify an explicit version instead of `$Latest` because of the launch template parameter constraint `Context cannot be used with Launch Template version '$Latest' or '$Default'.`

Added a test for this new parameter and updated the test for the launch template version number. The documentation for these fields is intentionally vague as the CFN construct for spot fleets does not document this field https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-context

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
