### PR TITLE
fix(integ): avoid SSM throttling in canary test polling

### DIFF
--- a/integ/components/deadline/common/functions/awaitSsmCommand.ts
+++ b/integ/components/deadline/common/functions/awaitSsmCommand.ts
@@ -10,7 +10,12 @@ declare global {
   interface ReadableStream {}
 }
 
-const ssm = new SSM({});
+// Adaptive retry (client-side rate limiting) + more attempts so the polling below rides
+// through SSM ThrottlingExceptions under parallel, long-running test load.
+const ssm = new SSM({
+  maxAttempts: 10,
+  retryMode: 'adaptive',
+});
 
 interface CommandResponse {
   output: string;
@@ -30,8 +35,8 @@ export async function ssmCommand(bastionId: string, params: SendCommandRequest):
       Details: true,
     };
     while (true) {
-      // Sleep for 1,000ms = 1s
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // Poll every 5s to keep the SSM call rate down and avoid throttling.
+      await new Promise(resolve => setTimeout(resolve, 5000));
 
       const invocations = await ssm.listCommandInvocations(listParams);
       if (invocations.CommandInvocations![0]) {


### PR DESCRIPTION
### Why

The RFDK integration-test canaries (both `rfdk-canaries` and `rfdk-mainline-canaries-test`) fail deterministically on `deadline_03_workerFleetHttp` — the **Windows** worker tests (WF-2-x) — with:

```
ThrottlingException: Rate exceeded
  at ssm.listCommandInvocations (components/deadline/common/functions/awaitSsmCommand.ts:36)
```

The Linux worker tests (WF-1-x) in the same suite pass.

### Root cause

`ssmCommand()` polls `ssm.listCommandInvocations` in a busy loop with a **1-second** interval until the command finishes. Windows worker bring-up/job assignment is long-running, so those tests issue far more polls than the Linux ones. With the canary running suites in parallel (`RUN_TESTS_IN_PARALLEL=true`), the aggregate `listCommandInvocations` rate exceeds the account's SSM API limit. The default client (`new SSM({})` — standard retry, `maxAttempts=3`) can't absorb the sustained throttling, so it throws and fails the test.

This is test-infra flakiness independent of any runtime/product change; it only surfaced now that the canaries run again after the `--experimental-vm-modules` fix.

### What

`integ/components/deadline/common/functions/awaitSsmCommand.ts`:

- Configure the SSM client with **`retryMode: 'adaptive'`** (adds client-side rate limiting in response to throttling) and **`maxAttempts: 10`**.
- Increase the poll interval **1s → 5s** to cut `listCommandInvocations` call volume ~5×.

### Testing

- `tsc --noEmit` on the changed file passes.
- **Validated end-to-end via a full integration-test canary run against this branch** (test infra deployed/torn down in the RFDK test sandbox). All suites passed with **no `ThrottlingException`**:

  | Suite | Result |
  | --- | --- |
  | `deadline_01_repository` | 21/21 passed |
  | `deadline_02_renderQueue` | 10/10 passed |
  | `deadline_03_workerFleetHttp` | **8/8 passed** (incl. Windows `WF-2-1..4`, previously throttled) |
  | `deadline_04_workerFleetHttps` | 8/8 passed |
  | `deadline_05_secretsManagement` | 7/7 passed |

  Plus unit tests 1282/1282 and 21 python tests. The previously-failing Windows worker tests (`WF-2-x`) completed cleanly, confirming the throttling is resolved under the exact parallel-execution conditions that caused it.
