### PR TITLE
chore(repo): Add Deadline Cloud link to maintenance mode banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Render Farm Deployment Kit on AWS (RFDK)
 
 > [!NOTE]
-> On November 7, 2025, AWS Thinkbox Deadline 10 will enter maintenance mode. We recommend exploring AWS Deadline Cloud for render management. For questions, contact [support@awsthinkbox.zendesk.com](mailto:support@awsthinkbox.zendesk.com) or refer to the [Maintenance Mode FAQ](https://docs.thinkboxsoftware.com/products/deadline/10.4/1_User%20Manual/manual/maintenance-mode-faq.html).
+> On November 7, 2025, AWS Thinkbox Deadline 10 will enter maintenance mode. We recommend exploring [AWS Deadline Cloud](https://aws.amazon.com/deadline-cloud/) for render management. For questions, contact [support@awsthinkbox.zendesk.com](mailto:support@awsthinkbox.zendesk.com) or refer to the [Maintenance Mode FAQ](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/maintenance-mode-faq.html).
 
 The Render Farm Deployment Kit on AWS is an open-source library for use with the
 [AWS Cloud Development Kit](https://github.com/aws/aws-cdk) that is designed to help you


### PR DESCRIPTION
# Problem
We want to add a link to AWS Deadline Cloud in the Deadline 10 maintenance mode banner.

# Solution
Added the link. I also updated the FAQ link to use the `/latest/` URL to avoid broken links for any future version bumps.

# Testing
I verified that the link shows up and works as expected in GitHub when viewing the new branch.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
