### PR TITLE
chore(lambda): upgrade Lambda runtime from Node.js 18 to Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
+++ b/packages/aws-rfdk/lib/core/lib/exporting-log-group.ts
@@ -154,7 +154,7 @@ export class ExportingLogGroup extends Construct {
       handler: 'index.handler',
       lambdaPurpose: 'LogGroupExporter',
       logRetention: RetentionDays.ONE_DAY,
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       uuid: this.LOG_EXPORTER_UUID,
     });
 

--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -392,7 +392,7 @@ export class HealthMonitor extends HealthMonitorBase {
 
     this.unhealthyFleetActionLambda = new SingletonFunction(this, 'UnhealthyFleetAction', {
       code: Code.fromAsset(path.join(__dirname, '..', '..', 'lambdas', 'nodejs', 'unhealthyFleetAction')),
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'index.handler',
       lambdaPurpose: 'unhealthyFleetTermination',
       timeout: Duration.seconds(300),

--- a/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/imported-acm-certificate.ts
@@ -165,7 +165,7 @@ export class ImportedAcmCertificate extends Construct implements ICertificate {
       },
       layers: [ openSslLayer ],
       retryAttempts: 0,
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       timeout: Duration.minutes(5),
     });
 

--- a/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
@@ -198,7 +198,7 @@ export class MongoDbPostInstallSetup extends Construct {
       environment: {
         DEBUG: 'false',
       },
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'mongodb.configureMongo',
       layers: [ openSslLayer ],
       timeout: Duration.minutes(2),

--- a/packages/aws-rfdk/lib/core/lib/pad-efs-storage.ts
+++ b/packages/aws-rfdk/lib/core/lib/pad-efs-storage.ts
@@ -196,7 +196,7 @@ export class PadEfsStorage extends Construct {
 
     const lambdaProps: any = {
       code: Code.fromAsset(path.join(__dirname, '..', '..', 'lambdas', 'nodejs')),
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       logRetention: RetentionDays.ONE_WEEK,
       // Required for access point...
       vpc: props.vpc,

--- a/packages/aws-rfdk/lib/core/lib/staticip-server.ts
+++ b/packages/aws-rfdk/lib/core/lib/staticip-server.ts
@@ -324,7 +324,7 @@ export class StaticPrivateIpServer extends Construct implements IConnectable, IG
       eventHandler = new LambdaFunction(stack, functionUniqueId, {
         code: handlerCode,
         handler: 'index.handler',
-        runtime: Runtime.NODEJS_18_X,
+        runtime: Runtime.NODEJS_22_X,
         description: `Created by RFDK StaticPrivateIpServer to process instance launch lifecycle events in stack '${stack.stackName}'. This lambda attaches an ENI to newly launched instances.`,
         logRetention: RetentionDays.THREE_DAYS,
       });

--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -199,7 +199,7 @@ abstract class X509CertificateBase extends Construct {
         DATABASE: this.database.tableName,
         DEBUG: 'false',
       },
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       layers: [ openSslLayer ],
       handler: props.lambdaHandler,
       timeout: Duration.seconds(90),

--- a/packages/aws-rfdk/lib/core/test/mongodb-post-install.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-post-install.test.ts
@@ -117,7 +117,7 @@ describe('MongoDbPostInstall', () => {
           DEBUG: 'false',
         },
       },
-      Runtime: 'nodejs18.x',
+      Runtime: 'nodejs22.x',
       VpcConfig: {
         SecurityGroupIds: [
           {

--- a/packages/aws-rfdk/lib/core/test/pad-efs-storage.test.ts
+++ b/packages/aws-rfdk/lib/core/test/pad-efs-storage.test.ts
@@ -78,7 +78,7 @@ describe('Test PadEfsStorage', () => {
           },
         ],
         Handler: 'pad-efs-storage.getDiskUsage',
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs22.x',
         Timeout: 300,
         VpcConfig: {
           SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],
@@ -103,7 +103,7 @@ describe('Test PadEfsStorage', () => {
           },
         ],
         Handler: 'pad-efs-storage.padFilesystem',
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs22.x',
         Timeout: 900,
         VpcConfig: {
           SecurityGroupIds: [ stack.resolve(sg.securityGroupId) ],

--- a/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
+++ b/packages/aws-rfdk/lib/core/test/staticip-server.test.ts
@@ -93,7 +93,7 @@ describe('Test StaticIpServer', () => {
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
       Handler: 'index.handler',
-      Runtime: 'nodejs18.x',
+      Runtime: 'nodejs22.x',
       Description: 'Created by RFDK StaticPrivateIpServer to process instance launch lifecycle events in stack \'StackName\'. This lambda attaches an ENI to newly launched instances.',
     });
 

--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -448,7 +448,7 @@ export class ConfigureSpotEventPlugin extends Construct {
         DEBUG: 'false',
         LAMBDA_TIMEOUT_MINS: timeoutMins.toString(),
       },
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'configure-spot-event-plugin.configureSEP',
       timeout: Duration.minutes(timeoutMins),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/thinkbox-docker-images.ts
@@ -194,7 +194,7 @@ USER_ACCEPTS_AWS_CUSTOMER_AGREEMENT_AND_IP_LICENSE to signify your acceptance of
       uuid: '08553416-1fc9-4be9-a818-609a31ae1b5b',
       description: 'Used by the ThinkboxDockerImages construct to look up the ECR repositories where AWS Thinkbox publishes Deadline container images.',
       code: lambdaCode,
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'ecr-provider.handler',
       timeout: Duration.seconds(30),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/lib/version-query.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/version-query.ts
@@ -168,7 +168,7 @@ export class VersionQuery extends VersionQueryBase {
       uuid: '2e19e243-16ee-4d1a-a3c9-18d35eddd446',
       description: 'Used by the Version construct to get installer locations for a specific Deadline version.',
       code: lambdaCode,
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'version-provider.handler',
       timeout: Duration.seconds(30),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/lib/wait-for-stable-service.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/wait-for-stable-service.ts
@@ -74,7 +74,7 @@ export class WaitForStableService extends Construct {
       environment: {
         DEBUG: 'false',
       },
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'wait-for-stable-service.wait',
       timeout: Duration.minutes(15),
       logRetention: RetentionDays.ONE_WEEK,

--- a/packages/aws-rfdk/lib/deadline/test/version-query.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/version-query.test.ts
@@ -62,7 +62,7 @@ test('VersionQuery constructor full version', () => {
         'Arn',
       ],
     },
-    Runtime: 'nodejs18.x',
+    Runtime: 'nodejs22.x',
   });
 });
 

--- a/packages/aws-rfdk/lib/deadline/test/wait-for-stable-service.test.ts
+++ b/packages/aws-rfdk/lib/deadline/test/wait-for-stable-service.test.ts
@@ -87,7 +87,7 @@ describe('WaitForStableService', () => {
           DEBUG: 'false',
         },
       },
-      Runtime: 'nodejs18.x',
+      Runtime: 'nodejs22.x',
       Timeout: 900,
     }, 1);
   });


### PR DESCRIPTION
## Summary

Upgrade all 11 Lambda functions from `Runtime.NODEJS_18_X` to `Runtime.NODEJS_22_X`.

Node.js 18 was deprecated on AWS Lambda on Sep 1, 2025. Function create will be blocked starting Feb 1, 2027 and function update blocked Mar 3, 2027. Node.js 22 runs on Amazon Linux 2023 and is supported until Apr 2027.

## Changes

- 11 source files: `Runtime.NODEJS_18_X` → `Runtime.NODEJS_22_X`
- 5 test files: updated runtime assertions from `nodejs18.x` to `nodejs22.x`

## Testing

The Lambda handler code uses standard Node.js APIs (AWS SDK calls, filesystem operations, child_process) with no breaking changes between Node.js 18 and 22. Integration tests should be run to validate.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*