### PR TITLE
feat(deadline): upgraded default Worker instance type to t3.large

### DIFF
--- a/integ/lib/sep-worker-struct.ts
+++ b/integ/lib/sep-worker-struct.ts
@@ -54,7 +54,7 @@ export class SepWorkerStruct extends Construct {
         maxCapacity: 1,
         workerMachineImage: MachineImage.genericLinux({ [Stack.of(this).region]: linuxAmi }),
         deadlineGroups: ['sep_group'],
-        instanceTypes: [new InstanceType('t2.micro')],
+        instanceTypes: [new InstanceType('t3.micro')],
         logGroupProps: {
           logGroupPrefix: `/${Stack.of(this).stackName}-${id}/`,
           retention: RetentionDays.TWO_MONTHS,

--- a/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/worker-fleet.ts
@@ -136,9 +136,9 @@ export interface WorkerInstanceFleetProps extends WorkerSettings {
   readonly workerMachineImage: IMachineImage;
 
   /**
-   * Type of instance to launch for executing repository installer.
+   * Type of instance to launch for the Workers.
    *
-   * @default - a T2-Large type will be used.
+   * @default - a T3-Large type will be used.
    */
   readonly instanceType?: InstanceType;
 
@@ -450,7 +450,7 @@ export class WorkerInstanceFleet extends WorkerInstanceFleetBase {
     // Launching the fleet with deadline workers.
     this.fleet = new AutoScalingGroup(this, 'Default', {
       vpc: props.vpc,
-      instanceType: (props.instanceType ? props.instanceType : InstanceType.of(InstanceClass.T2, InstanceSize.LARGE)),
+      instanceType: (props.instanceType ? props.instanceType : InstanceType.of(InstanceClass.T3, InstanceSize.LARGE)),
       machineImage: props.workerMachineImage,
       keyName: props.keyName,
       vpcSubnets,

--- a/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-fleet.test.ts
@@ -117,7 +117,7 @@ test('default worker fleet is created correctly', () => {
   // THEN
   Template.fromStack(wfstack).resourceCountIs('AWS::AutoScaling::AutoScalingGroup', 1);
   Template.fromStack(wfstack).hasResourceProperties('AWS::AutoScaling::LaunchConfiguration', {
-    InstanceType: 't2.large',
+    InstanceType: 't3.large',
     IamInstanceProfile: {
       Ref: Match.stringLikeRegexp('^workerFleetInstanceProfile.*'),
     },
@@ -374,7 +374,7 @@ test('default worker fleet is created correctly with linux image', () => {
   // 3 = repository + renderqueue + worker fleet
   Template.fromStack(stack).resourceCountIs('AWS::AutoScaling::AutoScalingGroup', 3);
   Template.fromStack(stack).hasResourceProperties('AWS::AutoScaling::LaunchConfiguration', {
-    InstanceType: 't2.large',
+    InstanceType: 't3.large',
     IamInstanceProfile: {
       Ref: Match.stringLikeRegexp('^workerFleetInstanceProfile.*'),
     },


### PR DESCRIPTION
## Problem

We want to use newer instance types by default.

## Solution

The only older instance types I found are some T2 instances.  I upgraded them to T3.

## Testing

Ran the `deadline_05_secretsManagement` integ test, and it still succeeds.  This test both launches workers using the default instance type in `WorkerInstanceFleet` and uses the `SepWorkerStruct`.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
