### PR TITLE
feat(core): update to work with Deadline 10.4.0

### DIFF
--- a/integ/components/deadline/common/scripts/bastion/utils/configure-deadline.sh
+++ b/integ/components/deadline/common/scripts/bastion/utils/configure-deadline.sh
@@ -30,7 +30,13 @@ else
   # Non-TLS connections can connect to the repository directly
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxyUseSSL False
   sudo $DEADLINE/deadlinecommand SetIniFileSetting ProxySSLCA ""
-  sudo $DEADLINE/deadlinecommand ChangeRepository Remote $ENDPOINT >/dev/null
+  ALL_USERS_OPTION=
+  if $DEADLINE/deadlinecommand --help | grep "^ChangeRepository " | grep -q "<Save For All Users>"; then
+    # Deadline 10.4 added an option to "Save For All Users".
+    # This is the default behavior in prior versions.
+    ALL_USERS_OPTION="True"
+  fi
+  sudo $DEADLINE/deadlinecommand ChangeRepository Remote $ENDPOINT '' '' $ALL_USERS_OPTION >/dev/null
 fi
 
 exit 0

--- a/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
+++ b/integ/components/deadline/deadline_01_repository/bin/deadline_01_repository.ts
@@ -5,7 +5,11 @@
 
 import { App, Stack, Aspects } from 'aws-cdk-lib';
 import { AutoScalingGroupRequireImdsv2Aspect } from 'aws-cdk-lib/aws-autoscaling';
-import { InstanceRequireImdsv2Aspect, LaunchTemplateRequireImdsv2Aspect } from 'aws-cdk-lib/aws-ec2';
+import {
+  InstanceRequireImdsv2Aspect,
+  LaunchTemplateRequireImdsv2Aspect,
+  MachineImage,
+} from 'aws-cdk-lib/aws-ec2';
 import {
   Stage,
   ThinkboxDockerRecipes,
@@ -49,7 +53,14 @@ const structs: Array<StorageStruct> = [
   }),
 ];
 
-new RepositoryTestingTier(app, 'RFDKInteg-DL-TestingTier' + integStackTag, { env, integStackTag, structs });
+new RepositoryTestingTier(app, 'RFDKInteg-DL-TestingTier' + integStackTag, {
+  env,
+  integStackTag,
+  structs,
+  // Currently we test using MongoDB 3.6, which doesn't run on the
+  // Amazon Linux 2023 image that we use to test Deadline 10.4.0.
+  bastionMachineImageOverride: MachineImage.latestAmazonLinux2(),
+});
 
 // Adds IAM Policy to Instance and ASG Roles
 Aspects.of(app).add(new SSMInstancePolicyAspect());

--- a/integ/components/deadline/deadline_03_workerFleetHttp/test/deadline_03_workerFleetHttp.test.ts
+++ b/integ/components/deadline/deadline_03_workerFleetHttp/test/deadline_03_workerFleetHttp.test.ts
@@ -15,8 +15,8 @@ const bastionRegex = /bastionId/;
 const rqRegex = /renderQueueEndpointWF(\d)/;
 
 const testCases: Array<Array<any>> = [
-  [ 'Linux Worker HTTP mode', 1 ],
-  [ 'Windows Worker HTTP mode', 2 ],
+  [ 'Linux Worker HTTP mode', 1, 'Linux' ],
+  [ 'Windows Worker HTTP mode', 2, 'Windows' ],
 ];
 let bastionId: any;
 let renderQueueEndpoints: Array<string> = [];
@@ -45,7 +45,7 @@ beforeAll( async () => {
   });
 });
 
-describe.each(testCases)('Deadline WorkerFleet tests (%s)', (_, id) => {
+describe.each(testCases)('Deadline WorkerFleet tests (%s)', (_, id, workerOS) => {
   describe('Worker node tests', () => {
 
     // Before testing the render queue, send a command to configure the Deadline client to use that endpoint
@@ -139,7 +139,7 @@ describe.each(testCases)('Deadline WorkerFleet tests (%s)', (_, id) => {
             'sudo -i',
             'su - ec2-user >/dev/null',
             'cd ~ec2-user',
-            `./testScripts/WF-submit-jobs-to-sets.sh "${name}" "${arg}"`,
+            `./testScripts/WF-submit-jobs-to-sets.sh "${workerOS}" "${name}" "${arg}"`,
           ],
         },
       };

--- a/integ/components/deadline/deadline_04_workerFleetHttps/test/deadline_04_workerFleetHttps.test.ts
+++ b/integ/components/deadline/deadline_04_workerFleetHttps/test/deadline_04_workerFleetHttps.test.ts
@@ -19,8 +19,8 @@ const rqRegex = /renderQueueEndpointWFS(\d)/;
 const certRegex = /CertSecretARNWFS(\d)/;
 
 const testCases: Array<Array<any>> = [
-  [ 'Linux Worker HTTPS (TLS) mode', 1 ],
-  [ 'Windows Worker HTTPS (TLS) mode', 2 ],
+  [ 'Linux Worker HTTPS (TLS) mode', 1, 'Linux' ],
+  [ 'Windows Worker HTTPS (TLS) mode', 2, 'Windows' ],
 ];
 let bastionId: any;
 let renderQueueEndpoints: Array<string> = [];
@@ -54,7 +54,7 @@ beforeAll( async () => {
   });
 });
 
-describe.each(testCases)('Deadline WorkerFleetHttps tests (%s)', (_, id) => {
+describe.each(testCases)('Deadline WorkerFleetHttps tests (%s)', (_, id, workerOS) => {
 
   beforeAll( async () => {
     if(secretARNs[id]) {
@@ -191,7 +191,7 @@ describe.each(testCases)('Deadline WorkerFleetHttps tests (%s)', (_, id) => {
             'sudo -i',
             'su - ec2-user >/dev/null',
             'cd ~ec2-user',
-            `./testScripts/WFS-submit-jobs-to-sets.sh "${name}" "${arg}"`,
+            `./testScripts/WFS-submit-jobs-to-sets.sh "${workerOS}" "${name}" "${arg}"`,
           ],
         },
       };

--- a/integ/test-config.sh
+++ b/integ/test-config.sh
@@ -54,6 +54,7 @@ export LINUX_DEADLINE_AMI_ID
 export WINDOWS_DEADLINE_AMI_ID
 
 # Configure test suites to include in end-to-end test
+#   - To skip a test, set it to true
 export SKIP_deadline_01_repository_TEST
 export SKIP_deadline_02_renderQueue_TEST
 export SKIP_deadline_03_workerFleetHttp_TEST

--- a/packages/aws-rfdk/lib/core/lib/deployment-instance.ts
+++ b/packages/aws-rfdk/lib/core/lib/deployment-instance.ts
@@ -172,7 +172,7 @@ export class DeploymentInstance extends Construct implements IScriptHost, IConne
     this.asg = new AutoScalingGroup(this, 'ASG', {
       instanceType: props.instanceType ?? InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
       keyName: props.keyName,
-      machineImage: props.machineImage ?? MachineImage.latestAmazonLinux2(),
+      machineImage: props.machineImage ?? MachineImage.latestAmazonLinux2023(),
       minCapacity: 1,
       maxCapacity: 1,
       securityGroup: props.securityGroup,

--- a/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
@@ -585,6 +585,8 @@ export class MongoDbInstance extends Construct implements IMongoDb, IGrantable {
       'sudo chmod 750 /etc/mongod_certs/', // Directory needs to be executable.
       // mongod user id might, potentially change on reboot. Make sure we own all mongo data
       `sudo chown mongod.mongod -R ${MongoDbInstance.MONGO_DEVICE_MOUNT_POINT}`,
+      // We need yaml for some of our MongoDB configuration scripts
+      'sudo yum install -y python3-PyYAML',
       // Configure mongod
       'bash ./setMongoLimits.sh',
       `bash ./setStoragePath.sh "${MongoDbInstance.MONGO_DEVICE_MOUNT_POINT}"`,

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/secretsFunction.sh
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/secretsFunction.sh
@@ -6,8 +6,8 @@
 function get_secret_string() {
   SECRET_ID=$1
   AWS_REGION=$(echo ${SECRET_ID} | cut -d: -f4)
-  PYTHON_SCRIPT="import json,sys; d=json.load(sys.stdin); print d[\"SecretString\"];"
+  PYTHON_SCRIPT="import json,sys; d=json.load(sys.stdin); print(d[\"SecretString\"]);"
   set +x
-  export RET_VALUE=$(aws --region ${AWS_REGION} secretsmanager get-secret-value --secret-id "${SECRET_ID}" | python -c "${PYTHON_SCRIPT}" )
+  export RET_VALUE=$(aws --region ${AWS_REGION} secretsmanager get-secret-value --secret-id "${SECRET_ID}" | python3 -c "${PYTHON_SCRIPT}" )
   set -x
 }

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setLiveConfiguration.sh
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setLiveConfiguration.sh
@@ -8,7 +8,7 @@
 
 set -xeufo pipefail
 
-cat /etc/mongod.conf | python ./setupMongodLiveConfig.py > ./mongod.conf.new
+cat /etc/mongod.conf | python3 ./setupMongodLiveConfig.py > ./mongod.conf.new
 sudo mv ./mongod.conf.new /etc/mongod.conf
 # Make sure mongod user can read the config file
 sudo chmod 640 /etc/mongod.conf

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setMongoNoAuth.sh
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setMongoNoAuth.sh
@@ -3,7 +3,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cat /etc/mongod.conf | python ./setupMongodNoAuth.py > ./mongod.conf.new
+cat /etc/mongod.conf | python3 ./setupMongodNoAuth.py > ./mongod.conf.new
 sudo mv ./mongod.conf.new /etc/mongod.conf
 # Make sure mongod user can read the config file
 sudo chmod 640 /etc/mongod.conf

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setStoragePath.sh
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setStoragePath.sh
@@ -16,7 +16,7 @@ fi
 
 STORAGE_PATH=$1
 
-cat /etc/mongod.conf | python ./setupMongodStorage.py "${STORAGE_PATH}" > ./mongod.conf.new
+cat /etc/mongod.conf | python3 ./setupMongodStorage.py "${STORAGE_PATH}" > ./mongod.conf.new
 sudo mv ./mongod.conf.new /etc/mongod.conf
 # Make sure mongod user can read the config file
 sudo chmod 640 /etc/mongod.conf

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setupMongodLiveConfig.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setupMongodLiveConfig.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
@@ -98,7 +98,7 @@ def main():
   mongod_conf = yaml.load(sys.stdin)
   modify_security(mongod_conf)
   modify_net_options(mongod_conf)
-  print yaml.dump(mongod_conf, default_flow_style=False)
+  print(yaml.dump(mongod_conf, default_flow_style=False))
 
 if __name__ == '__main__':
   main()

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setupMongodNoAuth.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setupMongodNoAuth.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
@@ -81,7 +81,7 @@ def main():
   mongod_conf = yaml.load(sys.stdin)
   modify_security(mongod_conf)
   modify_network(mongod_conf)
-  print yaml.dump(mongod_conf, default_flow_style=False)
+  print(yaml.dump(mongod_conf, default_flow_style=False))
 
 if __name__ == '__main__':
   main()

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setupMongodStorage.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/3.6/setupMongodStorage.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/packages/aws-rfdk/lib/core/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/core/test/asset-constants.ts
@@ -6,7 +6,7 @@
 // ConfigureCloudWatchAgent.sh
 export const CWA_ASSET_LINUX = {
   Bucket: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-  Key: 'f3261b0f6923b012a8fce5cd6984211bc48b9977844b3fa44229234dc6f21d43',
+  Key: 'a1eed7232f6afcc474e870e7c3c01b7f4aec028de3a20eccc76ad9050032eecb',
 };
 
 // ConfigureCloudWatchAgent.ps1
@@ -38,5 +38,5 @@ export const INSTALL_MONGODB_3_6_SCRIPT_LINUX = {
 
 export const MONGODB_3_6_CONFIGURATION_SCRIPTS = {
   Bucket: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-  Key: '433ead41839a7d4dad68bf0149f907050caa6d95bb7b5b180e5ff21a5dad3c19',
+  Key: '3b571d3659f9f47af6005ca9619c6aec2a576cea5a53b8707544df0a80e368c8',
 };

--- a/packages/aws-rfdk/lib/core/test/cloudwatch-agent.test.ts
+++ b/packages/aws-rfdk/lib/core/test/cloudwatch-agent.test.ts
@@ -46,7 +46,7 @@ describe('CloudWatchAgent', () => {
     const host = new Instance(stack, 'Instance', {
       instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.LARGE),
       machineImage: new AmazonLinuxImage({
-        generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+        generation: AmazonLinuxGeneration.AMAZON_LINUX_2023,
       }),
       vpc,
     });
@@ -69,7 +69,7 @@ describe('CloudWatchAgent', () => {
     const host = new Instance(stack, 'Instance', {
       instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.LARGE),
       machineImage: new AmazonLinuxImage({
-        generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+        generation: AmazonLinuxGeneration.AMAZON_LINUX_2023,
       }),
       vpc,
     });
@@ -216,7 +216,7 @@ describe('CloudWatchAgent', () => {
     const host = new Instance(stack, 'Instance', {
       instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.LARGE),
       machineImage: new AmazonLinuxImage({
-        generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+        generation: AmazonLinuxGeneration.AMAZON_LINUX_2023,
       }),
       vpc,
     });

--- a/packages/aws-rfdk/lib/core/test/deployment-instance.test.ts
+++ b/packages/aws-rfdk/lib/core/test/deployment-instance.test.ts
@@ -158,7 +158,7 @@ describe('DeploymentInstance', () => {
 
       test('uses latest Amazon Linux machine image', () => {
         // GIVEN
-        const amazonLinux = MachineImage.latestAmazonLinux2();
+        const amazonLinux = MachineImage.latestAmazonLinux2023();
         const imageId: { Ref: string } = stack.resolve(amazonLinux.getImage(stack)).imageId;
 
         // THEN

--- a/packages/aws-rfdk/lib/core/test/health-monitor.test.ts
+++ b/packages/aws-rfdk/lib/core/test/health-monitor.test.ts
@@ -79,7 +79,7 @@ class TestMonitorableFleet extends Construct implements IMonitorableFleet {
     const fleet = new AutoScalingGroup(this, 'ASG', {
       instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.LARGE),
       machineImage: new AmazonLinuxImage({
-        generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+        generation: AmazonLinuxGeneration.AMAZON_LINUX_2023,
       }),
       vpc: props.vpc,
       minCapacity: props.minCapacity,

--- a/packages/aws-rfdk/lib/core/test/mongodb-installer.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-installer.test.ts
@@ -72,7 +72,7 @@ Please set the userSsplAcceptance property to USER_ACCEPTS_SSPL to signify your 
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
     const installer = new MongoDbInstaller(stack, {
       version: MongoDbVersion.COMMUNITY_3_6,
@@ -172,7 +172,7 @@ Please set the userSsplAcceptance property to USER_ACCEPTS_SSPL to signify your 
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
     const installer1 = new MongoDbInstaller(stack, {
       version: MongoDbVersion.COMMUNITY_3_6,

--- a/packages/aws-rfdk/lib/core/test/mongodb-instance.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-instance.test.ts
@@ -454,6 +454,7 @@ describe('Test MongoDbInstance', () => {
               'sudo chmod 640 -R /etc/mongod_certs/\n' +
               'sudo chmod 750 /etc/mongod_certs/\n' +
               'sudo chown mongod.mongod -R /var/lib/mongo\n' +
+              'sudo yum install -y python3-PyYAML\n' +
               'bash ./setMongoLimits.sh\n' +
               'bash ./setStoragePath.sh "/var/lib/mongo"\n' +
               'bash ./setMongoNoAuth.sh\n' +

--- a/packages/aws-rfdk/lib/core/test/mountable-ebs.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-ebs.test.ts
@@ -50,7 +50,7 @@ describe('Test MountableBlockVolume', () => {
     instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
   });
 

--- a/packages/aws-rfdk/lib/core/test/mountable-efs.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-efs.test.ts
@@ -52,7 +52,7 @@ describe('Test MountableEFS', () => {
     instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
   });
 

--- a/packages/aws-rfdk/lib/core/test/mountable-fsx-lustre.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mountable-fsx-lustre.test.ts
@@ -63,7 +63,7 @@ describe('MountableFsxLustre', () => {
     instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
       securityGroup: instanceSecurityGroup,
     });
   });

--- a/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
+++ b/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
@@ -36,7 +36,7 @@ describe('Test StaticIpServer', () => {
     new StaticPrivateIpServer(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // THEN
@@ -196,12 +196,12 @@ describe('Test StaticIpServer', () => {
     new StaticPrivateIpServer(stack, 'Instance1', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
     new StaticPrivateIpServer(stack, 'Instance2', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // THEN
@@ -238,7 +238,7 @@ describe('Test StaticIpServer', () => {
       new StaticPrivateIpServer(stack, 'Instance', {
         vpc,
         instanceType: new InstanceType('t3.small'),
-        machineImage: MachineImage.latestAmazonLinux2(),
+        machineImage: MachineImage.latestAmazonLinux2023(),
         vpcSubnets: {
           subnetType: SubnetType.PRIVATE_WITH_EGRESS,
           availabilityZones: ['dummy zone'],
@@ -252,7 +252,7 @@ describe('Test StaticIpServer', () => {
     new StaticPrivateIpServer(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
       resourceSignalTimeout: Duration.hours(12),
     });
 
@@ -269,7 +269,7 @@ describe('Test StaticIpServer', () => {
       new StaticPrivateIpServer(stack, 'InstanceFail', {
         vpc,
         instanceType: new InstanceType('t3.small'),
-        machineImage: MachineImage.latestAmazonLinux2(),
+        machineImage: MachineImage.latestAmazonLinux2023(),
         resourceSignalTimeout: Duration.seconds(12 * 60 * 60 + 1),
       });
     }).toThrow('Resource signal timeout cannot exceed 12 hours.');

--- a/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/database-connection.ts
@@ -210,7 +210,7 @@ class DocDBDatabaseConnection extends DatabaseConnection {
     }
     host.userData.addCommands(
       'configure_database_installation_args(){',
-      'getJsonVal(){ python -c \'import json,sys;obj=json.load(sys.stdin);print obj["\'$1\'"]\'; }',
+      'getJsonVal(){ python3 -c \'import json,sys;obj=json.load(sys.stdin);print(obj["\'$1\'"])\'; }',
       'SET_X_IS_SET=$-',
       '{ set +x; } 2>/dev/null',
       `export SECRET_STRING=\`aws secretsmanager get-secret-value --secret-id ${this.props.login.secretArn} --region ${Stack.of(this.props.login).region} | getJsonVal 'SecretString'\``,
@@ -236,7 +236,7 @@ class DocDBDatabaseConnection extends DatabaseConnection {
     }
     host.userData.addCommands(
       'configure_deadline_database(){',
-      'getJsonVal(){ python -c \'import json,sys;obj=json.load(sys.stdin);print obj["\'$1\'"]\'; }',
+      'getJsonVal(){ python3 -c \'import json,sys;obj=json.load(sys.stdin);print(obj["\'$1\'"])\'; }',
       'SET_X_IS_SET=$-',
       '{ set +x; } 2>/dev/null',
       `export SECRET_STRING=\`aws secretsmanager get-secret-value --secret-id ${this.props.login.secretArn} --region ${Stack.of(this.props.login).region} | getJsonVal 'SecretString'\``,
@@ -390,7 +390,7 @@ class MongoDbInstanceDatabaseConnection extends DatabaseConnection {
     const certPwSecret = this.props.clientCertificate.passphrase;
     host.userData.addCommands(
       'configure_database_installation_args(){',
-      'getJsonVal(){ python -c \'import json,sys;obj=json.load(sys.stdin);print obj["\'$1\'"]\'; }',
+      'getJsonVal(){ python3 -c \'import json,sys;obj=json.load(sys.stdin);print(obj["\'$1\'"])\'; }',
       // Suppress -x, so no secrets go to the logs
       'SET_X_IS_SET=$-',
       '{ set +x; } 2>/dev/null',
@@ -417,7 +417,7 @@ class MongoDbInstanceDatabaseConnection extends DatabaseConnection {
     const certPwSecret = this.props.clientCertificate.passphrase;
     host.userData.addCommands(
       'configure_deadline_database(){',
-      'getJsonVal(){ python -c \'import json,sys;obj=json.load(sys.stdin);print obj["\'$1\'"]\'; }',
+      'getJsonVal(){ python3 -c \'import json,sys;obj=json.load(sys.stdin);print(obj["\'$1\'"])\'; }',
       'SET_X_IS_SET=$-',
       '{ set +x; } 2>/dev/null',
       `export DB_CERT_FILE="${MongoDbInstanceDatabaseConnection.DB_CERT_LOCATION}"`,

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -31,6 +31,7 @@ import {
   Cluster,
   ContainerImage,
   Ec2TaskDefinition,
+  EcsOptimizedImage,
   LogDriver,
   PlacementConstraint,
   Scope,
@@ -452,6 +453,7 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
       // so this security group will get applied there
       // @ts-ignore
       securityGroup: props.securityGroups?.backend,
+      machineImage: EcsOptimizedImage.amazonLinux2023(),
     });
 
     this.backendConnections = this.asg.connections;

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -732,7 +732,7 @@ export class Repository extends Construct implements IRepository {
     this.installerGroup = new AutoScalingGroup(this, 'Installer', {
       instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.LARGE),
       machineImage: new AmazonLinuxImage({
-        generation: AmazonLinuxGeneration.AMAZON_LINUX_2,
+        generation: AmazonLinuxGeneration.AMAZON_LINUX_2023,
       }),
       vpc: props.vpc,
       vpcSubnets: props.vpcSubnets ?? {

--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -27,6 +27,7 @@ import {
   Compatibility,
   ContainerImage,
   Ec2Service,
+  EcsOptimizedImage,
   LogDriver,
   NetworkMode,
   PlacementConstraint,
@@ -541,6 +542,7 @@ export class UsageBasedLicensing extends Construct implements IGrantable {
       // so this security group will get applied there
       // @ts-ignore
       securityGroup: props.securityGroup,
+      machineImage: EcsOptimizedImage.amazonLinux2023(),
     });
 
     const taskDefinition = new TaskDefinition(this, 'TaskDefinition', {

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorker.sh
@@ -41,7 +41,7 @@ if [ ! -f "$DEADLINE_COMMAND" ]; then
 fi
 
 isVersionLessThan() {
-    python -c "import sys;sys.exit(0 if tuple(map(int, sys.argv[-2].split('.'))) < tuple(map(int, sys.argv[-1].split('.'))) else 1)" "$1" "$2"
+    python3 -c "import sys;sys.exit(0 if tuple(map(int, sys.argv[-2].split('.'))) < tuple(map(int, sys.argv[-1].split('.'))) else 1)" "$1" "$2"
 }
 
 DEADLINE_VERSION=$("$DEADLINE_COMMAND" -Version | grep -oP '[v]\K\d+\.\d+\.\d+\.\d+\b')
@@ -125,7 +125,16 @@ for worker_name in "${WORKER_NAMES[@]}"; do
 done
 
 # Restart service, if it exists, else restart application
+has_launcher_service=false
 if service --status-all | grep -q 'Deadline 10 Launcher'; then
+  has_launcher_service=true
+elif command -v systemctl; then
+  if systemctl list-unit-files deadline10launcher.service; then
+    has_launcher_service=true
+  fi
+fi
+
+if [ "$has_launcher_service" = "true" ]; then
   service deadline10launcher stop
   sudo killall -w deadlineworker || true
   service deadline10launcher start

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorkerHealthCheck.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/configureWorkerHealthCheck.sh
@@ -33,7 +33,7 @@ if [ ! -f "$DEADLINE_COMMAND" ]; then
 fi
 
 isVersionLessThan() {
-    python -c "import sys;sys.exit(0 if tuple(map(int, sys.argv[-2].split('.'))) < tuple(map(int, sys.argv[-1].split('.'))) else 1)" "$1" "$2"
+    python3 -c "import sys;sys.exit(0 if tuple(map(int, sys.argv[-2].split('.'))) < tuple(map(int, sys.argv[-1].split('.'))) else 1)" "$1" "$2"
 }
 
 DEADLINE_VERSION=$("$DEADLINE_COMMAND" -Version | grep -oP '[v]\K\d+\.\d+\.\d+\.\d+\b')

--- a/packages/aws-rfdk/lib/deadline/scripts/bash/getSecretToFile.sh
+++ b/packages/aws-rfdk/lib/deadline/scripts/bash/getSecretToFile.sh
@@ -32,10 +32,10 @@ export SECRET_JSON=$(aws --region ${AWS_REGION} secretsmanager get-secret-value 
 set -x
 if printenv SECRET_JSON | grep 'SecretString' 2>&1 > /dev/null
 then
-    # Secret was plain test. Just copy the contents of the SecretString into the output file
-    printenv SECRET_JSON | python -c "${PY_SCRIPT}" SecretString > "${OUTPUT_FILENAME}"
+    # Secret was plain text. Just copy the contents of the SecretString into the output file
+    printenv SECRET_JSON | python3 -c "${PY_SCRIPT}" SecretString > "${OUTPUT_FILENAME}"
 else
     # Secret value is binary. The contents of SecretBinary will be the base64 encoding of the secret
-    printenv SECRET_JSON | python -c "${PY_SCRIPT}" SecretBinary | base64 -w0 -i -d > "${OUTPUT_FILENAME}"
+    printenv SECRET_JSON | python3 -c "${PY_SCRIPT}" SecretBinary | base64 -w0 -i -d > "${OUTPUT_FILENAME}"
 fi
 unset SECRET_JSON

--- a/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/deadline/test/asset-constants.ts
@@ -12,7 +12,7 @@ export const CONFIG_REPO_DIRECT_CONNECT_LINUX = {
 // configureWorker.sh
 export const CONFIG_WORKER_ASSET_LINUX = {
   Bucket: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-  Key: '1cfdffe73bb016717ba1f43d64fe528af27b3784f524a97bb36533a6e6d057ff',
+  Key: '76766750db1ed4977df23b4ebb558126969a4ee7b29abb6f641bbf01e5d87ee2',
 };
 
 // configureWorker.ps1
@@ -24,7 +24,7 @@ export const CONFIG_WORKER_ASSET_WINDOWS = {
 // configureWorkerHealthCheck.sh
 export const CONFIG_WORKER_HEALTHCHECK_LINUX = {
   Bucket: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-  Key: '3e16ffda458a50d2a032ef783202a85bf4677f19b92a38d3605d6cd750879f75',
+  Key: 'ead757e1f1f867645f8a576b3f882aa25c8c5412561d41b5276434f71b46062b',
 };
 
 // configureWorkerHealthCheck.ps1
@@ -47,7 +47,7 @@ export const CONFIG_WORKER_PORT_ASSET_WINDOWS = {
 // getSecretToFile.sh
 export const GET_SECRET_TO_FILE_SCRIPT_LINUX = {
   Bucket: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-  Key: '2245b375c979246094a6a47007b55e51f117e987be5de9791c0799cddc3f1c2e',
+  Key: '798b6fa13b77a35cae7f9eed2716de82efce89e61640d17dbd3c620f53613cec',
 };
 
 // installDeadlineRepository.sh

--- a/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/database-connection.test.ts
@@ -128,7 +128,7 @@ describe('DocumentDB', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN
@@ -181,7 +181,7 @@ describe('DocumentDB', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN
@@ -213,7 +213,7 @@ describe('DocumentDB', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN
@@ -244,7 +244,7 @@ describe('DocumentDB', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN
@@ -535,7 +535,7 @@ describe('MongoDB', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN
@@ -561,7 +561,7 @@ describe('MongoDB', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN
@@ -623,7 +623,7 @@ describe('MongoDB', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN

--- a/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/render-queue.test.ts
@@ -209,7 +209,7 @@ describe('RenderQueue', () => {
           InstanceClass.R4,
           InstanceSize.LARGE,
         ),
-        machineImage: MachineImage.latestAmazonLinux2(),
+        machineImage: MachineImage.latestAmazonLinux2023(),
       });
 
       // WHEN
@@ -516,7 +516,7 @@ describe('RenderQueue', () => {
       // GIVEN
       const instance = new Instance(dependencyStack, 'BackendConnectionInstance', {
         instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
-        machineImage: MachineImage.latestAmazonLinux2(),
+        machineImage: MachineImage.latestAmazonLinux2023(),
         vpc,
       });
       const portNumber = 5555;
@@ -1209,7 +1209,7 @@ describe('RenderQueue', () => {
             InstanceClass.R4,
             InstanceSize.LARGE,
           ),
-          machineImage: MachineImage.latestAmazonLinux2(),
+          machineImage: MachineImage.latestAmazonLinux2023(),
         })];
         const role = new Role(stack, 'Role', {assumedBy: new AccountRootPrincipal()});
 
@@ -1249,7 +1249,7 @@ describe('RenderQueue', () => {
             InstanceClass.R4,
             InstanceSize.LARGE,
           ),
-          machineImage: MachineImage.latestAmazonLinux2(),
+          machineImage: MachineImage.latestAmazonLinux2023(),
         });
 
         renderQueue.configureClientInstance({
@@ -1416,7 +1416,7 @@ describe('RenderQueue', () => {
             InstanceClass.R4,
             InstanceSize.LARGE,
           ),
-          machineImage: MachineImage.latestAmazonLinux2(),
+          machineImage: MachineImage.latestAmazonLinux2023(),
         })];
         const role = new Role(stack, 'Role', {assumedBy: new AccountRootPrincipal()});
 
@@ -1450,7 +1450,7 @@ describe('RenderQueue', () => {
             InstanceClass.R4,
             InstanceSize.LARGE,
           ),
-          machineImage: MachineImage.latestAmazonLinux2(),
+          machineImage: MachineImage.latestAmazonLinux2023(),
         });
 
         renderQueue.configureClientInstance({

--- a/packages/aws-rfdk/lib/deadline/test/repository.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/repository.test.ts
@@ -930,7 +930,7 @@ test('repository configure client instance', () => {
   const instance = new Instance(stack, 'Instance', {
     vpc,
     instanceType: new InstanceType('t3.small'),
-    machineImage: MachineImage.latestAmazonLinux2(),
+    machineImage: MachineImage.latestAmazonLinux2023(),
   });
   const instanceRole = (
     instance
@@ -989,12 +989,12 @@ test('configureClientInstance uses singleton for repo config script', () => {
   const instance1 = new Instance(stack, 'Instance1', {
     vpc,
     instanceType: new InstanceType('t3.small'),
-    machineImage: MachineImage.latestAmazonLinux2(),
+    machineImage: MachineImage.latestAmazonLinux2023(),
   });
   const instance2 = new Instance(stack, 'Instance2', {
     vpc,
     instanceType: new InstanceType('t3.small'),
-    machineImage: MachineImage.latestAmazonLinux2(),
+    machineImage: MachineImage.latestAmazonLinux2023(),
   });
 
   // WHEN

--- a/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/worker-configuration.test.ts
@@ -59,7 +59,7 @@ describe('Test WorkerInstanceConfiguration for Linux', () => {
     instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
   });
 
@@ -468,7 +468,7 @@ describe('Test WorkerInstanceConfiguration connect to RenderQueue', () => {
     const instance = new Instance(stack, 'Instance', {
       vpc,
       instanceType: new InstanceType('t3.small'),
-      machineImage: MachineImage.latestAmazonLinux2(),
+      machineImage: MachineImage.latestAmazonLinux2023(),
     });
 
     // WHEN


### PR DESCRIPTION
## Problem

We want to use the new Deadline 10.4.0 release with the RFDK.

Most of the issues we encountered are related to OS support in Deadline.  Previously we installed Deadline on Amazon Linux 2, but this is no longer supported in Deadline 10.4.0.

## Solution

- We updated the OS to Amazon Linux 2023 (AL2023).
- Previously our scripts used Python 2.  This is not installed on AL2023 by default, so we changed our scripts to use Python 3 instead.
- AL2023 includes a new version of GnuPG with different output.  We changed our invocation to use a machine-readable format that works on both the newer and older version.
- The `WF-submit-jobs-to-sets.sh` scripts in our integration tests submitted jobs that run `/usr/bin/sleep`.  This command is not available on Windows, causing occasional test failures.  We changed the tests to run `timeout.exe` on Windows instead.

## Testing

I ran the integration tests with Deadline 10.4.0.10 and confirmed that they succeed.

I also ran the integration tests on an older revision of this change, and confirmed that they succeeded with Deadline 10.3.2.1.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
