### PR TITLE
fix(deps): revert to typescript-eslint v6.21.0

### DIFF
--- a/integ/package.json
+++ b/integ/package.json
@@ -55,8 +55,8 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "18.11.19",
-    "@typescript-eslint/eslint-plugin": "^7.3.1",
-    "@typescript-eslint/parser": "^7.3.1",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
     "aws-cdk": "2.133.0",
     "eslint": "^8.57.0",
     "eslint-import-resolver-node": "^0.3.9",


### PR DESCRIPTION
## Problem

Attempting to build the RFDK with an older version of Node.js fails with an error:

```
error @typescript-eslint/eslint-plugin@7.3.1: The engine "node" is incompatible with this module. Expected version "^18.18.0 \|\| >=20.0.0". Got "18.17.1"
```

## Solution

Revert the `@typescript-eslint` package to version 6.21.0.  This is newer than the [version 6.14.0 that we used in our most recent release](https://github.com/aws/aws-rfdk/blob/8e8b169e9efdd18675de08b677c00a0714739cf1/integ/package.json#L58), but lower than [version 7.0 which dropped support for older versions of Node.js](https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/).

## Testing

Confirmed that `yarn run build` works with Node.js 18.17.1.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
