### PR TITLE
fix: Add feature flag to unblock new deployments

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/cdk.json
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "python -m package.app",
   "context": {
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/cdk.json
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node bin/app.ts",
   "context": {
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/python/cdk.json
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/python/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "python -m package.app",
   "context": {
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/cdk.json
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node bin/app.ts",
   "context": {
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/examples/deadline/EC2-Image-Builder/python/cdk.json
+++ b/examples/deadline/EC2-Image-Builder/python/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "python -m package.app",
   "context": {
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/examples/deadline/EC2-Image-Builder/ts/cdk.json
+++ b/examples/deadline/EC2-Image-Builder/ts/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node bin/app.ts",
   "context": {
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/examples/deadline/Local-Zone/ts/cdk.json
+++ b/examples/deadline/Local-Zone/ts/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node bin/app.ts",
   "context": {
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/integ/cdk.json
+++ b/integ/cdk.json
@@ -1,5 +1,6 @@
 {
   "context": {
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/integ/components/_infrastructure/cdk.json
+++ b/integ/components/_infrastructure/cdk.json
@@ -1,6 +1,7 @@
 {
   "app": "npx ts-node bin/_infrastructure.ts",
   "context": {
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/integ/components/deadline/deadline_01_repository/cdk.json
+++ b/integ/components/deadline/deadline_01_repository/cdk.json
@@ -1,6 +1,7 @@
 {
   "app": "npx ts-node bin/deadline_01_repository.ts",
   "context": {
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/integ/components/deadline/deadline_02_renderQueue/cdk.json
+++ b/integ/components/deadline/deadline_02_renderQueue/cdk.json
@@ -1,6 +1,7 @@
 {
   "app": "npx ts-node bin/deadline_02_renderQueue.ts",
   "context": {
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/integ/components/deadline/deadline_03_workerFleetHttp/cdk.json
+++ b/integ/components/deadline/deadline_03_workerFleetHttp/cdk.json
@@ -1,6 +1,7 @@
 {
   "app": "npx ts-node bin/deadline_03_workerFleetHttp.ts",
   "context": {
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/integ/components/deadline/deadline_04_workerFleetHttps/cdk.json
+++ b/integ/components/deadline/deadline_04_workerFleetHttps/cdk.json
@@ -1,6 +1,7 @@
 {
   "app": "npx ts-node bin/deadline_04_workerFleetHttps.ts",
   "context": {
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }

--- a/integ/components/deadline/deadline_05_secretsManagement/cdk.json
+++ b/integ/components/deadline/deadline_05_secretsManagement/cdk.json
@@ -1,6 +1,7 @@
 {
   "app": "npx ts-node bin/deadline_05_secretsManagement.ts",
   "context": {
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true
   }
 }


### PR DESCRIPTION
## Problem
Deployments of RFDK to brand new accounts would fail with:

```
The Launch Configuration creation operation is not available in your account. Use launch templates to create configuration templates for your Auto Scaling groups.
```

This is because Launch Configurations were deprecated, and recently denied for new accounts in https://github.com/aws/aws-cdk/pull/25910

## Solution
Added the feature flag that converts launch configurations to launch templates, as described in the documentation: https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/cx-api/FEATURE_FLAGS.md#aws-cdkaws-autoscalinggeneratelaunchtemplateinsteadoflaunchconfig

## Testing
- tried deploying the All-In-AWS-Infrastructure-Basic example to a new AWS account, and confirmed I hit this error
- with these changes, was able to deployments did not hit the launch configuration error

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
