### PR TITLE
hiddenfix: add ap-south-1 to lambda layers allowlist

### DIFF
--- a/lambda-layers/lib/get-regions.ts
+++ b/lambda-layers/lib/get-regions.ts
@@ -17,6 +17,7 @@ const REGION_ALLOW_LIST = [
   'ap-northeast-1',
   'ap-northeast-2',
   'ap-northeast-3',
+  'ap-south-1',
   'ap-southeast-1',
   'ap-southeast-2',
   'ca-central-1',


### PR DESCRIPTION
## Summary
When I changed the lambda layers to use an allowlist instead of denylist for regions (in https://github.com/aws/aws-rfdk/pull/1422), I missed `ap-south-1`. I've now added it.

## Testing
- you can see in my testing here that I missed ap-south-1: https://github.com/aws/aws-rfdk/pull/1422
- this is my new output when publishing:
```
No new version, skipping publish for us-west-2
No new version, skipping publish for us-west-1
No new version, skipping publish for us-east-2
No new version, skipping publish for ca-central-1
No new version, skipping publish for us-east-1
No new version, skipping publish for ap-northeast-1
No new version, skipping publish for ap-northeast-3
No new version, skipping publish for eu-west-1
No new version, skipping publish for ap-northeast-2
No new version, skipping publish for eu-west-2
No new version, skipping publish for eu-west-3
No new version, skipping publish for eu-central-1
No new version, skipping publish for ap-southeast-2
No new version, skipping publish for eu-north-1
No new version, skipping publish for ap-southeast-1
No new version, skipping publish for sa-east-1
No new version, skipping publish for ap-south-1
```
- I confirmed there were 17 lines for both the old output (pre-allowlist) and now 17 lines with the full allowlist

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
