### PR TITLE
fix auto-approve conditional vulnerability

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: hmarr/auto-approve-action@v3.2.1
-      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      if: github.event.base.repo.id == github.event.head.repo.id && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
It's not secure to automerge dependabot changes without additional metadata. To fix this, we add the `github.event.base.repo.id == github.event.head.repo.id` conditional as a quick fix to make sure that this restricts the workflow to only execute if the source and target of the PR are the same repo, blocking it from running on any fork-origin PRs.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
