### PR TITLE
fix(deadline): revert to DocumentDB 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 node_modules/
 .tools/
 .BUILD_COMPLETED
+lerna-debug.log
 package-lock.json
 yarn-error.log
 

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
@@ -325,7 +325,7 @@ export class StorageTierDocDB extends StorageTier {
       masterUser: {
         username: 'adminuser',
       },
-      engineVersion: '5.0.0',
+      engineVersion: '3.6.0',
       backup: {
         // We recommend setting the retention of your backups to 15 days
         // for security reasons. The default retention is just one day.

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -678,7 +678,7 @@ export class Repository extends Construct implements IRepository {
        */
       const parameterGroup = databaseAuditLogging ? new ClusterParameterGroup(this, 'ParameterGroup', {
         description: 'DocDB cluster parameter group with enabled audit logs',
-        family: 'docdb5.0',
+        family: 'docdb3.6',
         parameters: {
           audit_logs: 'enabled',
         },
@@ -687,7 +687,7 @@ export class Repository extends Construct implements IRepository {
       const instances = props.documentDbInstanceCount ?? Repository.DEFAULT_NUM_DOCDB_INSTANCES;
       const dbCluster = new DatabaseCluster(this, 'DocumentDatabase', {
         masterUser: {username: 'DocDBUser'},
-        engineVersion: '5.0.0',
+        engineVersion: '3.6.0',
         instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
         vpc: props.vpc,
         vpcSubnets: props.vpcSubnets ?? { subnetType: SubnetType.PRIVATE_WITH_EGRESS, onePerAz: true },


### PR DESCRIPTION
## Problem

We were planning to update to DocumentDB 5.0 in this release, but we don't want to include a database upgrade with the Node.js 18 update.

## Solution

Revert the DocumentDB version to 3.6.

## Testing

Ran the `deadline_02_renderQueue` integration test suite.  Confirmed that it deployed DocumentDB with engine version 3.6, and the tests succeeded.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
