### PR TITLE
chore: Update github actions label to ubuntu 24

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   auto-approve:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: hmarr/auto-approve-action@v4.0.0
       if: github.event.base.repo.id == github.event.head.repo.id && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: jsii/superchain:1-buster-slim-node14
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   modify-labels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       -
         name: Checkout


### PR DESCRIPTION
## Summary
Github announced breaking changes to actions https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/

From what I can tell, the only change of interest is `ubuntu-latest` label being migrated to `ubuntu 24`. This draft PR will test that our actions work with the new label. For other changes in the announcement, we don't appear to be on github actions version 3, which is being removed so I think we're safe there.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
