### PR TITLE
fix(integ): special case for version 10.4.0.13 Repository installer

### DIFF
--- a/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
+++ b/integ/components/deadline/deadline_01_repository/test/deadline_01_repository.test.ts
@@ -186,7 +186,9 @@ describe.each(testCases)('Deadline Repository tests (%s)', (_, id) => {
         case '10.3.1.4':
           expectedVersion = '10.3.1.3';
           break;
-
+        case '10.4.0.13':
+          expectedVersion = '10.4.0.12';
+          break;
         default:
           expectedVersion = deadlineVersion!;
           break;


### PR DESCRIPTION
## Problem

The Deadline 10.4.0.13 Repository installer has a mismatched version number, such that the version in the installer filename (10.4.0.13) is different from the version embedded in the build (10.4.0.12). This causes errors in our `deadline_01_repository` integration test such as:

```
  ● Deadline Repository tests (RFDK-created DB and EFS) › EFS tests › DL-1-3: repository.ini version matches Deadline installer
    expect(received).toEqual(expected) // deep equality
    Expected: StringMatching /\[DeadlineRepository\]\nVersion=10\.4.0.13/
    Received: "[DeadlineRepository]
    Version=10.4.0.12
    VersionInformation=4a229067b
    DeploymentVersion=3
    [DeadlineIntegration]
    10.4.0.13
    VersionInformation=4a229067b
    "
      193 |       }
      194 |       const regex = new RegExp('\\[DeadlineRepository\\]\nVersion=' + expectedVersion.replace('.', '\\.'));
    > 195 |       expect(output).toEqual(expect.stringMatching(regex));
          |                      ^
      196 |     });
      197 |   });
      198 |
```

## Solution

Add a special case so the test will expect to find `Version=10.4.0.12` in the Deadline 10.4.0.13 installer.

## Testing

Ran the `deadline_01_repository` integration test for Deadline 10.4.0.13 and confirmed that this error no longer appears.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
