### PR TITLE
fix(core): prevent OS command injection in X509CertificatePem Lambda

### DIFF
--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/x509-certs/certificate.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/x509-certs/certificate.ts
@@ -18,7 +18,7 @@ import {
 } from '../filesystem';
 import { DistinguishedName } from './distinguished-name';
 
-const exec = promisify(child_process.exec);
+const execFile = promisify(child_process.execFile);
 
 export interface ICertificate {
   readonly cert: string;
@@ -67,14 +67,15 @@ export class Certificate implements ICertificate {
       const encrypedKeyFile: string = path.join(tmpDir, 'encrypted.key');
       await writeAsciiFile(encrypedKeyFile, key);
       const decryptedKeyFile: string = path.join(tmpDir, 'decrypted.key');
-      const cmd =
-        'openssl rsa ' +
-        `-in ${encrypedKeyFile} ` +
-        '-passin env:CERT_PASSPHRASE ' +
-        `-out ${decryptedKeyFile}`;
+      const args = [
+        'rsa',
+        '-in', encrypedKeyFile,
+        '-passin', 'env:CERT_PASSPHRASE',
+        '-out', decryptedKeyFile,
+      ];
 
-      console.debug(`Running: ${cmd}`);
-      await exec(cmd, { env: { CERT_PASSPHRASE: passphrase, PATH: process.env.PATH } });
+      console.debug(`Running: openssl ${args.join(' ')}`);
+      await execFile('openssl', args, { env: { CERT_PASSPHRASE: passphrase, PATH: process.env.PATH } });
 
       const keyDecrypted = await readAsciiFile(decryptedKeyFile);
 
@@ -98,17 +99,19 @@ export class Certificate implements ICertificate {
   ): Promise<[string, string]> {
     const crtFile: string = path.join(tmpDir, 'crt');
     const keyFile: string = path.join(tmpDir, 'key');
-    const cmd: string =
-      'openssl req -x509 ' +
-      '-passout env:CERT_PASSPHRASE ' +
-      '-newkey rsa:2048 ' +
-      `-days ${certValidFor} ` +
-      '-extensions v3_ca ' +
-      `-keyout ${keyFile} -out ${crtFile} ` +
-      `-subj ${subject.toString()}`;
+    const args = [
+      'req', '-x509',
+      '-passout', 'env:CERT_PASSPHRASE',
+      '-newkey', 'rsa:2048',
+      '-days', certValidFor.toString(),
+      '-extensions', 'v3_ca',
+      '-keyout', keyFile,
+      '-out', crtFile,
+      '-subj', subject.toString(),
+    ];
 
-    console.debug(`Running: ${cmd}`);
-    await exec(cmd, { env: { CERT_PASSPHRASE: passphrase, PATH: process.env.PATH } });
+    console.debug(`Running: openssl ${args.join(' ')}`);
+    await execFile('openssl', args, { env: { CERT_PASSPHRASE: passphrase, PATH: process.env.PATH } });
 
     const cert: string = await readAsciiFile(crtFile);
     const key: string = await readAsciiFile(keyFile);
@@ -133,25 +136,30 @@ export class Certificate implements ICertificate {
     const crtFile: string = path.join(tmpDir, 'cert.crt');
     const keyFile: string = path.join(tmpDir, 'cert.key');
 
-    const certSigningRequest =
-            'openssl req ' +
-            '-passout env:CERT_PASSPHRASE ' +
-            '-newkey rsa:2048 ' +
-            `-days ${certValidFor} ` +
-            `-out ${csrFile} -keyout ${keyFile} ` +
-            `-subj ${subject.toString()}`;
-    const crtCreate =
-            'openssl x509 -sha256 -req ' +
-            '-passin env:SIGNING_PASSPHRASE ' +
-            `-days ${certValidFor} ` +
-            `-in ${csrFile} ` +
-            `-CA ${signingCertFile} -CAkey ${signingKeyFile} -CAcreateserial ` +
-            `-out ${crtFile}`;
+    const csrArgs = [
+      'req',
+      '-passout', 'env:CERT_PASSPHRASE',
+      '-newkey', 'rsa:2048',
+      '-days', certValidFor.toString(),
+      '-out', csrFile,
+      '-keyout', keyFile,
+      '-subj', subject.toString(),
+    ];
+    const crtArgs = [
+      'x509', '-sha256', '-req',
+      '-passin', 'env:SIGNING_PASSPHRASE',
+      '-days', certValidFor.toString(),
+      '-in', csrFile,
+      '-CA', signingCertFile,
+      '-CAkey', signingKeyFile,
+      '-CAcreateserial',
+      '-out', crtFile,
+    ];
 
-    console.debug(`Running: ${certSigningRequest}`);
-    await exec(certSigningRequest, { env: { CERT_PASSPHRASE: passphrase, PATH: process.env.PATH }});
-    console.debug(`Running: ${crtCreate}`);
-    await exec(crtCreate, { env: { PATH: process.env.PATH, SIGNING_PASSPHRASE: signingCertificate.passphrase }});
+    console.debug(`Running: openssl ${csrArgs.join(' ')}`);
+    await execFile('openssl', csrArgs, { env: { CERT_PASSPHRASE: passphrase, PATH: process.env.PATH }});
+    console.debug(`Running: openssl ${crtArgs.join(' ')}`);
+    await execFile('openssl', crtArgs, { env: { PATH: process.env.PATH, SIGNING_PASSPHRASE: signingCertificate.passphrase }});
 
     const cert: string = await readAsciiFile(crtFile);
     const key: string = await readAsciiFile(keyFile);
@@ -188,10 +196,17 @@ export class Certificate implements ICertificate {
       await writeAsciiFile(keyFileName, this.key);
 
       const pkcs12FileName: string = path.join(tmpDir, 'cert.p12');
-      const command: string = 'openssl pkcs12 -export -nodes -passin env:PASSIN -passout env:PASSOUT ' +
-        `-out ${pkcs12FileName} -inkey ${keyFileName} -in ${crtFileName}`;
-      await exec(
-        command,
+      const args = [
+        'pkcs12', '-export', '-nodes',
+        '-passin', 'env:PASSIN',
+        '-passout', 'env:PASSOUT',
+        '-out', pkcs12FileName,
+        '-inkey', keyFileName,
+        '-in', crtFileName,
+      ];
+      await execFile(
+        'openssl',
+        args,
         { env: {
           PASSIN: this.passphrase,
           PASSOUT: passphrase,

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/x509-certs/test/certificate.test.ts
@@ -277,3 +277,26 @@ test('decrypt private key', async () => {
   // OpenSSL 1.1.x: -----BEGIN PRIVATE KEY-----
   expect(decryptedKey).toMatch(/-----BEGIN (?:RSA )?PRIVATE KEY-----/);
 });
+
+test('generate self-signed does not execute shell metacharacters in CN', async () => {
+  // GIVEN - a CN with shell metacharacters that would execute a command if passed through a shell
+  const markerFile = path.join(tmpDir, 'injection_marker');
+  const name: DistinguishedName = new DistinguishedName({
+    CN: `test$(touch ${markerFile})`,
+    O: 'TestO',
+    OU: 'TestOU',
+  });
+  const passphrase = 'test_passphrase';
+
+  // WHEN - generating a certificate (this may fail due to invalid CN characters, which is acceptable)
+  try {
+    await Certificate.fromGenerated(name, passphrase);
+  } catch (e) {
+    // It's acceptable for certificate generation to fail with invalid characters.
+    // The important thing is that the shell command was NOT executed.
+  }
+
+  // THEN - the marker file must NOT exist, proving shell injection did not occur
+  const markerExists = fs.existsSync(markerFile);
+  expect(markerExists).toBe(false);
+});

--- a/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/handlers.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/x509-certificate/handlers.ts
@@ -176,6 +176,9 @@ export class X509CertificateGenerator extends X509Common {
     ]);
 
     const subject = new DistinguishedName(resourceProperties.DistinguishedName);
+    if (!subject.isValid()) {
+      throw new Error('Invalid characters in certificate subject fields. Distinguished name fields must not contain \'/\'.');
+    }
     const passphrase = await Secret.fromArn(resourceProperties.Passphrase, this.secretsManagerClient).getValue() as string;
     let certExpiry: number = resourceProperties.CertificateValidFor ? Number(resourceProperties.CertificateValidFor) : 1095;
     let signingCert: Certificate | undefined;


### PR DESCRIPTION
## Summary

Replace all `child_process.exec()` calls with `child_process.execFile()` in the X509 certificate Lambda to prevent OS command injection via crafted Distinguished Name fields.

## Changes

- `certificate.ts`: Replace 5 instances of `exec(cmd)` with `execFile('openssl', args)` — eliminates shell interpretation of arguments
- `handlers.ts`: Add `subject.isValid()` input validation as defense-in-depth
- `certificate.test.ts`: Add test proving shell metacharacters in CN are not executed

## Testing

Full `yarn build+test` passes in Linux container (`node:18`) per CONTRIBUTING.md:

```
Test Suites: 62 passed, 62 total
Tests:       1281 passed, 1281 total
Snapshots:   0 total

Statements   : 97.88% ( 3333/3405 )
Branches     : 94.83% ( 1047/1104 )
Functions    : 96.99% ( 516/532 )
Lines        : 98.04% ( 3213/3277 )

Python tests: 21/21 pass
```

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*