### PR TITLE
feat!: Upgrades DocumentDB version to 5.0.0

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
@@ -325,7 +325,7 @@ export class StorageTierDocDB extends StorageTier {
       masterUser: {
         username: 'adminuser',
       },
-      engineVersion: '3.6.0',
+      engineVersion: '5.0.0',
       backup: {
         // We recommend setting the retention of your backups to 15 days
         // for security reasons. The default retention is just one day.

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -678,7 +678,7 @@ export class Repository extends Construct implements IRepository {
        */
       const parameterGroup = databaseAuditLogging ? new ClusterParameterGroup(this, 'ParameterGroup', {
         description: 'DocDB cluster parameter group with enabled audit logs',
-        family: 'docdb3.6',
+        family: 'docdb5.0',
         parameters: {
           audit_logs: 'enabled',
         },
@@ -687,7 +687,7 @@ export class Repository extends Construct implements IRepository {
       const instances = props.documentDbInstanceCount ?? Repository.DEFAULT_NUM_DOCDB_INSTANCES;
       const dbCluster = new DatabaseCluster(this, 'DocumentDatabase', {
         masterUser: {username: 'DocDBUser'},
-        engineVersion: '3.6.0',
+        engineVersion: '5.0.0',
         instanceType: InstanceType.of(InstanceClass.R5, InstanceSize.LARGE),
         vpc: props.vpc,
         vpcSubnets: props.vpcSubnets ?? { subnetType: SubnetType.PRIVATE_WITH_EGRESS, onePerAz: true },


### PR DESCRIPTION
## Summary
This change bumps our default DocumentDB version to 5.0.0. 

Note that users with existing DocumentDB clusters with previous versions will need to manually upgrade by following the documentation: https://docs.aws.amazon.com/documentdb/latest/developerguide/docdb-mvu.html

## Testing
- Deployed the All-In-AWS-Infrastructure-Basic typescript example to my account, using the latest release version, which created a DocDB 3.6 cluster
- Submitted a job, and confirmed it wrote to the DB successfully
- Followed the documentation to migrate my DocumentDB cluster to 5.0.0
- Confirmed I could submit and retrieve jobs to/from my DB (and my existing jobs showed up)
- Using these changes, redeployed to my existing RFDK stacks, confirmed it deployed correctly
- Confirmed I could submit and retrieve jobs to/from my DB (and my existing jobs showed up)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
