### PR TITLE
docs: fix stale documentation links

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -16,7 +16,7 @@ This repository's issues are intended for feature requests and bug reports.
 Ask your question here. Include any details relevant. Make sure you are not
 falling prey to the [X/Y problem][2]!
 
-[2]: http://xyproblem.info
+[2]: https://xyproblem.info/
 -->
 
 ### Environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ the minimum officially supported version that RFDK now supports. See our documen
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.2.0.10](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.2.0.10](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -164,7 +164,7 @@ GitHub release along with documentation and guidance on navigating the change.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.23.6](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.23.6](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### ⚠ BREAKING CHANGES
@@ -197,7 +197,7 @@ code change in your applications.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.21.4](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.21.4](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### ⚠ BREAKING CHANGES
@@ -219,7 +219,7 @@ changed to Node.js 14
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.20.3](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.20.3](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 ## [0.40.0](https://github.com/aws/aws-rfdk/compare/v0.39.0...v0.40.0) (2022-01-06)
 
@@ -231,7 +231,7 @@ changed to Node.js 14
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.20.2](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.20.2](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### ⚠ BREAKING CHANGES
@@ -261,7 +261,7 @@ on the HealthMonitor and WorkerInstanceFleet constructs were removed.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.19.4](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.19.4](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Bug Fixes
@@ -279,12 +279,12 @@ on the HealthMonitor and WorkerInstanceFleet constructs were removed.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.19.4](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.19.4](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### ⚠ BREAKING CHANGES
 
-RFDK will configure Deadline Secrets Management automatically when using Deadline 10.1.19.x or higher. If your CDK app uses the `Repository` construct with an un-pinned [`VersionQuery`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.VersionQuery.html), then upgrading RFDK will set up Deadline Secrets Management. Using Deadline Secrets Management is strongly encouraged for securing Deadline render farms, however it can potentially impact your workflows within Deadline. Please review the [Deadline Secrets Management documentation](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) to learn about the feature.
+RFDK will configure Deadline Secrets Management automatically when using Deadline 10.1.19.x or higher. If your CDK app uses the `Repository` construct with an un-pinned [`VersionQuery`](https://docs.aws.amazon.com/rfdk/api/latest/docs/aws-rfdk.deadline.VersionQuery.html), then upgrading RFDK will set up Deadline Secrets Management. Using Deadline Secrets Management is strongly encouraged for securing Deadline render farms, however it can potentially impact your workflows within Deadline. Please review the [Deadline Secrets Management documentation](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/secrets-management/deadline-secrets-management.html) to learn about the feature.
 
 See the [RFDK 0.38.x upgrade documentation](https://github.com/aws/aws-rfdk/blob/v0.38.0/packages/aws-rfdk/docs/upgrade/upgrading-0.38.md)
 for more details and guidance on how to upgrade.
@@ -316,7 +316,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.17.4](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.17.4](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### ⚠ BREAKING CHANGES
@@ -355,7 +355,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.17.4](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.17.4](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -378,7 +378,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.16.8](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.16.8](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Bug Fixes
@@ -396,7 +396,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.16.8](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.16.8](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -413,7 +413,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.15.2](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.15.2](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Bug Fixes
@@ -432,7 +432,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.15.2](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.15.2](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 ## [0.31.0](https://github.com/aws/aws-rfdk/compare/v0.30.0...v0.31.0) (2021-05-11)
 
@@ -444,7 +444,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.15.2](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.15.2](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Bug Fixes
@@ -461,7 +461,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.14.5](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.14.5](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -480,7 +480,7 @@ for more details and guidance on how to upgrade.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.14.5](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.14.5](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### ⚠ BREAKING CHANGES
@@ -518,7 +518,7 @@ our examples for an illustration of the code update required.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.14.5](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.14.5](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -540,14 +540,14 @@ our examples for an illustration of the code update required.
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.14.4](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.14.4](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Security Notice
 
 RFDK version 0.27.x and later include security enhancements.  We recommend you upgrade RFDK and Deadline to further restrict the permissions required for RFDK & Deadline to function. Please upgrade the version of RFDK used in your CDK application to 0.27.x, and configure your application to deploy Deadline 10.1.14.x or later to resolve the issue.
 
-If you have an existing deployment that was built with RFDK versions 0.26.x or earlier, you will need to upgrade to RFDK 0.27.x and Deadline 10.1.14.x or later before June 10, 2021 @ 1:00PM PST/ 3:00PM CST/ 4:00PM EST. Failure to upgrade by the above date may result in disruptions to your render farm. If you have any questions, please contact AWS Thinkbox Customer Support at https://support.thinkboxsoftware.com/.
+If you have an existing deployment that was built with RFDK versions 0.26.x or earlier, you will need to upgrade to RFDK 0.27.x and Deadline 10.1.14.x or later before June 10, 2021 @ 1:00PM PST/ 3:00PM CST/ 4:00PM EST. Failure to upgrade by the above date may result in disruptions to your render farm. If you have any questions, please contact AWS Thinkbox Customer Support at https://awsthinkbox.zendesk.com/hc/en-us.
 
 ### ⚠ BREAKING CHANGES
 
@@ -572,7 +572,7 @@ If you have an existing deployment that was built with RFDK versions 0.26.x or e
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.13.2](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.13.2](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -598,7 +598,7 @@ If you have an existing deployment that was built with RFDK versions 0.26.x or e
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.13.1](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.13.1](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -615,7 +615,7 @@ If you have an existing deployment that was built with RFDK versions 0.26.x or e
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.12.1](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.12.1](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Bug Fixes
@@ -632,7 +632,7 @@ If you have an existing deployment that was built with RFDK versions 0.26.x or e
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.12.1](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.12.1](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -650,7 +650,7 @@ If you have an existing deployment that was built with RFDK versions 0.26.x or e
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.12.1](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.12.1](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -672,7 +672,7 @@ If you have an existing deployment that was built with RFDK versions 0.26.x or e
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.11.5](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.11.5](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features
@@ -700,7 +700,7 @@ If you have an existing deployment that was built with RFDK versions 0.26.x or e
 
 ### Officially Supported Deadline Versions
 
-* [10.1.9.2 to 10.1.11.5](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/release-notes.html)
+* [10.1.9.2 to 10.1.11.5](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/release-notes.html)
 
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,7 @@ We have two styles of test in the RFDK.
 
 Create a commit with the proposed changes:
 
-- Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org).
+- Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org/).
   - The title must begin with `feat(module): title`, `fix(module): title`, `refactor(module): title` or
     `chore(module): title`. Our module titles are:
     - `core` -- for code related to constructs under `packages/aws-rfdk/lib/core`.
@@ -314,7 +314,7 @@ errors. CDK is using fixed dependencies for all their packages so we have no
 reasonable way to allow nonfixed dependencies as well.
 
 If you want to learn more about dependencies you can read the
-[yarn docs](https://yarnpkg.com/lang/en/docs/dependency-types/).
+[yarn docs](https://classic.yarnpkg.com/en/docs/dependency-types/).
 
 ### A package's `package.json`
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ using the power of Python and Typescript.
 
 The RFDK is available in:
 - Javascript, Typescript ([Node.js >= 18.0.0](https://nodejs.org/download/release/latest-v18.x/) officially supported, [Node.js >= 14.15.0](https://nodejs.org/download/release/latest-v14.x/) unofficially supported)
-  - We recommend using an [Active LTS Release](https://nodejs.org/en/about/releases/)
+  - We recommend using an [Active LTS Release](https://nodejs.org/en/about/previous-releases)
 - Python ([Python >= 3.6](https://www.python.org/downloads/))
 
 Note: Language version compatibility is the greater of those listed above and
@@ -40,7 +40,7 @@ reported the issue. Please try to include as much information as you can. Detail
 
 ## Security issue notifications
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
 ## Contributing
 
@@ -58,4 +58,4 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+We may ask you to sign a [Contributor License Agreement (CLA)](https://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/README.md
@@ -111,7 +111,7 @@ The Health Monitor component contains a [Network Load Balancer](https://docs.aws
 
 #### Bastion Host
 
-The Bastion Host is a `BastionHostLinux` construct that allows you to connect to the Render Queue and Worker Fleet if you would like to take a look at the state of these components. It is not an essential component to the render farm, so it can be omitted without side effects, if desired. To connect to it, please refer to [Bastion Hosts CDK documentation](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-ec2-readme.html#bastion-hosts).
+The Bastion Host is a `BastionHostLinux` construct that allows you to connect to the Render Queue and Worker Fleet if you would like to take a look at the state of these components. It is not an essential component to the render farm, so it can be omitted without side effects, if desired. To connect to it, please refer to [Bastion Hosts CDK documentation](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2-readme.html#bastion-hosts).
 
 ## Best Practices
 

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/README.md
@@ -110,7 +110,7 @@ These instructions assume that your working directory is `examples/deadline/All-
     # True = MongoDB, False = Amazon DocumentDB
     self.deploy_mongo_db: bool = False
     ```
-13. If you set `deploy_mongo_db` to `True`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `accept_sspl_license` in `package/config.py`:
+13. If you set `deploy_mongo_db` to `True`, then you must accept the [SSPL license](https://www.mongodb.com/legal/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `accept_sspl_license` in `package/config.py`:
 
     ```python
     # To accept the MongoDB SSPL, change from USER_REJECTS_SSPL to USER_ACCEPTS_SSPL

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/python/package/lib/storage_tier.py
@@ -180,7 +180,7 @@ class StorageTier(Stack):
         # 2) Uses RFDK's PadEfsStorage construct to add data to the EFS for the purpose of increasing the amount
         # of stored data to increase the baseline throughput.
         #
-        # See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html
+        # See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Alarms.html
         # for more information on AWS CloudWatch Alarms.
         # See: https://docs.aws.amazon.com/efs/latest/ug/performance.html#throughput-modes
         # for more information on Amazon EFS throughput modes.

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/README.md
@@ -105,7 +105,7 @@ These instructions assume that your working directory is `examples/deadline/All-
     // true = MongoDB, false = Amazon DocumentDB
     public readonly deployMongoDB: boolean = false;
     ```
-12. If you set `deployMongoDB` to `true`, then you must accept the [SSPL license](https://www.mongodb.com/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `acceptSsplLicense` in `bin/config.ts`:
+12. If you set `deployMongoDB` to `true`, then you must accept the [SSPL license](https://www.mongodb.com/legal/licensing/server-side-public-license) to successfully deploy MongoDB. To do so, change the value of `acceptSsplLicense` in `bin/config.ts`:
 
     ```ts
     // To accept the MongoDB SSPL, change from USER_REJECTS_SSPL to USER_ACCEPTS_SSPL

--- a/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
+++ b/examples/deadline/All-In-AWS-Infrastructure-Basic/ts/lib/storage-tier.ts
@@ -161,7 +161,7 @@ export abstract class StorageTier extends cdk.Stack {
     // 2) Uses RFDK's PadEfsStorage construct to add data to the EFS for the purpose of increasing the amount
     // of stored data to increase the baseline throughput.
     //
-    // See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html
+    // See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Alarms.html
     // for more information on AWS CloudWatch Alarms.
     // See: https://docs.aws.amazon.com/efs/latest/ug/performance.html#throughput-modes
     // for more information on Amazon EFS throughput modes.

--- a/examples/deadline/All-In-AWS-Infrastructure-SEP/README.md
+++ b/examples/deadline/All-In-AWS-Infrastructure-SEP/README.md
@@ -26,7 +26,7 @@ The Render Queue component contains the fleet of [Deadline Remote Connection Ser
 
 #### Spot Event Plugin Configurations
 
-Spot Event Plugin Configuration Setup component generates and saves the [Spot Fleet Request Configurations](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#spot-fleet-request-configurations). The Spot Workers that are created will be configured to connect to the Render Queue. The Spot Event Plugin requires additional Role for Deadline's Resource Tracker.
+Spot Event Plugin Configuration Setup component generates and saves the [Spot Fleet Request Configurations](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-fleet-configurations.html#event-spot-fleet-configurations-ref-label). The Spot Workers that are created will be configured to connect to the Render Queue. The Spot Event Plugin requires additional Role for Deadline's Resource Tracker.
 
 ## Prerequisites
 

--- a/examples/deadline/EC2-Image-Builder/README.md
+++ b/examples/deadline/EC2-Image-Builder/README.md
@@ -14,7 +14,7 @@ _**Note:** This application is an illustrative example to showcase some of the c
 
 ## Architecture
 
-This sample application uses an [EC2 ImageBuilder Image](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-image.html) to create an AMI in the DeadlineMachineImage stack that is used by the WorkerInstanceFleet in the same stack.
+This sample application uses an [EC2 ImageBuilder Image](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-imagebuilder-image.html) to create an AMI in the DeadlineMachineImage stack that is used by the WorkerInstanceFleet in the same stack.
 
 ### BaseFarmStack
 
@@ -28,7 +28,7 @@ The ComputeStack holds the images being created as well as the worker fleets the
 
 This construct creates all the infrastructure required by Image Builder to install Deadline onto an existing AMI and then create a WorkerInstanceFleet that uses it. The configuration for the image creation is as simple as providing the Deadline version, a parent AMI, the OS of the parent AMI, and a version number for your AMI. The parent AMI can be supplied by anything that supplied an `IMachineImage`, such as `MachineImage.genericLinux()` or `MachineImage.lookup()`. An image version also needs to be supplied. One strategy to use with versioning your image is to start with version `1.0.0` and bump the version if you need to change any of the input parameters, such as changing the parent AMI or Deadline version. Images for different OSes can be versioned separately.
 
-CDK does not have L2 constructs for Image Builder yet, so we are using the L1 constructs. An L1 construct is generated directly from the CloudFormation definition of the service, so referring to the [AWS CloudFormation user guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_ImageBuilder.html) will provide more details. You can read more about L1 vs L2 constructs in the [CDK Constructs user guide](https://docs.aws.amazon.com/cdk/latest/guide/constructs.html#constructs_lib).
+CDK does not have L2 constructs for Image Builder yet, so we are using the L1 constructs. An L1 construct is generated directly from the CloudFormation definition of the service, so referring to the [AWS CloudFormation user guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/AWS_ImageBuilder.html) will provide more details. You can read more about L1 vs L2 constructs in the [CDK Constructs user guide](https://docs.aws.amazon.com/cdk/v2/guide/constructs.html#constructs-lib-levels).
 
 #### Updates
 
@@ -47,7 +47,7 @@ An alternative to creating single images during the deployment of your render fa
 
 At this point in time, we do not provide Amazon-managed Deadline components for you to consume, so if you do choose to go this route, you would need to create a new version of your Deadline component for each release of Deadline, but you may decide this is worthwhile, depending on how many image variations you use for your workers. Due to the Image Builder pipeline still being an L1 construct in CDK, the AWS Console is recommended for building your pipeline.
 
-Once you have an image created from a pipeline, it can be consumed in your RFDK application using a [LookupMachineImage](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ec2.LookupMachineImage.html). The result of this lookup will always pick the most recent image if there are multiple matches, so you can always be sure that when your pipeline creates a newer image, your RFDK app deployment will pick it up. Note that the lookup stores the selected image in the CDK context, so if you would like to try and pick up a new image on an update deployment, you'll have to [clear the context](https://docs.aws.amazon.com/cdk/latest/guide/context.html#context_viewing) to get it.
+Once you have an image created from a pipeline, it can be consumed in your RFDK application using a [LookupMachineImage](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.LookupMachineImage.html). The result of this lookup will always pick the most recent image if there are multiple matches, so you can always be sure that when your pipeline creates a newer image, your RFDK app deployment will pick it up. Note that the lookup stores the selected image in the CDK context, so if you would like to try and pick up a new image on an update deployment, you'll have to [clear the context](https://docs.aws.amazon.com/cdk/v2/guide/context.html#context-viewing) to get it.
 
 ## Typescript
 

--- a/examples/deadline/EC2-Image-Builder/python/package/lib/deadline_machine_image.py
+++ b/examples/deadline/EC2-Image-Builder/python/package/lib/deadline_machine_image.py
@@ -39,7 +39,7 @@ class ImageBuilderProps():
     deadline_version: str
 
     # The parent image of the image recipe. Can use static methods on MachineImage to find your AMI. See
-    # https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ec2.MachineImage.html for more details.
+    # https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.MachineImage.html for more details.
     parent_ami: IMachineImage
 
     # The image version must be bumped any time the image or any components are modified, otherwise

--- a/examples/deadline/EC2-Image-Builder/ts/lib/deadline-machine-image.ts
+++ b/examples/deadline/EC2-Image-Builder/ts/lib/deadline-machine-image.ts
@@ -39,7 +39,7 @@ export interface DeadlineMachineImageProps {
 
   /**
    * The parent image of the image recipe. Can use static methods on MachineImage to find your AMI. See
-   * https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ec2.MachineImage.html for more details.
+   * https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.MachineImage.html for more details.
    */
   readonly parentAmi: IMachineImage,
 

--- a/examples/deadline/Local-Zone/README.md
+++ b/examples/deadline/Local-Zone/README.md
@@ -30,7 +30,7 @@ The service tier contains the repository and render queue, both of which are pro
 
 #### Compute Tier
 
-This tier holds the worker fleet and its health monitor. The health monitor contains a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) used to perform application-level health checks and the worker fleet contains an [Auto Scaling Group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html). Currently, these services are available in all launched local zones, so the construct can be placed in those zones.
+This tier holds the worker fleet and its health monitor. The health monitor contains a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) used to perform application-level health checks and the worker fleet contains an [Auto Scaling Group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/auto-scaling-groups.html). Currently, these services are available in all launched local zones, so the construct can be placed in those zones.
 
 ## Typescript
 

--- a/examples/deadline/Local-Zone/python/package/lib/compute_tier.py
+++ b/examples/deadline/Local-Zone/python/package/lib/compute_tier.py
@@ -100,7 +100,7 @@ class ComputeTier(Stack):
             render_queue=props.render_queue,
             # Not all instance types will be available in local zones. For a list of the instance types
             # available in each local zone, you can refer to:
-            # https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/#AWS_Services
+            # https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/#aws-services
             # BURSTABLE3 is a T3; the third generation of burstable instances
             instance_type=InstanceType.of(InstanceClass.BURSTABLE3, InstanceSize.LARGE),
             worker_machine_image=props.worker_machine_image,

--- a/examples/deadline/Local-Zone/ts/lib/compute-tier.ts
+++ b/examples/deadline/Local-Zone/ts/lib/compute-tier.ts
@@ -114,7 +114,7 @@ export class ComputeTier extends cdk.Stack {
       keyName: props.keyPairName,
       // Not all instance types will be available in local zones. For a list of the instance types
       // available in each local zone, you can refer to:
-      // https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/#AWS_Services
+      // https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/#aws-services
       // BURSTABLE3 is a T3; the third generation of burstable instances
       instanceType: InstanceType.of(InstanceClass.BURSTABLE3, InstanceSize.LARGE),
       userDataProvider: new UserDataProvider(this, 'UserDataProvider'),

--- a/integ/README.md
+++ b/integ/README.md
@@ -22,7 +22,7 @@ To run all test suites:
 
           Should be set to `true` to accept the MongoDB SSPL. Setting this variable is
           considered acceptance of the terms of the
-          [SSPL license](https://www.mongodb.com/licensing/server-side-public-license).
+          [SSPL license](https://www.mongodb.com/legal/licensing/server-side-public-license).
     * *[Optional]* configuration for **all** Deadline test components:
       *   `DEADLINE_VERSION`  
 

--- a/integ/components/deadline/common/functions/awaitSsmCommand.ts
+++ b/integ/components/deadline/common/functions/awaitSsmCommand.ts
@@ -10,7 +10,12 @@ declare global {
   interface ReadableStream {}
 }
 
-const ssm = new SSM({});
+// Adaptive retry (client-side rate limiting) + more attempts so the polling below rides
+// through SSM ThrottlingExceptions under parallel, long-running test load.
+const ssm = new SSM({
+  maxAttempts: 10,
+  retryMode: 'adaptive',
+});
 
 interface CommandResponse {
   output: string;
@@ -30,8 +35,8 @@ export async function ssmCommand(bastionId: string, params: SendCommandRequest):
       Details: true,
     };
     while (true) {
-      // Sleep for 1,000ms = 1s
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // Poll every 5s to keep the SSM call rate down and avoid throttling.
+      await new Promise(resolve => setTimeout(resolve, 5000));
 
       const invocations = await ssm.listCommandInvocations(listParams);
       if (invocations.CommandInvocations![0]) {

--- a/packages/aws-rfdk/bin/stage-deadline.ts
+++ b/packages/aws-rfdk/bin/stage-deadline.ts
@@ -233,7 +233,7 @@ function validateBucketName(s3BucketName: string): boolean {
   if (!regExpForS3Bucket.test(s3BucketName)) {
     console.error(`S3 bucket name '${s3BucketName}' has invalid format.\
     Please follow S3 bucket naming requirements:\
-    https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html`);
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/BucketRestrictions.html`);
     return false;
   }
   return true;

--- a/packages/aws-rfdk/docs/DockerImageRecipes.md
+++ b/packages/aws-rfdk/docs/DockerImageRecipes.md
@@ -8,7 +8,7 @@ A stage directory must contain a `Dockerfile` and a manifest file at the root of
 
 **Dockerfile** - The Dockerfile that Docker uses to assemble container images from Docker recipes.
 
-**Manifest File** - This file contains meta-data about each recipe and is used by RFDK to build up the corresponding [DockerImageAsset](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ecr-assets.DockerImageAsset.html) objects. In addition to the recipe meta-data, it also includes other useful information, such as the schema version. For more information, see [Manifest File Schema](#manifest-file-schema).
+**Manifest File** - This file contains meta-data about each recipe and is used by RFDK to build up the corresponding [DockerImageAsset](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecr_assets.DockerImageAsset.html) objects. In addition to the recipe meta-data, it also includes other useful information, such as the schema version. For more information, see [Manifest File Schema](#manifest-file-schema).
 
 ## Docker Image Recipe Composition
 
@@ -31,7 +31,7 @@ The **recipe** contains instructions that use the items in the **context directo
 When using a recipe, RFDK runs the Dockerfile with the build arguments for that recipe from the manifest file. The Dockerfile will then use the configuration scripts and Deadline Client installer to build the Docker image that will be deployed.
 
 The Dockerfile can either be:
-- A Dockerfile that supports [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/), containing branches for each recipe
+- A Dockerfile that supports [multi-stage builds](https://docs.docker.com/build/building/multi-stage/), containing branches for each recipe
 - A common Dockerfile that is used by all recipes
 
 ## Manifest File Schema

--- a/packages/aws-rfdk/docs/diagrams/README.md
+++ b/packages/aws-rfdk/docs/diagrams/README.md
@@ -1,7 +1,7 @@
 RFDK Architecture Diagrams
 ==========================
 
-RFDK uses https://app.diagrams.net for our diagrams. We use the `.svg` file format and embed the draw.io diagram inside.
+RFDK uses https://app.diagrams.net/ for our diagrams. We use the `.svg` file format and embed the draw.io diagram inside.
 
 ## Directory Structure
 The following directory structure convention is used to place the architecture diagrams:

--- a/packages/aws-rfdk/docs/upgrade/upgrading-0.40.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-0.40.md
@@ -2,14 +2,14 @@
 
 ## SpotEventPluginFleet
 
-Starting in RFDK v0.40.0, the `SpotEventPluginFleet` construct now creates an [EC2 Launch Template](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html)
+Starting in RFDK v0.40.0, the `SpotEventPluginFleet` construct now creates an [EC2 Launch Template](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-templates.html)
 instead of using Launch Specifications. This change will reconfigure the Spot Event Plugin settings in Deadline to use a new Spot Fleet Request configuration. If you have active
 Spot Fleet Requests created by the Spot Event Plugin, upgrading to RFDK v0.40.x and redeploying your render farm will orphan those Spot Fleet Requests. Therefore, we highly
 recommend following these instructions to upgrade to RFDK v0.40.x:
 
 1. Disable the Spot Event Plugin in Deadline. Refer to the [Spot Event Plugin "State" option in Deadline](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-configuration-options.html)
 for more information.
-2. Cancel any Spot Fleet Requests created by the Spot Event Plugin, which you can do by following these [instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-spot-fleets.html#cancel-spot-fleet).
+2. Cancel any Spot Fleet Requests created by the Spot Event Plugin, which you can do by following these [instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/cancel-spot-fleet.html).
 3. Upgrade to RFDK v0.40.x and redeploy your render farm.
 4. Once the deployment is complete, re-enable the Spot Event Plugin in Deadline. Refer to the [Spot Event Plugin "State" option in Deadline](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-configuration-options.html)
 for more information.

--- a/packages/aws-rfdk/docs/upgrade/upgrading-1.5.md
+++ b/packages/aws-rfdk/docs/upgrade/upgrading-1.5.md
@@ -4,7 +4,7 @@
 
 Please backup your existing database before upgrading to RFDK 1.5.x.
 
-In RFDK versions >= 1.5.x, we upgraded the default DocumentDB engine version to 5.0.0. Note that you may lose data and your deployment may fail if you have existing stacks with previous DocumentDB versions. You will need to manually upgrade your existing DocumentDB cluster by following the documentation: https://docs.aws.amazon.com/documentdb/latest/developerguide/docdb-mvu.html
+In RFDK versions >= 1.5.x, we upgraded the default DocumentDB engine version to 5.0.0. Note that you may lose data and your deployment may fail if you have existing stacks with previous DocumentDB versions. You will need to manually upgrade your existing DocumentDB cluster by following the documentation: https://docs.aws.amazon.com/documentdb/latest/devguide/docdb-mvu.html
 
 ## Updating MongoDB
 

--- a/packages/aws-rfdk/lib/core/README.md
+++ b/packages/aws-rfdk/lib/core/README.md
@@ -92,11 +92,11 @@ configBuilder.addLogsCollectList('logGroupName',
 
 ---
 
-_**Note:** `CloudWatchAgent` by default will validate the `CloudWatch Agent` installer. If your deployments are failing due to a validation failure, but you have verified that the failure is benign, then you can set a context variable ```SKIP_CWAGENT_VALIDATION_CTX_VAR = 'RFDK_SKIP_CWAGENT_VALIDATION'``` to skip the validation step. Read more how to [set and get a value from a context variable](https://docs.aws.amazon.com/cdk/latest/guide/get_context_var.html)._
+_**Note:** `CloudWatchAgent` by default will validate the `CloudWatch Agent` installer. If your deployments are failing due to a validation failure, but you have verified that the failure is benign, then you can set a context variable ```SKIP_CWAGENT_VALIDATION_CTX_VAR = 'RFDK_SKIP_CWAGENT_VALIDATION'``` to skip the validation step. Read more how to [set and get a value from a context variable](https://docs.aws.amazon.com/cdk/v2/guide/context.html#context-methods)._
 
 ---
 
-_**Note:** The `CloudWatch Agent` installer is downloaded via the Amazon S3 API, thus, this construct can be used on instances that have no access to the internet as long as the [VPC contains an VPC Gateway Endpoint for S3](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-s3.html)._
+_**Note:** The `CloudWatch Agent` installer is downloaded via the Amazon S3 API, thus, this construct can be used on instances that have no access to the internet as long as the [VPC contains an VPC Gateway Endpoint for S3](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html)._
 
 ---
 
@@ -229,7 +229,7 @@ const healthMonitor = new HealthMonitor(stack, 'HealthMonitor', {
 
 ### Deletion Protection
 
-To prevent the load balancer from being deleted accidentally, `HealthMonitor` enables deletion protection for the load balancer. Hence, you will first need to disable deletion protection using AWS Console or CLI before deleting the stack ( see [deletion protection](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection) to learn how to do it ).
+To prevent the load balancer from being deleted accidentally, `HealthMonitor` enables deletion protection for the load balancer. Hence, you will first need to disable deletion protection using AWS Console or CLI before deleting the stack ( see [deletion protection](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes) to learn how to do it ).
 
 In order to disable deletion protection, you can use `deletionProtection` property:
 
@@ -252,7 +252,7 @@ MongoDB is installed from the official sources using the system package manger (
 
 Successful installation of MongoDB with this class requires:
 1) Explicit acceptance of the terms of the SSPL license, under which MongoDB is distributed
-2) The instance on which the installation is being performed is in a subnet that can access the official MongoDB sites: https://repo.mongodb.org/ and https://www.mongodb.org
+2) The instance on which the installation is being performed is in a subnet that can access the official MongoDB sites: https://repo.mongodb.org/ and https://www.mongodb.com/
 
 ```ts
 const installer = new MongoDbInstaller(stack, {
@@ -263,7 +263,7 @@ const installer = new MongoDbInstaller(stack, {
 
 ---
 
-_**Note:** MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/licensing/server-side-public-license ). Users of `MongoDbInstaller` must explicitly signify their acceptance of the terms of the SSPL through `userSsplAcceptance` property. By default, `userSsplAcceptance` is set to rejection._
+_**Note:** MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/legal/licensing/server-side-public-license ). Users of `MongoDbInstaller` must explicitly signify their acceptance of the terms of the SSPL through `userSsplAcceptance` property. By default, `userSsplAcceptance` is set to rejection._
 
 ---
 
@@ -313,7 +313,7 @@ const mongoDb = {
 
 ---
 
-_**Note:** MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/licensing/server-side-public-license ). Users of `MongoDbInstance` must explicitly signify their acceptance of the terms of the SSPL through `userSsplAcceptance` property. By default, `userSsplAcceptance` is set to rejection._
+_**Note:** MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/legal/licensing/server-side-public-license ). Users of `MongoDbInstance` must explicitly signify their acceptance of the terms of the SSPL through `userSsplAcceptance` property. By default, `userSsplAcceptance` is set to rejection._
 
 ---
 
@@ -329,7 +329,7 @@ const instance = new MongoDbInstance(stack, 'MongoDbInstance', {
 
 ### Changing Instance Type
 
-It is possible to change an instance type on which MongoDB is running. To learn more on instance types please visit https://aws.amazon.com/ec2/instance-types. By default, Amazon EC2 R5 Large instance will is used. You can change it through `instanceType` property:
+It is possible to change an instance type on which MongoDB is running. To learn more on instance types please visit https://aws.amazon.com/ec2/instance-types/. By default, Amazon EC2 R5 Large instance will is used. You can change it through `instanceType` property:
 
 ```ts
 const instance = new MongoDbInstance(stack, 'MongoDbInstance', {
@@ -506,7 +506,7 @@ Credentials and specifications for *password-authenticated users* should be stor
 }
 ```
 
-For examples of the roles list, see the MongoDB user creation documentation, like [Add Users](https://docs.mongodb.com/manual/tutorial/create-users/) tutorial.
+For examples of the roles list, see the MongoDB user creation documentation, like [Add Users](https://www.mongodb.com/docs/manual/tutorial/create-users/) tutorial.
 
 We will later create these these 2 *password-authenticated users* in the admin database:
 
@@ -534,7 +534,7 @@ The `certificate` must be a secret containing the plaintext string contents of t
 
 ---
 
-_**Note:** MongoDB **requires** that this username differ from the MongoDB server certificate in at least one of: Organization (O), Organizational Unit (OU), or Domain Component (DC). See: https://docs.mongodb.com/manual/tutorial/configure-x509-client-authentication/._
+_**Note:** MongoDB **requires** that this username differ from the MongoDB server certificate in at least one of: Organization (O), Organizational Unit (OU), or Domain Component (DC). See: <https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/>._
 
 ---
 
@@ -566,7 +566,7 @@ const postInstallSetup = new MongoDbPostInstallSetup(stack, 'MongoPostInstall', 
 
 It is often useful to run commands on your instance at launch. This is done using scripts that are executed through instance [user data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html).
 
-RFDK includes a `ScriptAsset` class that generalizes the concept of the script (bash or powershell) that executes on an instance. `ScriptAsset` is a wrapper around the [CDK's S3 Asset construct](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3-assets.Asset.html):
+RFDK includes a `ScriptAsset` class that generalizes the concept of the script (bash or powershell) that executes on an instance. `ScriptAsset` is a wrapper around the [CDK's S3 Asset construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3_assets.Asset.html):
 
 ```ts
 const scriptAsset = new ScriptAsset(stack, 'ScriptAsset', {
@@ -670,7 +670,7 @@ RFDK provides the following constructs for working with X509 certificates: `X509
 
 #### Self-Signed Certificate
 
-In order to generate a sef-signed certificate you need to provide an identification for a self-signed CA ( see [rfc1779](https://tools.ietf.org/html/rfc1779) or [the X.520 specification](https://www.itu.int/itu-t/recommendations/rec.aspx?rec=X.520) ) using the `subject` property:
+In order to generate a sef-signed certificate you need to provide an identification for a self-signed CA ( see [rfc1779](https://datatracker.ietf.org/doc/html/rfc1779) or [the X.520 specification](https://www.itu.int/itu-t/recommendations/rec.aspx?rec=X.520) ) using the `subject` property:
 
 ```ts
 const cert = new X509CertificatePem(stack, 'X509CertificatePem', {
@@ -793,7 +793,7 @@ After deploying, you can follow the AWS System Manager user guide on how to [Sta
 
 ### SSH Access
 
-It is not possible to access the instance via SSH, by default. You need to allow ingress access on port 22 from the machine(s)/IP(s) that you want to ssh from ( see [Authorizing inbound traffic for your Linux instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html) ).
+It is not possible to access the instance via SSH, by default. You need to allow ingress access on port 22 from the machine(s)/IP(s) that you want to ssh from ( see [Authorizing inbound traffic for your Linux instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-to-linux-instance.html) ).
 
 Also, you need to provide the name of the EC2 SSH keypair to grant access to the instance:
 
@@ -812,4 +812,4 @@ const server = new StaticPrivateIpServer(stack, 'StaticPrivateIpServer', {
 
 ### Amazon EC2 Instance Connect
 
-You can also use an [Amazon EC2 Instance Connect](https://aws.amazon.com/about-aws/whats-new/2019/06/introducing-amazon-ec2-instance-connect/). Please see [Connecting to your Linux instance using EC2 Instance Connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Connect-using-EC2-Instance-Connect.html) for more details.
+You can also use an [Amazon EC2 Instance Connect](https://aws.amazon.com/about-aws/whats-new/2019/06/introducing-amazon-ec2-instance-connect/). Please see [Connecting to your Linux instance using EC2 Instance Connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-linux-inst-eic.html) for more details.

--- a/packages/aws-rfdk/lib/core/lib/cloudwatch-agent.ts
+++ b/packages/aws-rfdk/lib/core/lib/cloudwatch-agent.ts
@@ -48,7 +48,7 @@ export interface CloudWatchAgentProps {
  * optionally verify the installer, and finally install the CloudWatch Agent.
  * The installer is downloaded via the Amazon S3 API, thus, this construct can be used
  * on instances that have no access to the internet as long as the VPC contains
- * an VPC Gateway Endpoint for S3 ( https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-s3.html ).
+ * an VPC Gateway Endpoint for S3 ( https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html ).
  *
  * {@link CloudWatchAgent.SKIP_CWAGENT_VALIDATION_CTX_VAR} - Context variable to skip validation
  * of the downloaded CloudWatch Agent installer if set to 'TRUE'.

--- a/packages/aws-rfdk/lib/core/lib/health-monitor.ts
+++ b/packages/aws-rfdk/lib/core/lib/health-monitor.ts
@@ -200,7 +200,7 @@ export interface HealthMonitorProps {
    *
    * Note: This value is true by default which means that the deletion protection is enabled for the
    * load balancer. Hence, user needs to disable it using AWS Console or CLI before deleting the stack.
-   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes
    */
   readonly deletionProtection?: boolean;
 

--- a/packages/aws-rfdk/lib/core/lib/mongodb-installer.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-installer.ts
@@ -27,14 +27,14 @@ import {
 export enum MongoDbVersion {
   /**
    * MongoDB 8.0 Community Edition.
-   * See: https://www.mongodb.com/docs/v8.0/introduction/
+   * See: https://www.mongodb.com/docs/v8.0
    */
   COMMUNITY_8_0 = '8.0',
 }
 
 /**
  * Choices for signifying the user's stance on the terms of the SSPL.
- * See: https://www.mongodb.com/licensing/server-side-public-license
+ * See: https://www.mongodb.com/legal/licensing/server-side-public-license
  */
 export enum MongoDbSsplLicenseAcceptance {
   /**
@@ -53,7 +53,7 @@ export enum MongoDbSsplLicenseAcceptance {
  */
 export interface MongoDbInstallerProps {
   /**
-   * MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/licensing/server-side-public-license ).
+   * MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/legal/licensing/server-side-public-license ).
    * Users of MongoDbInstaller must explicitly signify their acceptance of the terms of the SSPL through this
    * property before the {@link MongoDbInstaller} will be allowed to install MongoDB.
    *
@@ -80,7 +80,7 @@ export interface MongoDbInstallerProps {
  * Successful installation of MongoDB with this class requires:
  * 1) Explicit acceptance of the terms of the SSPL license, under which MongoDB is distributed; and
  * 2) The instance on which the installation is being performed is in a subnet that can access
- * the official MongoDB sites: https://repo.mongodb.org/ and https://www.mongodb.org
+ * the official MongoDB sites: https://repo.mongodb.org/ and https://www.mongodb.com/
  *
  * Resources Deployed
  * ------------------------
@@ -112,7 +112,7 @@ The MongoDbInstaller will install MongoDB Community Edition onto one or more EC2
 
 MongoDB is provided by MongoDB Inc. under the SSPL license. By installing MongoDB, you are agreeing to the terms of this license.
 Follow the link below to read the terms of the SSPL license.
-https://www.mongodb.com/licensing/server-side-public-license
+https://www.mongodb.com/legal/licensing/server-side-public-license
 
 By using the MongoDbInstaller to install MongoDB you agree to the terms of the SSPL license.
 
@@ -134,7 +134,7 @@ Please set the userSsplAcceptance property to USER_ACCEPTS_SSPL to signify your 
    *
    * Notes:
    * 1) The instance on which the installation is being performed must be in a subnet that can access
-   * the official MongoDB sites: https://repo.mongodb.org/ and https://www.mongodb.org; and
+   * the official MongoDB sites: https://repo.mongodb.org/ and https://www.mongodb.com/; and
    * 2) At this time, this method only supports installation onto instances that are running an operating system
    * that is compatible with x86-64 RedHat 7 -- this includes Amazon Linux 2, RedHat 7, and CentOS 7.
    *

--- a/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-instance.ts
@@ -125,7 +125,7 @@ export interface MongoDbInstanceVolumeProps {
  */
 export interface MongoDbApplicationProps {
   /**
-   * MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/licensing/server-side-public-license ).
+   * MongoDB Community edition is licensed under the terms of the SSPL (see: https://www.mongodb.com/legal/licensing/server-side-public-license ).
    * Users of MongoDbInstance must explicitly signify their acceptance of the terms of the SSPL through this
    * property before the {@link MongoDbInstance} will be allowed to install MongoDB.
    *

--- a/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
+++ b/packages/aws-rfdk/lib/core/lib/mongodb-post-install.ts
@@ -43,7 +43,7 @@ import {
 
 /**
  * User added to the $external admin database.
- * Referencing: https://docs.mongodb.com/v3.6/core/security-x.509/#member-certificate-requirements
+ * Referencing: https://www.mongodb.com/docs/manual/core/security-x.509#member-certificate-requirements
  */
 export interface MongoDbX509User {
   /**
@@ -54,7 +54,7 @@ export interface MongoDbX509User {
    * Some important notes:
    * 1. MongoDB **requires** that this username differ from the MongoDB server certificate
    * in at least one of: Organization (O), Organizational Unit (OU), or Domain Component (DC).
-   * See: https://docs.mongodb.com/manual/tutorial/configure-x509-client-authentication/
+   * See: https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/
    *
    * 2. The client certificate must be signed by the same Certificate Authority (CA) as the
    * server certificate that is being used by the MongoDB application.
@@ -74,7 +74,7 @@ export interface MongoDbX509User {
 export interface MongoDbUsers {
   /**
    * Zero or more secrets containing credentials, and specification for users to be created in the
-   * admin database for authentication using SCRAM. See: https://docs.mongodb.com/v3.6/core/security-scram/
+   * admin database for authentication using SCRAM. See: https://www.mongodb.com/docs/manual/core/security-scram/
    *
    * Each secret must be a JSON document with the following structure:
    *     {
@@ -84,7 +84,7 @@ export interface MongoDbUsers {
    *     }
    *
    * For examples of the roles list, see the MongoDB user creation documentation. For example,
-   * https://docs.mongodb.com/manual/tutorial/create-users/
+   * https://www.mongodb.com/docs/manual/tutorial/create-users/
    *
    * @default No password-authenticated users are created.
    */
@@ -92,7 +92,7 @@ export interface MongoDbUsers {
 
   /**
    * Information on the X.509-authenticated users that should be created.
-   * See: https://docs.mongodb.com/v3.6/core/security-x.509/
+   * See: https://www.mongodb.com/docs/manual/core/security-x.509
    *
    * @default No x.509 authenticated users are created.
    */

--- a/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-ebs.ts
@@ -55,7 +55,7 @@ export enum BlockVolumeFormat {
  */
 export interface MountableBlockVolumeProps {
   /**
-   * The {@link https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ec2.Volume.html|EBS Block Volume}
+   * The {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.Volume.html|EBS Block Volume}
    * that will be mounted by this object.
    */
   readonly blockVolume: IVolume;

--- a/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-efs.ts
@@ -37,7 +37,7 @@ import {
  */
 export interface MountableEfsProps {
   /**
-   * The {@link https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-efs.FileSystem.html|EFS}
+   * The {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_efs.FileSystem.html|EFS}
    * filesystem that will be mounted by the object.
    */
   readonly filesystem: efs.IFileSystem;

--- a/packages/aws-rfdk/lib/core/lib/mountable-filesystem.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-filesystem.ts
@@ -12,8 +12,8 @@ import { IScriptHost } from './script-assets';
 
 /**
  * An instance type that can mount an {@link IMountableFilesystem}. For example, this could be an
- * {@link https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ec2.Instance.html|EC2 Instance}
- * or an {@link https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-autoscaling.AutoScalingGroup.html|EC2 Auto Scaling Group}
+ * {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.Instance.html|EC2 Instance}
+ * or an {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_autoscaling.AutoScalingGroup.html|EC2 Auto Scaling Group}
  */
 export interface IMountingInstance extends IConnectable, IConstruct, IScriptHost {
 }

--- a/packages/aws-rfdk/lib/core/lib/mountable-fsx-lustre.ts
+++ b/packages/aws-rfdk/lib/core/lib/mountable-fsx-lustre.ts
@@ -32,7 +32,7 @@ import {
  */
 export interface MountableFsxLustreProps {
   /**
-   * The {@link https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-fsx.LustreFileSystem.html|FSx for Lustre}
+   * The {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_fsx.LustreFileSystem.html|FSx for Lustre}
    * filesystem that will be mounted by the object.
    */
   readonly filesystem: LustreFileSystem;
@@ -46,7 +46,7 @@ export interface MountableFsxLustreProps {
 
   /**
    * Extra Lustre mount options that will be added to /etc/fstab for the file system.
-   * See: {@link http://manpages.ubuntu.com/manpages/precise/man8/mount.lustre.8.html}
+   * See: {@link https://doc.lustre.org/lustre_manual.xhtml}
    *
    * The given values will be joined together into a single string by commas.
    * ex: ['soft', 'rsize=4096'] will become 'soft,rsize=4096'

--- a/packages/aws-rfdk/lib/core/lib/script-assets.ts
+++ b/packages/aws-rfdk/lib/core/lib/script-assets.ts
@@ -122,7 +122,7 @@ export interface ScriptAssetProps extends AssetProps {}
  * This is used by other constructs to generalize the concept of a script
  * (bash or powershell) that executes on an instance.
  * It provides a wrapper around the CDK’s S3 Asset construct
- * ( https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3-assets.Asset.html )
+ * ( https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3_assets.Asset.html )
  *
  * The script asset is placed into and fetched from the CDK bootstrap S3 bucket.
  *

--- a/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
+++ b/packages/aws-rfdk/lib/core/lib/x509-certificate.ts
@@ -43,7 +43,7 @@ import { IX509CertificateEncodePkcs12, IX509CertificateGenerate } from '../../la
 
 /**
  * The identification for a self-signed CA or Certificate.
- * These fields are industry standard, and can be found in rfc1779 (see: https://tools.ietf.org/html/rfc1779)
+ * These fields are industry standard, and can be found in rfc1779 (see: https://datatracker.ietf.org/doc/html/rfc1779)
  * or the X.520 specification (see: ITU-T Rec.X.520)
  */
 export interface DistinguishedName {

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodLiveConfig.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodLiveConfig.py
@@ -20,7 +20,7 @@ import yaml
 # mongod.conf
 
 # for documentation of all options, see:
-#   http://docs.mongodb.org/manual/reference/configuration-options/
+#   https://www.mongodb.com/docs/manual/reference/configuration-options/
 
 # where to write logging data.
 systemLog:
@@ -65,13 +65,13 @@ net:
 """
 
 def modify_security(mongod_conf):
-  # Reference: https://docs.mongodb.com/v3.6/reference/configuration-options/#security-options
+  # Reference: https://www.mongodb.com/docs/manual/reference/configuration-options/#security-options
   security_conf = mongod_conf.setdefault('security', {})
   security_conf['authorization'] = 'enabled'
 
 
 def modify_net_options(mongod_conf):
-  # Reference: https://docs.mongodb.com/v3.6/reference/configuration-options/#net-options
+  # Reference: https://www.mongodb.com/docs/manual/reference/configuration-options/#net-options
   net_conf = mongod_conf.setdefault('net', {})
 
   # Ensure the default port is in-use, or else our security groups

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodNoAuth.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodNoAuth.py
@@ -11,7 +11,7 @@
 # mongod.conf
 
 # for documentation of all options, see:
-#   http://docs.mongodb.org/manual/reference/configuration-options/
+#   https://www.mongodb.com/docs/manual/reference/configuration-options/
 
 # where to write logging data.
 systemLog:
@@ -59,12 +59,12 @@ import sys
 import yaml
 
 def modify_security(mongod_conf):
-  # Reference: https://docs.mongodb.com/v3.6/reference/configuration-options/#security-options
+  # Reference: https://www.mongodb.com/docs/manual/reference/configuration-options/#security-options
   security_conf = mongod_conf.setdefault('security', {})
   security_conf['authorization'] = 'disabled'
 
 def modify_network(mongod_conf):
-  # Reference: https://docs.mongodb.com/v3.6/reference/configuration-options/#net-options
+  # Reference: https://www.mongodb.com/docs/manual/reference/configuration-options/#net-options
   net_conf = mongod_conf.setdefault('net', {})
   net_conf['port'] = 27017
   net_conf['bindIp'] = '127.0.0.1'

--- a/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodStorage.py
+++ b/packages/aws-rfdk/lib/core/scripts/mongodb/8.0/setupMongodStorage.py
@@ -12,7 +12,7 @@
 # mongod.conf
 
 # for documentation of all options, see:
-#   http://docs.mongodb.org/manual/reference/configuration-options/
+#   https://www.mongodb.com/docs/manual/reference/configuration-options/
 
 # where to write logging data.
 systemLog:

--- a/packages/aws-rfdk/lib/core/test/mongodb-installer.test.ts
+++ b/packages/aws-rfdk/lib/core/test/mongodb-installer.test.ts
@@ -44,7 +44,7 @@ The MongoDbInstaller will install MongoDB Community Edition onto one or more EC2
 
 MongoDB is provided by MongoDB Inc. under the SSPL license. By installing MongoDB, you are agreeing to the terms of this license.
 Follow the link below to read the terms of the SSPL license.
-https://www.mongodb.com/licensing/server-side-public-license
+https://www.mongodb.com/legal/licensing/server-side-public-license
 
 By using the MongoDbInstaller to install MongoDB you agree to the terms of the SSPL license.
 

--- a/packages/aws-rfdk/lib/deadline/README.md
+++ b/packages/aws-rfdk/lib/deadline/README.md
@@ -48,8 +48,8 @@ _**Note:** RFDK constructs currently support Deadline 10.1.9 and later, unless o
 The [Spot Event Plugin](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html) can scale cloud-based EC2 Spot instances dynamically based on the queued Jobs and Tasks in the Deadline Database. It associates a Spot Fleet Request with named Deadline Worker Groups, allowing multiple Spot Fleets with different hardware and software specifications to be launched for different types of Jobs based on their Group assignment.
 
 The `ConfigureSpotEventPlugin` construct has two main responsibilities:
-- Construct a [Spot Fleet Request](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-requests.html) configuration from the list of [Spot Event Plugin Fleets](#spot-event-plugin-fleet).
-- Modify and save the options of the Spot Event Plugin itself. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration-options).
+- Construct a [Spot Fleet Request](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-request-type.html) configuration from the list of [Spot Event Plugin Fleets](#spot-event-plugin-fleet).
+- Modify and save the options of the Spot Event Plugin itself. See [Deadline Documentation](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration).
 
 ---
 
@@ -175,7 +175,7 @@ IP address. Application Load Balancers can scale to use any available IP address
 exclusively for the Render Queue's ALB.
 1. The size of the subnet can be limited to only what is necessary for your workload, avoiding an overly permissive auto-registration rule.
 
-Please consult the [`All-In-AWS-Infrastructure-Basic` example CDK application](https://github.com/aws/aws-rfdk/blob/release/examples/deadline/All-In-AWS-Infrastructure-Basic) for a reference implementation that demonstrates dedicated subnets.
+Please consult the [`All-In-AWS-Infrastructure-Basic` example CDK application](https://github.com/aws/aws-rfdk/tree/release/examples/deadline/All-In-AWS-Infrastructure-Basic) for a reference implementation that demonstrates dedicated subnets.
 
 For more details on dedicated subnet placements, see:
 - [Render Queue Subnet Placement](#render-queue-subnet-placement)
@@ -239,7 +239,7 @@ The `RenderQueue` construct leverages the built-in health monitoring functionali
 
 ### Render Queue Deletion Protection
 
-By default, the Load Balancer in the `RenderQueue` has [deletion protection](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection) enabled to ensure that it does not get accidentally deleted. This also means that it cannot be automatically destroyed by CDK when you destroy your stack and must be done manually (see [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection)).
+By default, the Load Balancer in the `RenderQueue` has [deletion protection](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes) enabled to ensure that it does not get accidentally deleted. This also means that it cannot be automatically destroyed by CDK when you destroy your stack and must be done manually (see [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes)).
 
 You can specify deletion protection with a property in the `RenderQueue`:
 ```ts
@@ -326,7 +326,7 @@ Deadline Clients can be configured either in ECS or EC2.
 
 #### 1. Configure Deadline Client in ECS
 
-An ECS Container Instance and Task Definition for deploying Deadline Client can be configured to directly connect to the `Repository`. A mapping of environment variables and ECS [`MountPoint`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ecs.MountPoint.html)s are produced which can be used to configure a [`ContainerDefinition`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ecs.ContainerDefinition.html) to connect to the `Repository`.
+An ECS Container Instance and Task Definition for deploying Deadline Client can be configured to directly connect to the `Repository`. A mapping of environment variables and ECS [`MountPoint`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.MountPoint.html)s are produced which can be used to configure a [`ContainerDefinition`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.ContainerDefinition.html) to connect to the `Repository`.
 
 The example below demonstrates configuration of Deadline Client in ECS:
 ```ts
@@ -367,7 +367,7 @@ When using Deadline 10.1.19 or higher, RFDK enables [Deadline Secrets Management
 
 When RFDK generates the administrator credentials, it sets the Secret's removal policy to `RETAIN` so that you will not lose them if you destroy the CloudFormation Stack that they are in. If you do want to delete this Secret, you will have to destroy it manually or change the `credentialsRemovalPolicy` to `DESTROY`. If you destroy the Stack that contains your Secret and its policy set to `RETAIN`, your existing Secret will be orphaned from your RFDK application and re-deploying the Stack will generate a new one. To help prevent orphaning a Secret that contains administrator credentials that are still in use, RFDK places it in the Stack that contains your database, so that their lifecycles are in sync.
 
-If your database is imported into your RFDK app rather than being generated by it, RFDK will not generate credentials during deployment. You must create your own Secret with the credentials you'd like to use and [import it](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-secretsmanager-readme.html#importing-secrets).
+If your database is imported into your RFDK app rather than being generated by it, RFDK will not generate credentials during deployment. You must create your own Secret with the credentials you'd like to use and [import it](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_secretsmanager-readme.html#importing-secrets).
 
 If you would like to use your own credentials for Deadline Secrets Management, you can do so by storing them in AWS Secrets Manager and providing them to the `Repository` construct. The Secret must be a JSON document with the following format:
 
@@ -414,7 +414,7 @@ For further details, please consult the RFDK developer guide topic on [using Dea
 
 ![architecture diagram](../../docs/diagrams/deadline/SpotEventPluginFleet.svg)
 
-This construct represents a Spot Fleet launched by the [Deadline's Spot Event Plugin](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html) from the [Spot Fleet Request Configuration](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#spot-fleet-request-configurations). The construct itself doesn't create a Spot Fleet Request, but creates all the required resources to be used in the Spot Fleet Request Configuration.
+This construct represents a Spot Fleet launched by the [Deadline's Spot Event Plugin](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html) from the [Spot Fleet Request Configuration](https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-fleet-configurations.html#event-spot-fleet-configurations-ref-label). The construct itself doesn't create a Spot Fleet Request, but creates all the required resources to be used in the Spot Fleet Request Configuration.
 
 This construct is expected to be used as an input to the [ConfigureSpotEventPlugin](#configure-spot-event-plugin) construct. `ConfigureSpotEventPlugin` construct will generate a Spot Fleet Request Configuration from each provided `SpotEventPluginFleet` and will set these configurations to the Spot Event Plugin.
 
@@ -509,7 +509,7 @@ Docker image recipes required by various constructs in Deadline (e.g. `RenderQue
 
 ---
 
-_**Note:** The `ThinkboxDockerRecipes` class requires a [multi-stage Dockerfile](https://docs.docker.com/develop/develop-images/multistage-build/), so your version of Docker must meet the minimum version that supports multi-stage builds (version 17.05)._
+_**Note:** The `ThinkboxDockerRecipes` class requires a [multi-stage Dockerfile](https://docs.docker.com/build/building/multi-stage/), so your version of Docker must meet the minimum version that supports multi-stage builds (version 17.05)._
 
 _**Note:** Regardless of what language is consuming `aws-rfdk`, the Node.js package is required since the `stage-deadline` script is used by `ThinkboxDockerRecipes` when running `cdk synth` or `cdk deploy`._
 
@@ -696,7 +696,7 @@ const version = new VersionQuery(stack, 'Version', {
 
 ![architecture diagram](../../docs/diagrams/deadline/WorkerInstanceFleet.svg)
 
-A `WorkerInstanceFleet` represents a fleet of instances that are the render nodes of your render farm. These instances are created in an [`AutoScalingGroup`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-autoscaling.AutoScalingGroup.html) with a provided AMI that should have Deadline Client installed as well as any desired render applications. Each of the instances will configure itself to connect to the specified [`RenderQueue`](#renderqueue) so that they are able to communicate with Deadline to pick up render jobs. Any logs emitted by the workers are sent to CloudWatch via a CloudWatch agent.
+A `WorkerInstanceFleet` represents a fleet of instances that are the render nodes of your render farm. These instances are created in an [`AutoScalingGroup`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_autoscaling.AutoScalingGroup.html) with a provided AMI that should have Deadline Client installed as well as any desired render applications. Each of the instances will configure itself to connect to the specified [`RenderQueue`](#renderqueue) so that they are able to communicate with Deadline to pick up render jobs. Any logs emitted by the workers are sent to CloudWatch via a CloudWatch agent.
 
 You can create a `WorkerInstanceFleet` like this:
 ```ts
@@ -712,7 +712,7 @@ const fleet = new WorkerInstanceFleet(stack, 'WorkerFleet', {
 The `WorkerInstanceFleet` uses Elastic Load Balancing (ELB) health checks with its `AutoScalingGroup` to ensure the fleet is operating as expected. ELB health checks have two components:
 
 1. **EC2 Status Checks** - Amazon EC2 identifies any hardware or software issues on instances. If a status check fails for an instance, it will be replaced. For more information, see [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html).
-2. **Load Balancer Health Checks** - Load balancers send periodic pings to instances in the `AutoScalingGroup`. If a ping to an instance fails, the instance is considered unhealthy. For more information, see [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-elb-healthcheck.html).
+2. **Load Balancer Health Checks** - Load balancers send periodic pings to instances in the `AutoScalingGroup`. If a ping to an instance fails, the instance is considered unhealthy. For more information, see [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-load-balancer-asg.html).
 
 EC2 status checks are great for detecting lower level issues with instances and automatically replacing them. If you also want to detect any issues with Deadline on your instances, you can do this by configuring health monitoring options on the `WorkerInstanceFleet` along with a `HealthMonitor` (see [aws-rfdk](https://github.com/aws/aws-rfdk/blob/release/packages/aws-rfdk/lib/core/README.md)). The `HealthMonitor` will ensure that your `WorkerInstanceFleet` remains healthy by checking that a minimum number of hosts are healthy for a given grace period. If the fleet is found to be unhealthy, its capacity will set to 0, meaning that all instances will be terminated. This is a precaution to save on costs in the case of a misconfigured render farm.
 

--- a/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/configure-spot-event-plugin.ts
@@ -117,7 +117,7 @@ export enum SpotEventPluginPreJobTaskMode {
 /**
  * The Worker Extra Info column to be used to display AWS Instance Status
  * if the instance has been marked to be stopped or terminated by EC2 or Spot Event Plugin.
- * See "AWS Instance Status" option at https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration-options
+ * See "AWS Instance Status" option at https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration
  * and https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/worker-config.html#extra-info
  */
 export enum SpotEventPluginDisplayInstanceStatus {
@@ -136,7 +136,7 @@ export enum SpotEventPluginDisplayInstanceStatus {
 
 /**
  * The settings of the Spot Event Plugin.
- * For more details see https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration-options
+ * For more details see https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration
  */
 export interface SpotEventPluginSettings {
   /**
@@ -261,7 +261,7 @@ export interface ConfigureSpotEventPluginProps {
 
   /**
    * The Spot Event Plugin settings.
-   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration-options
+   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration
    *
    * @default Default values of SpotEventPluginSettings will be set.
    */

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue-ref.ts
@@ -346,7 +346,7 @@ export interface RenderQueueProps {
    *
    * Note: This value is true by default which means that the deletion protection is enabled for the
    * load balancer. Hence, user needs to disable it using AWS Console or CLI before deleting the stack.
-   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#deletion-protection
+   * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes
    */
   readonly deletionProtection?: boolean;
 
@@ -362,7 +362,7 @@ export interface RenderQueueProps {
    * ECS container host for the Deadline Remote Connection Server. This can reduce
    * the amount of read throughput required for the Repository Filesystem.
    *
-   * For more information, please see: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-fscache
+   * For more information, please see: https://docs.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-fscache
    *
    * Note: If enabling this, then your Repository filesystem may require additional
    * mount options to take advantage. Not every filesystem's driver supports integration

--- a/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/render-queue.ts
@@ -548,7 +548,7 @@ export class RenderQueue extends RenderQueueBase implements IGrantable {
     }
 
     // An explicit dependency is required from the service to the ASG providing its capacity.
-    // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+    // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-dependson.html
     this.pattern.service.node.addDependency(this.asg);
 
     this.loadBalancer = this.pattern.loadBalancer;

--- a/packages/aws-rfdk/lib/deadline/lib/repository.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/repository.ts
@@ -674,7 +674,7 @@ export class Repository extends Construct implements IRepository {
       /**
        * This option is part of enabling audit logging for DocumentDB; the other required part is the enabling of the CloudWatch exports below.
        *
-       * For more information about audit logging in DocumentDB, see:  https://docs.aws.amazon.com/documentdb/latest/developerguide/event-auditing.html
+       * For more information about audit logging in DocumentDB, see:  https://docs.aws.amazon.com/documentdb/latest/devguide/event-auditing.html
        */
       const parameterGroup = databaseAuditLogging ? new ClusterParameterGroup(this, 'ParameterGroup', {
         description: 'DocDB cluster parameter group with enabled audit logs',

--- a/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet-ref.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet-ref.ts
@@ -7,7 +7,7 @@
  * The allocation strategy for the Spot Instances in your Spot Fleet
  * determines how it fulfills your Spot Fleet request from the possible
  * Spot Instance pools represented by its launch specifications.
- * See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-configuration-strategies.html#ec2-fleet-allocation-strategy
+ * See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html
  */
 export enum SpotFleetAllocationStrategy {
   /**

--- a/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/spot-event-plugin-fleet.ts
@@ -83,7 +83,7 @@ export interface SpotEventPluginFleetProps {
 
   /**
    * The  the maximum capacity that the Spot Fleet can grow to.
-   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#spot-fleet-requests
+   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-fleet-request.html#event-spot-fleet-requests-ref-label
    */
   readonly maxCapacity: number;
 
@@ -96,7 +96,7 @@ export interface SpotEventPluginFleetProps {
    * Deadline groups these workers need to be assigned to.
    *
    * Also, note that the Spot Fleet configuration does not allow using wildcards as part of the Group name
-   * as described here https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#wildcards
+   * as described here https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-fleet-configurations.html#wildcards-in-group-names
    */
   readonly deadlineGroups: string[];
 
@@ -402,7 +402,7 @@ export class SpotEventPluginFleet extends Construct implements ISpotEventPluginF
 
   /**
    * The  the maximum capacity that the Spot Fleet can grow to.
-   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#spot-fleet-requests
+   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-fleet-request.html#event-spot-fleet-requests-ref-label
    */
   public readonly maxCapacity: number;
 

--- a/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
+++ b/packages/aws-rfdk/lib/deadline/lib/usage-based-licensing.ts
@@ -607,7 +607,7 @@ export class UsageBasedLicensing extends Construct implements IGrantable {
     });
 
     // An explicit dependency is required from the service to the ASG providing its capacity.
-    // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+    // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-dependson.html
     this.service.node.addDependency(this.asg);
 
     this.node.defaultChild = this.service;

--- a/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/types.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/configure-spot-event-plugin/types.ts
@@ -14,13 +14,13 @@ export interface SEPConfiguratorResourceProps {
 
   /**
    * The Spot Fleet Request Configurations.
-   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#example-spot-fleet-request-configurations
+   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-fleet-configurations.html#event-spot-fleet-configurations-ref-label
    */
   readonly spotFleetRequestConfigurations?: SpotFleetRequestConfiguration;
 
   /**
    * The Spot Event Plugin settings.
-   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration-options
+   * See https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#event-plugin-configuration
    */
   readonly spotPluginConfigurations?: PluginSettings;
 
@@ -124,7 +124,7 @@ export interface PluginSettings {
 }
 
 /**
- * The interface representing the Spot Fleet Request Configurations (see https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot.html#spot-fleet-request-configurations).
+ * The interface representing the Spot Fleet Request Configurations (see https://docs.thinkboxsoftware.com/products/deadline/10.2/1_User%20Manual/manual/event-spot-fleet-configurations.html#event-spot-fleet-configurations-ref-label).
  * Used for communication between Lambda and ConfigureSpotEventPlugin construct.
  */
 export interface SpotFleetRequestConfiguration {

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/custom-resource/README.md
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/custom-resource/README.md
@@ -38,17 +38,17 @@ the form of an environment variable.
 ## Information on CfnCustomResources
 
 Custom Resource Request fields:
-  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref.html
 
 Custom Resource Response fields:
-  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref.html
 
 Custom Resource Best Practices:
-  https://aws.amazon.com/premiumsupport/knowledge-center/best-practices-custom-cf-lambda/
+  https://repost.aws/knowledge-center/best-practices-custom-cf-lambda
 
 ## CfnCustomResource Resource Replacement
 
-From: https://aws.amazon.com/premiumsupport/knowledge-center/best-practices-custom-cf-lambda/
+From: https://repost.aws/knowledge-center/best-practices-custom-cf-lambda
 
 When an update triggers replacement of a physical resource, AWS CloudFormation compares the PhysicalResourceId returned by your Lambda function to the previous PhysicalResourceId. If the IDs differ, AWS CloudFormation assumes the resource has been replaced with a new physical resource.
 
@@ -58,7 +58,7 @@ Carefully consider when you return a new PhysicalResourceId. Use PhysicalResourc
 
 ## CfnCustomResource Idempotency
 
-From: https://aws.amazon.com/premiumsupport/knowledge-center/best-practices-custom-cf-lambda/
+From: https://repost.aws/knowledge-center/best-practices-custom-cf-lambda
 
 An idempotent function can be repeated any number of times with the same inputs, and the result will be the same as if it had been done only once. Idempotency is valuable when working with AWS CloudFormation to ensure that retries, updates, and rollbacks don't create duplicate resources or introduce errors.
 

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/custom-resource/reply.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/custom-resource/reply.ts
@@ -32,7 +32,7 @@ export async function sendCfnResponse(args: {
 }): Promise<void> {
 
   // Construct the CustomResource response.
-  // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html
+  // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref.html
   const responseObject = {
     Status: args.status,
     Reason: args.reason ?? `See CloudWatch Logs -- Group: '${args.context.logGroupName}'  Stream: '${args.context.logStreamName}'`,

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/custom-resource/types.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/custom-resource/types.ts
@@ -5,7 +5,7 @@
 
 /**
  * The relevant fields from a CustomResource request event for sending the required response to Cfn.
- *  Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
+ *  Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref.html
  */
 export interface CfnRequestEvent {
   readonly RequestType: 'Create' | 'Update' | 'Delete';

--- a/packages/aws-rfdk/lib/lambdas/nodejs/lib/secrets-manager/validation.ts
+++ b/packages/aws-rfdk/lib/lambdas/nodejs/lib/secrets-manager/validation.ts
@@ -7,7 +7,7 @@
  * Check whether the given string matches the SecretsManager ARN format.
  * arn:aws:secretsmanager:<Region>:<AccountId>:secret:OptionalPath/SecretName-6RandomCharacters
  * Reference:
- *   https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_iam-permissions.html#iam-resources
+ *   https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html#reference_iam-permissions
  * @param value
  */
 export function isArn(value: string): boolean {

--- a/tools/pkglint/lib/rules.ts
+++ b/tools/pkglint/lib/rules.ts
@@ -141,7 +141,7 @@ export class AuthorAWS extends ValidationRule {
 
   public validate(pkg: PackageJson): void {
     expectJSON(this.name, pkg, 'author.name', 'Amazon Web Services');
-    expectJSON(this.name, pkg, 'author.url', 'https://aws.amazon.com');
+    expectJSON(this.name, pkg, 'author.url', 'https://aws.amazon.com/');
     expectJSON(this.name, pkg, 'author.organization', true);
   }
 }


### PR DESCRIPTION
### Why

The documentation link checker reports broken links **and broken link redirects** in the published RFDK docs (internal ticket V1899617587). Rather than fix only the handful visible in the currently published docs, this sweeps **every documentation URL in the repository**, so the next published docs build is clean.

Worth being precise about the symptom: most of these links still load. Retired pages 301-redirect, and browsers silently ignore an unknown fragment. The two real defects are that **anchors no longer resolve** (dropping the reader at the top of a page instead of the section being cited), and that many links **only resolve via a redirect**, which the checker reports separately.

### What

**Broken anchors and moved pages**

- **CDK v1 API reference → v2** (the largest group): `cdk/api/latest/docs/@aws-cdk_aws-<mod>.<Class>.html` → `cdk/api/v2/docs/aws-cdk-lib.aws_<mod>.<Class>.html`. Note the module separator changes from `-` to `_` (`aws-s3-assets` → `aws_s3_assets`). Also the `aws-ec2` and `aws-secretsmanager` readme pages.
- **CDK v1 developer guide → v2**, including anchors renamed in v2:
  `constructs.html#constructs_lib` → `#constructs-lib-levels`,
  `context.html#context_viewing` → `#context-viewing`,
  `get_context_var.html` → `context.html#context-methods` (the v2 path exists but soft-redirects to the guide index).
- **Deadline 10.2 moved several Spot Event Plugin sections onto their own pages**, so these point at the new pages instead of anchors that no longer exist:

  | Old anchor on `event-spot.html` | New target |
  | --- | --- |
  | `#event-plugin-configuration-options` | `#event-plugin-configuration` |
  | `#spot-fleet-requests` | `event-spot-fleet-request.html#event-spot-fleet-requests-ref-label` |
  | `#spot-fleet-request-configurations`, `#example-spot-fleet-request-configurations` | `event-spot-fleet-configurations.html#event-spot-fleet-configurations-ref-label` |
  | `#wildcards` | `event-spot-fleet-configurations.html#wildcards-in-group-names` |

- **AWS docs whose sections moved**: EC2 Fleet allocation strategies and Spot Fleet cancellation are now their own pages; ALB deletion protection is documented under `#load-balancer-attributes`; Secrets Manager IAM permissions moved to `auth-and-access.html#reference_iam-permissions`; the Local Zones features page renamed `#AWS_Services` to `#aws-services`.
- **`mount.lustre(8)`**: `manpages.ubuntu.com/manpages/precise/…` is a hard 404, and the page is no longer published for *any* suite, so a version bump doesn't help. Now links the official Lustre manual.

**Links that only resolved through a redirect** now point at their destination: CloudFormation `UserGuide` → `TemplateReference`, several EC2 / Auto Scaling / S3 / VPC / DocumentDB / CloudWatch page renames, MongoDB docs (`docs.mongodb.com` and the pinned `v3.6` tree → `www.mongodb.com/docs/manual`), Deadline docs `10.1` → `latest`, Docker multi-stage build, Node.js previous releases, IETF datatracker, Red Hat docs, classic Yarn docs, an AWS Premium Support article now on re:Post, and a few `http:` → `https:` / trailing-slash normalisations.

**Also fixed** a markdown link that swallowed the trailing `._` of its sentence into the URL (producing a 404), by making it an explicit autolink.

### Testing

Swept all **223 documentation URLs** in the repo (excluding CHANGELOG commit links) and checked each for status, whether it resolves **without** a redirect, and — where the link has a fragment — whether that `id` is actually present in the target page:

- **205 resolve directly with HTTP 200** (145 plain, 60 with a verified anchor).
- **0 broken pages and 0 verifiable broken anchors remain.**
- The remaining 18 are reviewed and deliberately left:
  - the **verbatim Apache License 2.0 text** in `pkglint` and the **MongoDB SSPL licence URL** — licence text, not documentation links (changing the former would also break `pkglint`, which compares every package's LICENSE against it byte-for-byte);
  - three hosts that return **403 to crawlers** but work in a browser (`docs.redhat.com`, `awsthinkbox.zendesk.com`);
  - a few pages that now **redirect to a guide index** with no equivalent destination (ECS AMI storage config, the IAM service-authorization action lists), where guessing a target would be worse than leaving the redirect;
  - `downloads.thinkboxsoftware.com`, which now redirects into the Deadline Cloud console — that's user-facing guidance and deserves an explicit decision rather than a silent rewrite.

All changes are inside doc comments, markdown, or one user-facing error-message string; no logic is affected, and no test asserts on any changed string. CI covers the build and unit tests.

### Note on the remaining reported links

Some links in the checker's report are **not fixable from this repository**. Anchors such as `#assets_types_docker`, `#permissions_grants`, `#resources_removal` and `#getting_started_prerequisites` appear nowhere in RFDK's source — they come from `aws-cdk-lib`'s own jsii docstrings, which are rendered into RFDK's API reference, and would need an upstream change. The localised page variants (`/de_de/`, `/es_es/`, …) that 404 are AWS documentation page chrome rather than RFDK content.

Also note the published API reference is generated by the release pipeline, so **the report will not change until a docs build/release publishes these fixes**.


### Scope note: what is deliberately left alone

- **`downloads.thinkboxsoftware.com`** is *not* changed. Its root now redirects to the Deadline Cloud console in a browser, but the host is a **functional endpoint** used at runtime (`ECR_INDEX_URL` in `ecr-provider.ts`, `VERSION_INDEX_URL` in `version-provider.ts`, with a matching test assertion), and the doc comment in `thinkbox-docker-images.ts` accurately describes the host RFDK actually contacts. Rewriting it would make the documentation wrong and risk the runtime.
- **Verbatim Apache License 2.0 text** in `tools/pkglint/lib/licensing.ts` keeps its `http://` URLs. `pkglint` compares every package's LICENSE against that constant byte-for-byte, so changing it would break the build as well as altering licence text.
- Two hosts return **403 to crawlers** while working fine in a browser (`docs.redhat.com`, `awsthinkbox.zendesk.com`). Their predecessors were also 403 *and* redirected, so this is a small improvement rather than a regression.
- A few AWS pages now redirect to a guide **index** with no equivalent destination (ECS AMI storage config, the IAM service-authorization action lists). Guessing a target would be worse than leaving the redirect.

The MongoDB SSPL reference URL *is* updated to its current canonical location (`/legal/licensing/...`), in the doc comments, the acceptance message, and the test that asserts it, so the three stay consistent.

### What this will and will not resolve

Reconciling with the report: across the 176 pages it scans there are 317 links (excluding the localized page chrome), of which **93 redirect** and 4 fail outright — which is essentially the reported count. Of those 93:

- **~26 are RFDK's own and are fixed here.**
- **67 are not present in this repository at all.** 64 of them appear only in the *developer guide* pages, which are authored in a separate AWS documentation source, not in `aws-rfdk`. The largest single cluster is 23 `docs.aws.amazon.com/forms/...` links from the documentation feedback widget, plus CDK guide links in the guide's prose.

So this PR fixes everything in RFDK's control, but the remainder needs a change in the guide's source (and some of it is documentation page template, not content). Also note the published reference is generated by the release pipeline, so the report will not change until a docs build publishes these fixes.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
