### PR TITLE
fix: Set Amazon Linux version based on Deadline Repository version

### DIFF
--- a/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
@@ -592,6 +592,8 @@ export class MongoDbInstance extends Construct implements IMongoDb, IGrantable {
       `bash ./setStoragePath.sh "${MongoDbInstance.MONGO_DEVICE_MOUNT_POINT}"`,
       'bash ./setMongoNoAuth.sh',
       'sudo service mongod start',
+      // Ensure the mongo service started
+      'sudo service mongod status',
       `bash ./setAdminCredentials.sh "${this.adminUser.secretArn}"`,
     );
     this.adminUser.grantRead(instance.grantPrincipal);

--- a/packages/aws-rfdk/lib/core/test/mongodb-instance.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-instance.test.ts
@@ -459,6 +459,7 @@ describe('Test MongoDbInstance', () => {
               'bash ./setStoragePath.sh "/var/lib/mongo"\n' +
               'bash ./setMongoNoAuth.sh\n' +
               'sudo service mongod start\n' +
+              'sudo service mongod status\n' +
               'bash ./setAdminCredentials.sh \"',
               {
                 Ref: Match.stringLikeRegexp('^MongoDbInstanceAdminUser.*'),

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -732,7 +732,7 @@ export class Repository extends Construct implements IRepository {
     this.installerGroup = new AutoScalingGroup(this, 'Installer', {
       instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.LARGE),
       machineImage: new AmazonLinuxImage({
-        generation: AmazonLinuxGeneration.AMAZON_LINUX_2023,
+        generation: this.getAmazonLinuxGenerationForDeadlineVersion(this.version),
       }),
       vpc: props.vpc,
       vpcSubnets: props.vpcSubnets ?? {
@@ -1056,5 +1056,18 @@ export class Repository extends Construct implements IRepository {
       host: installerGroup,
       args: installerArgs,
     });
+  }
+
+  /**
+   * Return an AmazonLinuxGeneration that can run the specified version of Deadline.
+   */
+  private getAmazonLinuxGenerationForDeadlineVersion(deadlineVersion: IVersion): AmazonLinuxGeneration {
+    const REMOVED_SUPPORT_FOR_AMAZON_LINUX_2 = new Version([10, 4, 0, 0]);
+
+    if (deadlineVersion.isLessThan(REMOVED_SUPPORT_FOR_AMAZON_LINUX_2)) {
+      return AmazonLinuxGeneration.AMAZON_LINUX_2;
+    } else {
+      return AmazonLinuxGeneration.AMAZON_LINUX_2023;
+    }
   }
 }


### PR DESCRIPTION
## Problem
Recent changes to move RFDK infrastructure to Amazon Linux 2023 were causing integration tests to fail when installing the Deadline repository for Deadline versions before 10.4.0.10.

## Solution
When we install the Deadline Repository, we check the Deadline version, and fall back to AL2 instances if they are versions older than 10.4.0.

## Testing
- in the test-config.sh, set the `DEADLINE_VERSION="10.3.2.1"`
- ran `yarn e2e` from the integ directory, confirmed integration tests passed
- reverted test-config changes, reran integration tests, confirmed they passed with the latest Deadline version

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
