### PR TITLE
chore: unblock non-CDK dependency updates

### DIFF
--- a/integ/package.json
+++ b/integ/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "18.11.19",
+    "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.24.0",
     "@typescript-eslint/parser": "^8.32.0",
     "aws-cdk": "2.1132.0",

--- a/tools/pkglint/package.json
+++ b/tools/pkglint/package.json
@@ -45,7 +45,7 @@
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.16.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.4.5"
   },
   "nozem": {
     "ostools": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12565,11 +12565,6 @@ typescript@next:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.0-dev.20250212.tgz#b36b2f50e96cee77e4ee619769a741977aa4023f"
   integrity sha512-KuSQZsJS5e7rBVbj7QY72K4kievEtZgBYyYYaxp0a3YmBlG5bpbuKJO0ltyRGkFcBgOVw4McWjKeL5+6MqRWOw==
 
-typescript@~5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
 typescript@~5.4, typescript@~5.4.5:
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"


### PR DESCRIPTION
### Why

Two of the outstanding non-CDK dependency updates fail CI for reasons that live in **our build configuration**, not in the bumps themselves. This fixes the configuration so those updates can land.

**1. `pkglint` lagged the repository's TypeScript version**

[#1687](https://github.com/aws/aws-rfdk/pull/1687) (jest and `@types/jest` → 30) fails inside the `pkglint` package with:

```
jest-mock/build/index.d.ts(164,11): error TS2304: Cannot find name 'Disposable'.
jest-mock/build/index.d.ts(8,21):   error TS2726: Cannot find lib definition for 'esnext.disposable'.
```

jest 30's types reference `Symbol.dispose`, and the `esnext.disposable` lib only exists from **TypeScript 5.2**. `tools/pkglint` pinned `typescript: ~5.1.6` while the rest of the repo (`packages/aws-rfdk`, `integ`, `lambda-layers`) is on `~5.4.5`.

**2. `integ`'s Node typings predate the generic `ReadableStream`**

[#1686](https://github.com/aws/aws-rfdk/pull/1686) (`@aws-sdk/client-ecs` → 3.1112.0) fails with:

```
@smithy/core/dist-types/submodules/event-streams/eventstream-serde/utils.d.ts(6,68):
  error TS2315: Type 'ReadableStream' is not generic.
```

Newer `@aws-sdk` / `@smithy` releases declare `ReadableStream<T>` in their `.d.ts` files. `integ` pinned `@types/node` **18.11.19**, whose typings don't provide a generic `ReadableStream`. `integ` is the only package that still type-checks dependency declaration files, which is why the failure surfaces there even though the dependency is declared at the root and in `packages/aws-rfdk`.

### What

- `tools/pkglint/package.json`: `typescript` `~5.1.6` → `~5.4.5`, aligning pkglint with the rest of the repository. **This does not change the TypeScript version RFDK is built with** — it only stops pkglint lagging behind it, so it stays consistent with the CDK-pinned version.
- `integ/package.json`: `@types/node` `18.11.19` → `^22.10.2`, matching `lambda-layers`. Node 18 typings are stale for this repo regardless, now that RFDK targets the `nodejs24` runtime.
- `yarn.lock`: drops the now-unused `typescript@~5.1.6` resolution. (`@types/node@^22.10.2` was already resolved for `lambda-layers`, so nothing is added.)

**Why not `skipLibCheck`?** It would silence the error, but it would also stop `integ` type-checking *every* dependency's typings — hiding real problems rather than fixing the cause. Correcting the Node typings addresses the actual mismatch. Adding `"DOM"` to `lib` would also work, but it pulls browser globals into Node code.

### Testing

Both fixes were reproduced and verified against the exact versions the dependabot PRs propose:

| Scenario | Result |
| --- | --- |
| `@types/jest` 30 + TypeScript **5.1.6** | the 2 errors above (TS2304, TS2726) |
| `@types/jest` 30 + TypeScript **5.4.5** | **0 errors** |
| `@aws-sdk/client-ecs` 3.1112.0 + `@types/node` **18.11.19** | 2 × TS2315 |
| `@aws-sdk/client-ecs` 3.1112.0 + `@types/node` **22** | **0 errors** |

Then verified in the real workspace: with `@aws-sdk/client-ecs` bumped and `@types/node` at `^22.10.2`, `integ` type-checks with **0 errors** and no `skipLibCheck`, and `pkglint` builds cleanly on TypeScript 5.4.5. yarn resolves 22.x for `integ` while the root stays on 18.11.19, with no duplicate-typings conflicts. No source code is modified.

### Follow-up

With this merged and the dependabot branches rebased, [#1687](https://github.com/aws/aws-rfdk/pull/1687) and [#1686](https://github.com/aws/aws-rfdk/pull/1686) are expected to go green.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
