### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -5,6 +5,9 @@ name: Auto Approve Dependabot PR's
 on:
   pull_request_target
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ mainline, 'feature*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   modify-labels:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - .github/config/labels.yml
 
+permissions:
+  issues: write
+
 jobs:
   modify-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.