### PR TITLE
fix: use SafeLoader for yaml.load in MongoDB setup scripts

### DIFF
--- a/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodLiveConfig.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodLiveConfig.py
@@ -95,7 +95,7 @@ def modify_net_options(mongod_conf):
   ssl_conf['PEMKeyFile'] = '/etc/mongod_certs/key.pem'
 
 def main():
-  mongod_conf = yaml.load(sys.stdin)
+  mongod_conf = yaml.load(sys.stdin, Loader=yaml.SafeLoader)
   modify_security(mongod_conf)
   modify_net_options(mongod_conf)
   print(yaml.dump(mongod_conf, default_flow_style=False))

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodNoAuth.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodNoAuth.py
@@ -78,7 +78,7 @@ def modify_network(mongod_conf):
     pass
 
 def main():
-  mongod_conf = yaml.load(sys.stdin)
+  mongod_conf = yaml.load(sys.stdin, Loader=yaml.SafeLoader)
   modify_security(mongod_conf)
   modify_network(mongod_conf)
   print(yaml.dump(mongod_conf, default_flow_style=False))

--- a/packages/aws-rfdk/lib/core/test/asset-constants.ts
+++ b/packages/aws-rfdk/lib/core/test/asset-constants.ts
@@ -38,5 +38,5 @@ export const INSTALL_MONGODB_8_0_SCRIPT_LINUX = {
 
 export const MONGODB_8_0_CONFIGURATION_SCRIPTS = {
   Bucket: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-  Key: 'c1c40e6ac96769539de343b85ef12d12399dfedfdc4cb3129af6205d76953dfb',
+  Key: 'ea54c3ebdc417d7cc0fae38dd2c0693386a3121edea09ec7454a36e1f72d5ce2',
 };


### PR DESCRIPTION
## Summary

Replace `yaml.load(sys.stdin)` with `yaml.load(sys.stdin, Loader=yaml.SafeLoader)` in two MongoDB configuration scripts to prevent unsafe deserialization.

## Files Changed

- `packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodNoAuth.py` (line 81)
- `packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodLiveConfig.py` (line 98)

## Why

Using `yaml.load()` without a Loader is unsafe as it can execute arbitrary Python objects during deserialization. `SafeLoader` restricts deserialization to simple Python types (dicts, lists, strings, numbers), which is all that's needed for MongoDB config YAML.

## Testing

The MongoDB config files these scripts process are simple key-value YAML — no custom Python types are used. SafeLoader handles this correctly.