### PR TITLE
chore(deps): bumping cdk from 2.163.0 to 2.168.0

### DIFF
--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="package"),
 
     install_requires=[
-        "aws-cdk-lib==2.163.0",
+        "aws-cdk-lib==2.168.0",
         "aws-rfdk==1.6.0"
     ],
 

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/package.json
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/package.json
@@ -19,7 +19,7 @@
     "typescript": "~5.4.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "aws-rfdk": "1.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/python/setup.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/python/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="package"),
 
     install_requires=[
-        "aws-cdk-lib==2.163.0",
+        "aws-cdk-lib==2.168.0",
         "aws-rfdk==1.6.0"
     ],
 

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/package.json
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/ts/package.json
@@ -24,7 +24,7 @@
     "typescript": "~5.4.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.189.1",
+    "aws-cdk-lib": "2.168.0",
     "aws-rfdk": "1.6.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/examples/deadline/EC2-Image-Builder/python/setup.py
+++ b/examples/deadline/EC2-Image-Builder/python/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="package"),
 
     install_requires=[
-        "aws-cdk-lib==2.163.0",
+        "aws-cdk-lib==2.168.0",
         "aws-rfdk==1.6.0",
     ],
 

--- a/examples/deadline/EC2-Image-Builder/ts/package.json
+++ b/examples/deadline/EC2-Image-Builder/ts/package.json
@@ -20,7 +20,7 @@
     "typescript": "~5.4.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.189.1",
+    "aws-cdk-lib": "2.168.0",
     "aws-rfdk": "1.6.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/examples/deadline/Local-Zone/python/setup.py
+++ b/examples/deadline/Local-Zone/python/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="package"),
 
     install_requires=[
-        "aws-cdk-lib==2.163.0",
+        "aws-cdk-lib==2.168.0",
         "aws-rfdk==1.6.0"
     ],
 

--- a/examples/deadline/Local-Zone/ts/package.json
+++ b/examples/deadline/Local-Zone/ts/package.json
@@ -19,7 +19,7 @@
     "typescript": "~5.4.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "aws-rfdk": "1.6.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/integ/package.json
+++ b/integ/package.json
@@ -57,7 +57,7 @@
     "@types/node": "18.11.19",
     "@typescript-eslint/eslint-plugin": "^8.24.0",
     "@typescript-eslint/parser": "^8.32.0",
-    "aws-cdk": "2.163.0",
+    "aws-cdk": "2.1132.0",
     "eslint": "^8.57.1",
     "eslint-import-resolver-node": "^0.3.9",
     "eslint-import-resolver-typescript": "^4.4.4",
@@ -75,12 +75,12 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.940.0",
     "@aws-sdk/client-secrets-manager": "^3.946.0",
     "@aws-sdk/client-ssm": "^3.907.0",
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "aws-rfdk": "1.6.0",
     "constructs": "^10.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "aws-rfdk": "1.6.0",
     "constructs": "^10.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/util-dynamodb": "^3.902.0",
     "@types/jest": "^29.5.14",
     "@types/node": "18.11.19",
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "constructs": "^10.0.0",
     "fs-extra": "^11.3.2",
     "jest": "^29.7.0",

--- a/packages/aws-rfdk/lib/core/test/deployment-instance.test.ts
+++ b/packages/aws-rfdk/lib/core/test/deployment-instance.test.ts
@@ -20,7 +20,7 @@ import {
 } from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { ILogGroup } from 'aws-cdk-lib/aws-logs';
-import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Asset } from 'aws-cdk-lib/aws-s3-assets';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import {Construct} from 'constructs';
@@ -57,6 +57,8 @@ describe('DeploymentInstance', () => {
     let vpc: Vpc;
     let stack: cdk.Stack;
     let target: DeploymentInstance;
+    let cloudWatchAgentInstallerBucket: IBucket;
+    let rfdkExternalDepsBucket: IBucket;
 
     beforeAll(() => {
       // GIVEN
@@ -67,6 +69,11 @@ describe('DeploymentInstance', () => {
       target = new DeploymentInstance(stack, DEFAULT_CONSTRUCT_ID, {
         vpc,
       });
+      // These imported buckets must be created before any test synthesizes the app. Newer versions
+      // of aws-cdk-lib forbid modifying the construct tree (even adding imports) after the first
+      // synthesis, and Template.fromStack() synthesizes the app.
+      cloudWatchAgentInstallerBucket = Bucket.fromBucketArn(depStack, 'CloudWatchAgentInstallerBucket', `arn:aws:s3:::amazoncloudwatch-agent-${stack.region}`);
+      rfdkExternalDepsBucket = Bucket.fromBucketArn(depStack, 'RfdkExternalDependenciesBucket', `arn:aws:s3:::rfdk-external-dependencies-${stack.region}`);
     });
 
     describe('Auto-Scaling Group', () => {
@@ -366,9 +373,6 @@ describe('DeploymentInstance', () => {
       });
 
       test('can fetch the CloudWatch Agent installer from S3', () => {
-        // GIVEN
-        const cloudWatchAgentInstallerBucket = Bucket.fromBucketArn(depStack, 'CloudWatchAgentInstallerBucket', `arn:aws:s3:::amazoncloudwatch-agent-${stack.region}` );
-
         // THEN
         Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
           PolicyDocument: {
@@ -394,9 +398,6 @@ describe('DeploymentInstance', () => {
       });
 
       test('can fetch GPG installer from RFDK dependencies S3 bucket', () => {
-        // GIVEN
-        const rfdkExternalDepsBucket = Bucket.fromBucketArn(depStack, 'RfdkExternalDependenciesBucket', `arn:aws:s3:::rfdk-external-dependencies-${stack.region}` );
-
         // THEN
         Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
           PolicyDocument: {

--- a/packages/aws-rfdk/package.json
+++ b/packages/aws-rfdk/package.json
@@ -76,7 +76,7 @@
     "@types/aws-lambda": "^8.10.155",
     "@types/jest": "^29.5.14",
     "@types/sinon": "^21.0.0",
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-jest": "^4.1.0",
     "awslint": "2.68.0",
@@ -100,11 +100,11 @@
     "typescript": "~5.4.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "constructs": "^10.0.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.163.0",
+    "aws-cdk-lib": "2.168.0",
     "constructs": "^10.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/asset-awscli-v1@^2.2.202", "@aws-cdk/asset-awscli-v1@^2.2.208", "@aws-cdk/asset-awscli-v1@^2.2.229":
+"@aws-cdk/asset-awscli-v1@^2.2.208":
   version "2.2.290"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.290.tgz#8cd8b9d1c59a3327da3d89b6d15f5383543a2fef"
   integrity sha512-YNJgFMoPY6PYf4y1zw0iT9S3r1aoCmF5/2/96kGUTmCX14QIHF4S4tQHG8v7MRHwypPcqqRYibXDYMLAilwWJQ==
 
-"@aws-cdk/asset-kubectl-v20@^2.1.2", "@aws-cdk/asset-kubectl-v20@^2.1.3":
+"@aws-cdk/asset-kubectl-v20@^2.1.3":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.4.tgz#5b76656f651a192e8d28766a5bdf04c444905363"
   integrity sha512-Ps2MkmjYgMyflagqQ4dgTElc7Vwpqj8spw8dQVFiSeaaMPsuDSNsPax3/HjuDuwqsmLdaCZc6umlxYLpL0kYDA==
@@ -17,21 +17,13 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
-"@aws-cdk/cloud-assembly-schema@^38.0.0", "@aws-cdk/cloud-assembly-schema@^38.0.1":
+"@aws-cdk/cloud-assembly-schema@^38.0.1":
   version "38.0.1"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz#cdf4684ae8778459e039cd44082ea644a3504ca9"
   integrity sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==
   dependencies:
     jsonschema "^1.4.1"
     semver "^7.6.3"
-
-"@aws-cdk/cloud-assembly-schema@^41.0.0":
-  version "41.2.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz#c1ef513e1cc0528dbc05948ae39d5631306af423"
-  integrity sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==
-  dependencies:
-    jsonschema "~1.4.1"
-    semver "^7.7.1"
 
 "@aws-crypto/crc32@5.2.0":
   version "5.2.0"
@@ -6468,27 +6460,6 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.163.0:
-  version "2.163.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.163.0.tgz#14416fa6e06375ea85501c5b747485aa559b338a"
-  integrity sha512-JZEOtd0qnu2fP0X6/x7Sj/HhB5xKqjJ6Lkf0LFa2mR9dAg/31T73jrn56SbftYW+GVlPCd76DkQgl+CeW2gWcQ==
-  dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.202"
-    "@aws-cdk/asset-kubectl-v20" "^2.1.2"
-    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^38.0.0"
-    "@balena/dockerignore" "^1.0.2"
-    case "1.6.3"
-    fs-extra "^11.2.0"
-    ignore "^5.3.2"
-    jsonschema "^1.4.1"
-    mime-types "^2.1.35"
-    minimatch "^3.1.2"
-    punycode "^2.3.1"
-    semver "^7.6.3"
-    table "^6.8.2"
-    yaml "1.10.2"
-
 aws-cdk-lib@2.168.0:
   version "2.168.0"
   resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.168.0.tgz#f24cc174b55dcae0c69716ff5882d1a70814859b"
@@ -6508,26 +6479,6 @@ aws-cdk-lib@2.168.0:
     punycode "^2.3.1"
     semver "^7.6.3"
     table "^6.8.2"
-    yaml "1.10.2"
-
-aws-cdk-lib@2.189.1:
-  version "2.189.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.189.1.tgz#57681865d0ff138a26299066695c06c46329bcb7"
-  integrity sha512-9JU0yUr2iRTJ1oCPrHyx7hOtBDWyUfyOcdb6arlumJnMcQr2cyAMASY8HuAXHc8Y10ipVp8dRTW+J4/132IIYA==
-  dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.229"
-    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^41.0.0"
-    "@balena/dockerignore" "^1.0.2"
-    case "1.6.3"
-    fs-extra "^11.3.0"
-    ignore "^5.3.2"
-    jsonschema "^1.5.0"
-    mime-types "^2.1.35"
-    minimatch "^3.1.2"
-    punycode "^2.3.1"
-    semver "^7.7.1"
-    table "^6.9.0"
     yaml "1.10.2"
 
 aws-cdk@2.1132.0:
@@ -8409,15 +8360,6 @@ fs-extra@^11.2.0, fs-extra@^11.3.2:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.3.0:
-  version "11.3.6"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.6.tgz#f7cb80e9df550cd1db6f537fa5cdd568d3e70d10"
-  integrity sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -9993,15 +9935,10 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonschema@^1.4.1, jsonschema@^1.5.0:
+jsonschema@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
   integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
-
-jsonschema@~1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
-  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
 just-diff-apply@^5.2.0:
   version "5.5.0"
@@ -12305,7 +12242,7 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-table@^6.8.2, table@^6.9.0:
+table@^6.8.2:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"
   integrity sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,12 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/asset-awscli-v1@^2.2.202":
-  version "2.2.223"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.223.tgz#a7d4cb66fb64e5b8e5609591d2ff120898607595"
-  integrity sha512-a4eJHrzW0moUQR8wty2m0u93iabpQS3/8NviK6luaqYJ3Vog5LvSVJ4fGSGJD8B/7yQ7MlQWZ/DvFVFJz7nU4Q==
+"@aws-cdk/asset-awscli-v1@^2.2.202", "@aws-cdk/asset-awscli-v1@^2.2.208", "@aws-cdk/asset-awscli-v1@^2.2.229":
+  version "2.2.290"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.290.tgz#8cd8b9d1c59a3327da3d89b6d15f5383543a2fef"
+  integrity sha512-YNJgFMoPY6PYf4y1zw0iT9S3r1aoCmF5/2/96kGUTmCX14QIHF4S4tQHG8v7MRHwypPcqqRYibXDYMLAilwWJQ==
 
-"@aws-cdk/asset-awscli-v1@^2.2.229":
-  version "2.2.257"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.257.tgz#2c5bd5d3eba3463c6b4be6f40d96e45ab4d12ef5"
-  integrity sha512-8F3CfFWbaN1kgMpzCvqpLO948lEOvD5t++AGUnPNjNLPTkbdi1v8gY85HvrkXHvKkKjHrlo8u+twGmQb6le4FA==
-
-"@aws-cdk/asset-kubectl-v20@^2.1.2":
+"@aws-cdk/asset-kubectl-v20@^2.1.2", "@aws-cdk/asset-kubectl-v20@^2.1.3":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.4.tgz#5b76656f651a192e8d28766a5bdf04c444905363"
   integrity sha512-Ps2MkmjYgMyflagqQ4dgTElc7Vwpqj8spw8dQVFiSeaaMPsuDSNsPax3/HjuDuwqsmLdaCZc6umlxYLpL0kYDA==
@@ -22,7 +17,7 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
-"@aws-cdk/cloud-assembly-schema@^38.0.0":
+"@aws-cdk/cloud-assembly-schema@^38.0.0", "@aws-cdk/cloud-assembly-schema@^38.0.1":
   version "38.0.1"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz#cdf4684ae8778459e039cd44082ea644a3504ca9"
   integrity sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==
@@ -6494,6 +6489,27 @@ aws-cdk-lib@2.163.0:
     table "^6.8.2"
     yaml "1.10.2"
 
+aws-cdk-lib@2.168.0:
+  version "2.168.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.168.0.tgz#f24cc174b55dcae0c69716ff5882d1a70814859b"
+  integrity sha512-eZkXYJaCLKRY1XzFKWHPr/7vSMMRmhz8p2oZacfxzr6XrzWcD5xtoNx2qIf215jaAI5Hewg31AMGZvQRQVNajw==
+  dependencies:
+    "@aws-cdk/asset-awscli-v1" "^2.2.208"
+    "@aws-cdk/asset-kubectl-v20" "^2.1.3"
+    "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
+    "@aws-cdk/cloud-assembly-schema" "^38.0.1"
+    "@balena/dockerignore" "^1.0.2"
+    case "1.6.3"
+    fs-extra "^11.2.0"
+    ignore "^5.3.2"
+    jsonschema "^1.4.1"
+    mime-types "^2.1.35"
+    minimatch "^3.1.2"
+    punycode "^2.3.1"
+    semver "^7.6.3"
+    table "^6.8.2"
+    yaml "1.10.2"
+
 aws-cdk-lib@2.189.1:
   version "2.189.1"
   resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.189.1.tgz#57681865d0ff138a26299066695c06c46329bcb7"
@@ -6513,6 +6529,11 @@ aws-cdk-lib@2.189.1:
     semver "^7.7.1"
     table "^6.9.0"
     yaml "1.10.2"
+
+aws-cdk@2.1132.0:
+  version "2.1132.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.1132.0.tgz#d4fc844bf556f0da03f8048365cb2d77410f2f39"
+  integrity sha512-kcIzBZQO+2v+F97iaeI29fdOUQEx44wr0qDb9HXNqdU82V+1ZKI1KuFlHwH2nq7+6iNc1bu60se4hFf+2d7vXg==
 
 aws-cdk@2.163.0:
   version "2.163.0"
@@ -8379,10 +8400,19 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.2.0, fs-extra@^11.3.0, fs-extra@^11.3.2:
+fs-extra@^11.2.0, fs-extra@^11.3.2:
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.2.tgz#c838aeddc6f4a8c74dd15f85e11fe5511bfe02a4"
   integrity sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^11.3.0:
+  version "11.3.6"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.6.tgz#f7cb80e9df550cd1db6f537fa5cdd568d3e70d10"
+  integrity sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"


### PR DESCRIPTION
### Why

`Runtime.NODEJS_22_X` — required to migrate the RFDK Lambda functions off the deprecated `nodejs18.x` runtime (follow-up PR) — does not exist in the pinned `aws-cdk-lib` 2.163.0. It was added in 2.168.0 (aws/aws-cdk#32104). This is the minimum bump that unblocks that migration.

2.168.0 is deliberately chosen as the smallest step that provides `NODEJS_22_X`:
- It keeps the existing jsii 5.4 toolchain, so no coordinated `AWS-RFDK-pipeline` jsii/doc-generation change is required.
- It retains Node.js 14+ build support (no consumer build-environment break).

A separate, larger upgrade to a security-current CDK (>= 2.246.0, which fixes GHSA-999r-qq7v-r334 / GHSA-vcrf-j523-4mrf) plus the jsii 5.9 toolchain and its pipeline-sync is tracked as a follow-up; it is intentionally out of scope here so the runtime migration is not blocked on it.

### Changes

- `aws-cdk-lib` 2.163.0 → 2.168.0 across the root, `packages/aws-rfdk`, `integ`, all example `ts/package.json`, and all example `python/setup.py` files (per the RFDK UpdatingDependencies procedure). `constructs`, `jsii`, and `typescript` are unchanged (2.168.0 uses the same versions RFDK already pins).
- `deployment-instance.test.ts`: hoist the imported S3 buckets into `beforeAll`; `aws-cdk-lib` >= 2.167 forbids modifying the construct tree after the first synthesis (`Synthesis has been called multiple times`).
- Peer dependencies aligned via `scripts/fix-peer-deps.sh`.

### Verification

- Full workspace build: 1281/1281 unit tests across 62 suites; lint and pkglint clean.
- All four TypeScript example apps build (the base build script does not build the examples).
- Integration tests (repository, renderQueue, workerFleetHttps) run against a test sandbox: all stack types deploy from 2.168.0-synthesized templates; renderQueue functional suite passes 10/10 including TLS. Two pre-existing, unrelated failures were observed and excluded (reproduce without this change): a repository log-content test asserting on an `eventId` field the `GetLogEvents` API does not return, and worker fleet ASGs failing to launch a published basic-worker AMI that returns 403. Both will be filed separately.

### Consumer impact

The `aws-cdk-lib` peerDependency moves 2.163.0 → 2.168.0; consumers update their app's `aws-cdk-lib` accordingly when adopting the release containing this change. No minimum-Node change.
