### PR TITLE
chore: Update prep_release to pull AL2023 docker

### DIFF
--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -48,12 +48,13 @@ PULL_AL_FROM_ECR_ARGS=(
     "${ECR_REGION}"
     # Image versions to pull
     "latest" # required for building and publishing lambda layers
-    "2"      # required for building Deadline docker images for running integration tests
+    "2"      # required for building Deadline docker images for running integration tests for old versions
+    "2023"   # required for building Deadline docker images for running integration tests
 )
 /bin/bash ${SCRIPT_DIR}/pull_amazonlinux_from_ecr.sh "${PULL_AL_FROM_ECR_ARGS[@]}"
 
 # Run integ tests
-(cd "${ROOT_DIR}" && yarn run build)
+(cd "${ROOT_DIR}" && yarn clean && yarn build)
 pushd $TESTS_DIR
 yarn run e2e-automated
 popd


### PR DESCRIPTION
## Summary
Our prep_release script needs to be bumped to pull AL2023 images instead of AL2. I also added a clean step here to clean up any existing artifacts when running the tests, just in case.

## Testing
Ran `pull_amazonlinux_from_ecr.sh` with the new args, confirmed it worked locally.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
